### PR TITLE
Support string for bytea

### DIFF
--- a/const.go
+++ b/const.go
@@ -8,3 +8,4 @@ import (
 )
 
 var byteType = reflect.TypeOf(byte(0))
+var stringType = reflect.TypeOf("")

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -9,6 +9,7 @@ Dynamic SSZ supports only SSZ-compatible types as defined in the SSZ specificati
 ### Base Types
 - `uint8`/`byte`, `uint16`, `uint32`, `uint64` - Unsigned integers
 - `bool` - Boolean values
+- `string` - Strings (treated like a []byte)
 
 ### Composite Types
 - **Arrays**: Fixed-size arrays of supported types
@@ -20,7 +21,6 @@ Dynamic SSZ supports only SSZ-compatible types as defined in the SSZ specificati
 The following types are **not** part of the SSZ specification and therefore not supported:
 - Signed integers (`int`, `int8`, `int16`, `int32`, `int64`)
 - Floating-point numbers (`float32`, `float64`)
-- Strings (`string`) - Use `[]byte` instead
 - Maps
 - Channels
 - Functions
@@ -39,11 +39,11 @@ The SSZ specification defines `uint128` and `uint256` types, but Go doesn't have
 - **uint256**: Use `github.com/holiman/uint256` for proper uint256 handling
   ```go
   import "github.com/holiman/uint256"
-  
+
   type MyStruct struct {
       // For SSZ marshalling/unmarshalling
       Balance1 [32]byte
-      
+
       // For actual usage in calculations
       Balance2 uint256.Int
   }
@@ -60,17 +60,18 @@ type ValidStruct struct {
     Count      uint64
     Flag       bool
     Hash       [32]byte
-    
+    Name       string
+
     // Composite types
     Values     []uint32      `ssz-max:"100"`
     Data       []byte        `ssz-max:"1024"`
+    Labels     []string      `ssz-max:"10"`
     Matrix     [][]byte      `ssz-size:"?,32" ssz-max:"64"`
     SubStruct  *OtherStruct  // Pointer treated as empty instance for nil pointer
 }
 
 // NOT supported
 type InvalidStruct struct {
-    Name    string         // ❌ Use []byte instead
     Score   float64        // ❌ Not part of SSZ
     Count   int            // ❌ Use uint64 instead
     Mapping map[string]int // ❌ Maps not supported
@@ -345,13 +346,13 @@ For multi-dimensional arrays/slices, specify sizes and maximums for each dimensi
 type MyStruct struct {
     // Fixed dimensions
     Fixed2D     [][]byte  `ssz-size:"4,32"`                // 4x32 fixed matrix
-    
+
     // Mixed dimensions
     Mixed       [][]byte  `ssz-size:"?,32" ssz-max:"100"`  // Dynamic outer (max 100), fixed inner (32)
-    
+
     // Fully dynamic
     Dynamic2D   [][]byte  `ssz-size:"?,?" ssz-max:"64,256"` // Max 64x256 matrix
-    
+
     // With spec values
     SpecBased   [][]uint64 `ssz-size:"?,?" ssz-max:"100,100" dynssz-max:"MAX_COMMITTEES,MAX_VALIDATORS"`
 }

--- a/hasher.go
+++ b/hasher.go
@@ -195,11 +195,7 @@ func CalculateLimit(maxCapacity, numItems, size uint64) uint64 {
 
 func (h *Hasher) FillUpTo32() {
 	// pad zero bytes to the left
-	bufLen := len(h.buf)
-	if bufLen == 0 {
-		// Special case: empty buffer should be padded to 32 bytes
-		h.buf = append(h.buf, zeroBytes[:32]...)
-	} else if rest := bufLen % 32; rest != 0 {
+	if rest := len(h.buf) % 32; rest != 0 {
 		h.buf = append(h.buf, zeroBytes[:32-rest]...)
 	}
 }

--- a/hasher.go
+++ b/hasher.go
@@ -195,7 +195,11 @@ func CalculateLimit(maxCapacity, numItems, size uint64) uint64 {
 
 func (h *Hasher) FillUpTo32() {
 	// pad zero bytes to the left
-	if rest := len(h.buf) % 32; rest != 0 {
+	bufLen := len(h.buf)
+	if bufLen == 0 {
+		// Special case: empty buffer should be padded to 32 bytes
+		h.buf = append(h.buf, zeroBytes[:32]...)
+	} else if rest := bufLen % 32; rest != 0 {
 		h.buf = append(h.buf, zeroBytes[:32-rest]...)
 	}
 }

--- a/marshal.go
+++ b/marshal.go
@@ -91,6 +91,9 @@ func (d *DynSsz) marshalType(sourceType *TypeDescriptor, sourceValue reflect.Val
 			buf = marshalUint32(buf, uint32(sourceValue.Uint()))
 		case reflect.Uint64:
 			buf = marshalUint64(buf, uint64(sourceValue.Uint()))
+		case reflect.String:
+			// Convert string to []byte and append
+			buf = append(buf, []byte(sourceValue.String())...)
 		default:
 			return nil, fmt.Errorf("unknown type: %v", sourceType)
 		}

--- a/marshal.go
+++ b/marshal.go
@@ -92,28 +92,11 @@ func (d *DynSsz) marshalType(sourceType *TypeDescriptor, sourceValue reflect.Val
 		case reflect.Uint64:
 			buf = marshalUint64(buf, uint64(sourceValue.Uint()))
 		case reflect.String:
-			// Convert string to []byte
-			stringBytes := []byte(sourceValue.String())
-			
-			// Check if this is a fixed-size string
-			if sourceType.Size > 0 {
-				// Fixed-size string: pad or truncate to exact size
-				fixedSize := int(sourceType.Size)
-				if len(stringBytes) > fixedSize {
-					// Truncate if too long
-					buf = append(buf, stringBytes[:fixedSize]...)
-				} else {
-					// Pad with zeros if too short
-					buf = append(buf, stringBytes...)
-					padding := fixedSize - len(stringBytes)
-					for i := 0; i < padding; i++ {
-						buf = append(buf, 0)
-					}
-				}
-			} else {
-				// Dynamic string: append as-is
-				buf = append(buf, stringBytes...)
+			newBuf, err := d.marshalString(sourceType, sourceValue, buf, idt)
+			if err != nil {
+				return nil, err
 			}
+			buf = newBuf
 		default:
 			return nil, fmt.Errorf("unknown type: %v", sourceType)
 		}
@@ -405,5 +388,50 @@ func (d *DynSsz) marshalDynamicSlice(sourceType *TypeDescriptor, sourceValue ref
 		buf = append(buf, zeroData...)
 	}
 
+	return buf, nil
+}
+
+// marshalString encodes Go string values into SSZ format.
+//
+// Strings in SSZ can be either fixed-size or dynamic:
+//   - Fixed-size strings (with ssz-size tag): Encoded with zero padding to exact size
+//   - Dynamic strings: Encoded as-is without padding
+//
+// Parameters:
+//   - sourceType: The TypeDescriptor containing string metadata and size constraints
+//   - sourceValue: The reflect.Value of the string to encode
+//   - buf: The buffer to append the encoded data to
+//   - idt: Indentation level for verbose logging
+//
+// Returns:
+//   - []byte: The buffer with the encoded string appended
+//   - error: Always nil for strings (kept for consistency with other marshal functions)
+//
+// Fixed-size strings are truncated if longer than the specified size or padded
+// with zeros if shorter. Dynamic strings are encoded as their raw byte representation.
+func (d *DynSsz) marshalString(sourceType *TypeDescriptor, sourceValue reflect.Value, buf []byte, idt int) ([]byte, error) {
+	// Convert string to []byte
+	stringBytes := []byte(sourceValue.String())
+	
+	// Check if this is a fixed-size string
+	if sourceType.Size > 0 {
+		// Fixed-size string: pad or truncate to exact size
+		fixedSize := int(sourceType.Size)
+		if len(stringBytes) > fixedSize {
+			// Truncate if too long
+			buf = append(buf, stringBytes[:fixedSize]...)
+		} else {
+			// Pad with zeros if too short
+			buf = append(buf, stringBytes...)
+			padding := fixedSize - len(stringBytes)
+			for i := 0; i < padding; i++ {
+				buf = append(buf, 0)
+			}
+		}
+	} else {
+		// Dynamic string: append as-is
+		buf = append(buf, stringBytes...)
+	}
+	
 	return buf, nil
 }

--- a/sszsize.go
+++ b/sszsize.go
@@ -153,8 +153,14 @@ func (d *DynSsz) getSszValueSize(targetType *TypeDescriptor, targetValue reflect
 		case reflect.Uint64:
 			staticSize = 8
 		case reflect.String:
-			// String size is the length of the string in bytes
-			staticSize = uint32(len(targetValue.String()))
+			// String size depends on whether it's fixed or dynamic
+			if targetType.Size > 0 {
+				// Fixed-size string: always return the fixed size
+				staticSize = uint32(targetType.Size)
+			} else {
+				// Dynamic string: return the actual length
+				staticSize = uint32(len(targetValue.String()))
+			}
 
 		default:
 			return 0, fmt.Errorf("unhandled reflection kind in size check: %v", targetType.Kind)

--- a/sszsize.go
+++ b/sszsize.go
@@ -152,6 +152,9 @@ func (d *DynSsz) getSszValueSize(targetType *TypeDescriptor, targetValue reflect
 			staticSize = 4
 		case reflect.Uint64:
 			staticSize = 8
+		case reflect.String:
+			// String size is the length of the string in bytes
+			staticSize = uint32(len(targetValue.String()))
 
 		default:
 			return 0, fmt.Errorf("unhandled reflection kind in size check: %v", targetType.Kind)

--- a/string_test.go
+++ b/string_test.go
@@ -10,188 +10,434 @@ import (
 	. "github.com/pk910/dynamic-ssz"
 )
 
-func TestStringMarshaling(t *testing.T) {
+// TestStringInContainerBasics tests string marshaling, unmarshaling, and size calculation within containers
+func TestStringInContainerBasics(t *testing.T) {
+	type StringContainer struct {
+		Data string `ssz-max:"100"`
+	}
+
 	testCases := []struct {
-		name     string
-		value    string
-		expected []byte
+		name         string
+		value        string
+		expectedSize int
 	}{
-		{"empty string", "", []byte{}},
-		{"simple string", "hello", []byte("hello")},
-		{"unicode string", "hello 世界", []byte("hello 世界")},
-		{"string with null bytes", "hello\x00world", []byte("hello\x00world")},
+		{"empty", "", 4},       // 4 bytes for offset
+		{"simple", "hello", 9}, // 4 bytes offset + 5 bytes data
+		{"unicode", "hello 世界", 4 + len("hello 世界")},
+		{"with_nulls", "hello\x00world", 15}, // 4 bytes offset + 11 bytes data
 	}
 
 	dynssz := NewDynSsz(nil)
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := dynssz.MarshalSSZ(tc.value)
+			container := StringContainer{Data: tc.value}
+
+			// Test marshaling
+			encoded, err := dynssz.MarshalSSZ(container)
 			if err != nil {
 				t.Fatalf("MarshalSSZ failed: %v", err)
 			}
-			if !bytes.Equal(result, tc.expected) {
-				t.Errorf("MarshalSSZ result mismatch: got %v, want %v", result, tc.expected)
-			}
-		})
-	}
-}
 
-func TestStringUnmarshaling(t *testing.T) {
-	testCases := []struct {
-		name     string
-		data     []byte
-		expected string
-	}{
-		{"empty string", []byte{}, ""},
-		{"simple string", []byte("hello"), "hello"},
-		{"unicode string", []byte("hello 世界"), "hello 世界"},
-		{"string with null bytes", []byte("hello\x00world"), "hello\x00world"},
-	}
-
-	dynssz := NewDynSsz(nil)
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			var result string
-			err := dynssz.UnmarshalSSZ(&result, tc.data)
+			// Test unmarshaling
+			var decoded StringContainer
+			err = dynssz.UnmarshalSSZ(&decoded, encoded)
 			if err != nil {
 				t.Fatalf("UnmarshalSSZ failed: %v", err)
 			}
-			if result != tc.expected {
-				t.Errorf("UnmarshalSSZ result mismatch: got %q, want %q", result, tc.expected)
+			if decoded.Data != tc.value {
+				t.Errorf("UnmarshalSSZ mismatch: got %q, want %q", decoded.Data, tc.value)
 			}
-		})
-	}
-}
 
-func TestStringInStruct(t *testing.T) {
-	type TestStruct struct {
-		Name string
-		Age  uint32
-	}
-
-	dynssz := NewDynSsz(nil)
-
-	// Test marshaling
-	original := TestStruct{Name: "Alice", Age: 30}
-	data, err := dynssz.MarshalSSZ(original)
-	if err != nil {
-		t.Fatalf("MarshalSSZ failed: %v", err)
-	}
-
-	// Test unmarshaling
-	var decoded TestStruct
-	err = dynssz.UnmarshalSSZ(&decoded, data)
-	if err != nil {
-		t.Fatalf("UnmarshalSSZ failed: %v", err)
-	}
-
-	if decoded.Name != original.Name || decoded.Age != original.Age {
-		t.Errorf("Round-trip failed: got %+v, want %+v", decoded, original)
-	}
-}
-
-func TestStringHashTreeRoot(t *testing.T) {
-	testCases := []struct {
-		name   string
-		value  string
-		// Note: These expected values would need to be calculated based on SSZ spec
-		// For now, we just ensure it doesn't error
-	}{
-		{"empty string", ""},
-		{"simple string", "hello"},
-		{"unicode string", "hello 世界"},
-	}
-
-	dynssz := NewDynSsz(nil)
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			root, err := dynssz.HashTreeRoot(tc.value)
-			if err != nil {
-				t.Fatalf("HashTreeRoot failed: %v", err)
-			}
-			// Just ensure we got a 32-byte root
-			if len(root) != 32 {
-				t.Errorf("HashTreeRoot returned wrong size: got %d bytes, want 32", len(root))
-			}
-		})
-	}
-}
-
-func TestStringSlice(t *testing.T) {
-	dynssz := NewDynSsz(nil)
-
-	// Test slice of strings
-	original := []string{"hello", "world", "test"}
-	data, err := dynssz.MarshalSSZ(original)
-	if err != nil {
-		t.Fatalf("MarshalSSZ failed: %v", err)
-	}
-
-	var decoded []string
-	err = dynssz.UnmarshalSSZ(&decoded, data)
-	if err != nil {
-		t.Fatalf("UnmarshalSSZ failed: %v", err)
-	}
-
-	if len(decoded) != len(original) {
-		t.Fatalf("Length mismatch: got %d, want %d", len(decoded), len(original))
-	}
-
-	for i, v := range decoded {
-		if v != original[i] {
-			t.Errorf("Element %d mismatch: got %q, want %q", i, v, original[i])
-		}
-	}
-}
-
-func TestStringArray(t *testing.T) {
-	dynssz := NewDynSsz(nil)
-
-	// Test array of strings
-	original := [3]string{"one", "two", "three"}
-	data, err := dynssz.MarshalSSZ(original)
-	if err != nil {
-		t.Fatalf("MarshalSSZ failed: %v", err)
-	}
-
-	var decoded [3]string
-	err = dynssz.UnmarshalSSZ(&decoded, data)
-	if err != nil {
-		t.Fatalf("UnmarshalSSZ failed: %v", err)
-	}
-
-	for i, v := range decoded {
-		if v != original[i] {
-			t.Errorf("Element %d mismatch: got %q, want %q", i, v, original[i])
-		}
-	}
-}
-
-func TestStringSizeSSZ(t *testing.T) {
-	testCases := []struct {
-		name     string
-		value    string
-		expected int
-	}{
-		{"empty string", "", 0},
-		{"simple string", "hello", 5},
-		{"unicode string", "hello 世界", len("hello 世界")},
-	}
-
-	dynssz := NewDynSsz(nil)
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			size, err := dynssz.SizeSSZ(tc.value)
+			// Test size calculation
+			size, err := dynssz.SizeSSZ(container)
 			if err != nil {
 				t.Fatalf("SizeSSZ failed: %v", err)
 			}
-			if size != tc.expected {
-				t.Errorf("SizeSSZ mismatch: got %d, want %d", size, tc.expected)
+			if size != tc.expectedSize {
+				t.Errorf("SizeSSZ mismatch: got %d, want %d", size, tc.expectedSize)
 			}
 		})
+	}
+}
+
+// TestStringVsByteContainerEquivalence tests that containers with string vs []byte fields
+// produce identical encoding, decoding, and hash roots
+func TestStringVsByteContainerEquivalence(t *testing.T) {
+	type StringContainer struct {
+		Data string `ssz-max:"100"`
+	}
+
+	type ByteContainer struct {
+		Data []byte `ssz-max:"100"`
+	}
+
+	testCases := []struct {
+		name  string
+		value string
+	}{
+		{"empty", ""},
+		{"single_char", "a"},
+		{"hello", "hello"},
+		{"exactly_32_bytes", "abcdefghijklmnopqrstuvwxyz123456"},
+		{"over_32_bytes", "abcdefghijklmnopqrstuvwxyz1234567890"},
+		{"unicode", "hello 世界"},
+		{"binary", "test\x00\x01\x02\xff"},
+	}
+
+	dynssz := NewDynSsz(nil)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			strContainer := StringContainer{Data: tc.value}
+			byteContainer := ByteContainer{Data: []byte(tc.value)}
+
+			// Test encoding
+			strEncoded, err := dynssz.MarshalSSZ(strContainer)
+			if err != nil {
+				t.Fatalf("Failed to marshal string container: %v", err)
+			}
+
+			byteEncoded, err := dynssz.MarshalSSZ(byteContainer)
+			if err != nil {
+				t.Fatalf("Failed to marshal byte container: %v", err)
+			}
+
+			if !bytes.Equal(strEncoded, byteEncoded) {
+				t.Errorf("Encoding mismatch:\nString: %x\nBytes:  %x", strEncoded, byteEncoded)
+			}
+
+			// Test hash roots
+			strHash, err := dynssz.HashTreeRoot(strContainer)
+			if err != nil {
+				t.Fatalf("Failed to hash string container: %v", err)
+			}
+
+			byteHash, err := dynssz.HashTreeRoot(byteContainer)
+			if err != nil {
+				t.Fatalf("Failed to hash byte container: %v", err)
+			}
+
+			if strHash != byteHash {
+				t.Errorf("Hash mismatch:\nString: %x\nBytes:  %x", strHash, byteHash)
+			}
+
+			// Test decoding round-trip
+			var decodedStr StringContainer
+			err = dynssz.UnmarshalSSZ(&decodedStr, strEncoded)
+			if err != nil {
+				t.Fatalf("Failed to unmarshal string container: %v", err)
+			}
+
+			if decodedStr.Data != tc.value {
+				t.Errorf("String round-trip failed: got %q, want %q", decodedStr.Data, tc.value)
+			}
+
+			var decodedByte ByteContainer
+			err = dynssz.UnmarshalSSZ(&decodedByte, byteEncoded)
+			if err != nil {
+				t.Fatalf("Failed to unmarshal byte container: %v", err)
+			}
+
+			if !bytes.Equal(decodedByte.Data, []byte(tc.value)) {
+				t.Errorf("Byte round-trip failed: got %q, want %q", decodedByte.Data, tc.value)
+			}
+		})
+	}
+}
+
+// TestFixedArraysOfStrings tests fixed-size arrays of strings within containers
+func TestFixedArraysOfStrings(t *testing.T) {
+	type StringArrayContainer struct {
+		Data [3]string `ssz-max:"0,1000"`
+	}
+
+	type ByteArrayContainer struct {
+		Data [3][]byte `ssz-max:"0,1000"`
+	}
+
+	dynssz := NewDynSsz(nil)
+
+	// Test data
+	strArray := [3]string{"hello", "world", "test"}
+	byteArray := [3][]byte{[]byte("hello"), []byte("world"), []byte("test")}
+
+	strContainer := StringArrayContainer{Data: strArray}
+	byteContainer := ByteArrayContainer{Data: byteArray}
+
+	// Test encoding
+	strEncoded, err := dynssz.MarshalSSZ(strContainer)
+	if err != nil {
+		t.Fatalf("Failed to marshal string array container: %v", err)
+	}
+
+	byteEncoded, err := dynssz.MarshalSSZ(byteContainer)
+	if err != nil {
+		t.Fatalf("Failed to marshal byte array container: %v", err)
+	}
+
+	if !bytes.Equal(strEncoded, byteEncoded) {
+		t.Errorf("Encoding mismatch between [3]string and [3][]byte containers")
+	}
+
+	// Test hash
+	strHash, err := dynssz.HashTreeRoot(strContainer)
+	if err != nil {
+		t.Fatalf("HashTreeRoot failed: %v", err)
+	}
+
+	byteHash, err := dynssz.HashTreeRoot(byteContainer)
+	if err != nil {
+		t.Fatalf("HashTreeRoot failed: %v", err)
+	}
+
+	if strHash != byteHash {
+		t.Errorf("Hash mismatch between [3]string and [3][]byte containers")
+	}
+}
+
+// TestFixedSizeStringVsByteArray verifies that fixed-size strings behave
+// identically to fixed-size byte arrays
+func TestFixedSizeStringVsByteArray(t *testing.T) {
+	type WithFixedString struct {
+		Data string `ssz-size:"32"`
+		ID   uint32
+	}
+
+	type WithByteArray struct {
+		Data [32]byte
+		ID   uint32
+	}
+
+	dynssz := NewDynSsz(nil)
+
+	testCases := []struct {
+		name  string
+		value string
+	}{
+		{"empty", ""},
+		{"short", "hello"},
+		{"exact_32", "abcdefghijklmnopqrstuvwxyz123456"},
+		{"over_32_truncated", "abcdefghijklmnopqrstuvwxyz1234567890"}, // Should be truncated
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create byte array with same data
+			var byteData [32]byte
+			copy(byteData[:], []byte(tc.value))
+
+			strStruct := WithFixedString{
+				Data: tc.value,
+				ID:   42,
+			}
+
+			byteStruct := WithByteArray{
+				Data: byteData,
+				ID:   42,
+			}
+
+			// Marshal both
+			strData, err := dynssz.MarshalSSZ(strStruct)
+			if err != nil {
+				t.Fatalf("Failed to marshal string struct: %v", err)
+			}
+
+			byteStructData, err := dynssz.MarshalSSZ(byteStruct)
+			if err != nil {
+				t.Fatalf("Failed to marshal byte struct: %v", err)
+			}
+
+			// They should be identical
+			if !bytes.Equal(strData, byteStructData) {
+				t.Errorf("Marshaled data mismatch:\nString: %x\nBytes:  %x", strData, byteStructData)
+			}
+
+			// Hash both
+			strHash, err := dynssz.HashTreeRoot(strStruct)
+			if err != nil {
+				t.Fatalf("Failed to hash string struct: %v", err)
+			}
+
+			byteHash, err := dynssz.HashTreeRoot(byteStruct)
+			if err != nil {
+				t.Fatalf("Failed to hash byte struct: %v", err)
+			}
+
+			// Hashes should be identical
+			if strHash != byteHash {
+				t.Errorf("Hash mismatch:\nString: %x\nBytes:  %x", strHash, byteHash)
+			}
+
+			// Test unmarshaling
+			var decodedStr WithFixedString
+			err = dynssz.UnmarshalSSZ(&decodedStr, strData)
+			if err != nil {
+				t.Fatalf("Failed to unmarshal string struct: %v", err)
+			}
+
+			// For strings longer than 32, we expect truncation
+			expectedStr := tc.value
+			if len(expectedStr) > 32 {
+				expectedStr = expectedStr[:32]
+			}
+
+			if decodedStr.Data != expectedStr {
+				t.Errorf("Unmarshal mismatch: got %q, want %q", decodedStr.Data, expectedStr)
+			}
+		})
+	}
+}
+
+// TestMixedStringTypes tests that mixing fixed and dynamic strings works correctly
+func TestMixedStringTypes(t *testing.T) {
+	type MixedStruct struct {
+		FixedStr1  string `ssz-size:"16"`
+		DynamicStr string `ssz-max:"100"`
+		FixedStr2  string `ssz-size:"8"`
+		ID         uint32
+	}
+
+	dynssz := NewDynSsz(nil)
+
+	test := MixedStruct{
+		FixedStr1:  "hello",
+		DynamicStr: "world",
+		FixedStr2:  "test",
+		ID:         42,
+	}
+
+	data, err := dynssz.MarshalSSZ(test)
+	if err != nil {
+		t.Fatalf("Failed to marshal: %v", err)
+	}
+
+	// Expected layout:
+	// 16 bytes for FixedStr1 (padded)
+	// 4 bytes offset for DynamicStr
+	// 8 bytes for FixedStr2 (padded)
+	// 4 bytes for ID
+	// Then the dynamic string data
+	expectedFixedSize := 16 + 4 + 8 + 4
+	if len(data) < expectedFixedSize {
+		t.Errorf("Data too short: got %d bytes, expected at least %d", len(data), expectedFixedSize)
+	}
+
+	// Unmarshal and verify
+	var decoded MixedStruct
+	err = dynssz.UnmarshalSSZ(&decoded, data)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+
+	if decoded.FixedStr1 != test.FixedStr1 {
+		t.Errorf("FixedStr1 mismatch: got %q, want %q", decoded.FixedStr1, test.FixedStr1)
+	}
+	if decoded.DynamicStr != test.DynamicStr {
+		t.Errorf("DynamicStr mismatch: got %q, want %q", decoded.DynamicStr, test.DynamicStr)
+	}
+	if decoded.FixedStr2 != test.FixedStr2 {
+		t.Errorf("FixedStr2 mismatch: got %q, want %q", decoded.FixedStr2, test.FixedStr2)
+	}
+	if decoded.ID != test.ID {
+		t.Errorf("ID mismatch: got %d, want %d", decoded.ID, test.ID)
+	}
+}
+
+// TestStringSliceVsByteSliceWithMaxSize verifies that []string and [][]byte
+// have the same hash root when they have max size hints (proper SSZ lists)
+func TestStringSliceVsByteSliceWithMaxSize(t *testing.T) {
+	dynssz := NewDynSsz(nil)
+
+	testCases := []struct {
+		name    string
+		strings []string
+		bytes   [][]byte
+	}{
+		{
+			"single_element",
+			[]string{"hello"},
+			[][]byte{[]byte("hello")},
+		},
+		{
+			"multiple_elements",
+			[]string{"one", "two", "three"},
+			[][]byte{[]byte("one"), []byte("two"), []byte("three")},
+		},
+		{
+			"with_empty",
+			[]string{"", "test", ""},
+			[][]byte{{}, []byte("test"), {}},
+		},
+		{
+			"empty_slice",
+			[]string{},
+			[][]byte{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// They should encode identically
+			strSliceEncoded, err := dynssz.MarshalSSZ(tc.strings)
+			if err != nil {
+				t.Fatalf("Failed to marshal []string: %v", err)
+			}
+
+			bytesSliceEncoded, err := dynssz.MarshalSSZ(tc.bytes)
+			if err != nil {
+				t.Fatalf("Failed to marshal [][]byte: %v", err)
+			}
+
+			if !bytes.Equal(strSliceEncoded, bytesSliceEncoded) {
+				t.Errorf("[]string and [][]byte should encode identically")
+				t.Logf("[]string encoded: %x", strSliceEncoded)
+				t.Logf("[][]byte encoded: %x", bytesSliceEncoded)
+			}
+
+			// They should have identical hash roots
+			strSliceHash, err := dynssz.HashTreeRoot(tc.strings)
+			if err != nil {
+				t.Fatalf("Failed to hash []string: %v", err)
+			}
+
+			bytesSliceHash, err := dynssz.HashTreeRoot(tc.bytes)
+			if err != nil {
+				t.Fatalf("Failed to hash [][]byte: %v", err)
+			}
+
+			if strSliceHash != bytesSliceHash {
+				t.Errorf("[]string and [][]byte should have identical hash roots")
+				t.Logf("[]string hash: %x", strSliceHash)
+				t.Logf("[][]byte hash: %x", bytesSliceHash)
+			}
+		})
+	}
+
+	// Also test with max size hints
+	type WithMaxSize struct {
+		StringList []string `ssz-max:"10"`
+		BytesList  [][]byte `ssz-max:"10"`
+	}
+
+	test := WithMaxSize{
+		StringList: []string{"hello", "world"},
+		BytesList:  [][]byte{[]byte("hello"), []byte("world")},
+	}
+
+	strHash, err := dynssz.HashTreeRoot(test.StringList)
+	if err != nil {
+		t.Fatalf("Failed to hash string list with max: %v", err)
+	}
+
+	bytesHash, err := dynssz.HashTreeRoot(test.BytesList)
+	if err != nil {
+		t.Fatalf("Failed to hash bytes list with max: %v", err)
+	}
+
+	if strHash != bytesHash {
+		t.Errorf("[]string and [][]byte with max size should have identical hash roots")
+		t.Logf("[]string (max 10) hash: %x", strHash)
+		t.Logf("[][]byte (max 10) hash: %x", bytesHash)
 	}
 }

--- a/string_test.go
+++ b/string_test.go
@@ -277,9 +277,14 @@ func TestFixedSizeStringVsByteArray(t *testing.T) {
 			}
 
 			// For strings longer than 32, we expect truncation
+			// For strings shorter than 32, we expect null padding
 			expectedStr := tc.value
 			if len(expectedStr) > 32 {
 				expectedStr = expectedStr[:32]
+			} else if len(expectedStr) < 32 {
+				// Pad with null bytes
+				paddingBytes := make([]byte, 32-len(expectedStr))
+				expectedStr = expectedStr + string(paddingBytes)
 			}
 
 			if decodedStr.Data != expectedStr {
@@ -330,14 +335,18 @@ func TestMixedStringTypes(t *testing.T) {
 		t.Fatalf("Failed to unmarshal: %v", err)
 	}
 
-	if decoded.FixedStr1 != test.FixedStr1 {
-		t.Errorf("FixedStr1 mismatch: got %q, want %q", decoded.FixedStr1, test.FixedStr1)
+	// Fixed-size strings will have null padding
+	expectedFixedStr1 := test.FixedStr1 + string(make([]byte, 16-len(test.FixedStr1)))
+	expectedFixedStr2 := test.FixedStr2 + string(make([]byte, 8-len(test.FixedStr2)))
+	
+	if decoded.FixedStr1 != expectedFixedStr1 {
+		t.Errorf("FixedStr1 mismatch: got %q, want %q", decoded.FixedStr1, expectedFixedStr1)
 	}
 	if decoded.DynamicStr != test.DynamicStr {
 		t.Errorf("DynamicStr mismatch: got %q, want %q", decoded.DynamicStr, test.DynamicStr)
 	}
-	if decoded.FixedStr2 != test.FixedStr2 {
-		t.Errorf("FixedStr2 mismatch: got %q, want %q", decoded.FixedStr2, test.FixedStr2)
+	if decoded.FixedStr2 != expectedFixedStr2 {
+		t.Errorf("FixedStr2 mismatch: got %q, want %q", decoded.FixedStr2, expectedFixedStr2)
 	}
 	if decoded.ID != test.ID {
 		t.Errorf("ID mismatch: got %d, want %d", decoded.ID, test.ID)

--- a/string_test.go
+++ b/string_test.go
@@ -1,0 +1,197 @@
+// dynssz: Dynamic SSZ encoding/decoding for Ethereum with fastssz efficiency.
+// This file is part of the dynssz package.
+// Copyright (c) 2024 by pk910. Refer to LICENSE for more information.
+package dynssz_test
+
+import (
+	"bytes"
+	"testing"
+
+	. "github.com/pk910/dynamic-ssz"
+)
+
+func TestStringMarshaling(t *testing.T) {
+	testCases := []struct {
+		name     string
+		value    string
+		expected []byte
+	}{
+		{"empty string", "", []byte{}},
+		{"simple string", "hello", []byte("hello")},
+		{"unicode string", "hello 世界", []byte("hello 世界")},
+		{"string with null bytes", "hello\x00world", []byte("hello\x00world")},
+	}
+
+	dynssz := NewDynSsz(nil)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := dynssz.MarshalSSZ(tc.value)
+			if err != nil {
+				t.Fatalf("MarshalSSZ failed: %v", err)
+			}
+			if !bytes.Equal(result, tc.expected) {
+				t.Errorf("MarshalSSZ result mismatch: got %v, want %v", result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestStringUnmarshaling(t *testing.T) {
+	testCases := []struct {
+		name     string
+		data     []byte
+		expected string
+	}{
+		{"empty string", []byte{}, ""},
+		{"simple string", []byte("hello"), "hello"},
+		{"unicode string", []byte("hello 世界"), "hello 世界"},
+		{"string with null bytes", []byte("hello\x00world"), "hello\x00world"},
+	}
+
+	dynssz := NewDynSsz(nil)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var result string
+			err := dynssz.UnmarshalSSZ(&result, tc.data)
+			if err != nil {
+				t.Fatalf("UnmarshalSSZ failed: %v", err)
+			}
+			if result != tc.expected {
+				t.Errorf("UnmarshalSSZ result mismatch: got %q, want %q", result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestStringInStruct(t *testing.T) {
+	type TestStruct struct {
+		Name string
+		Age  uint32
+	}
+
+	dynssz := NewDynSsz(nil)
+
+	// Test marshaling
+	original := TestStruct{Name: "Alice", Age: 30}
+	data, err := dynssz.MarshalSSZ(original)
+	if err != nil {
+		t.Fatalf("MarshalSSZ failed: %v", err)
+	}
+
+	// Test unmarshaling
+	var decoded TestStruct
+	err = dynssz.UnmarshalSSZ(&decoded, data)
+	if err != nil {
+		t.Fatalf("UnmarshalSSZ failed: %v", err)
+	}
+
+	if decoded.Name != original.Name || decoded.Age != original.Age {
+		t.Errorf("Round-trip failed: got %+v, want %+v", decoded, original)
+	}
+}
+
+func TestStringHashTreeRoot(t *testing.T) {
+	testCases := []struct {
+		name   string
+		value  string
+		// Note: These expected values would need to be calculated based on SSZ spec
+		// For now, we just ensure it doesn't error
+	}{
+		{"empty string", ""},
+		{"simple string", "hello"},
+		{"unicode string", "hello 世界"},
+	}
+
+	dynssz := NewDynSsz(nil)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			root, err := dynssz.HashTreeRoot(tc.value)
+			if err != nil {
+				t.Fatalf("HashTreeRoot failed: %v", err)
+			}
+			// Just ensure we got a 32-byte root
+			if len(root) != 32 {
+				t.Errorf("HashTreeRoot returned wrong size: got %d bytes, want 32", len(root))
+			}
+		})
+	}
+}
+
+func TestStringSlice(t *testing.T) {
+	dynssz := NewDynSsz(nil)
+
+	// Test slice of strings
+	original := []string{"hello", "world", "test"}
+	data, err := dynssz.MarshalSSZ(original)
+	if err != nil {
+		t.Fatalf("MarshalSSZ failed: %v", err)
+	}
+
+	var decoded []string
+	err = dynssz.UnmarshalSSZ(&decoded, data)
+	if err != nil {
+		t.Fatalf("UnmarshalSSZ failed: %v", err)
+	}
+
+	if len(decoded) != len(original) {
+		t.Fatalf("Length mismatch: got %d, want %d", len(decoded), len(original))
+	}
+
+	for i, v := range decoded {
+		if v != original[i] {
+			t.Errorf("Element %d mismatch: got %q, want %q", i, v, original[i])
+		}
+	}
+}
+
+func TestStringArray(t *testing.T) {
+	dynssz := NewDynSsz(nil)
+
+	// Test array of strings
+	original := [3]string{"one", "two", "three"}
+	data, err := dynssz.MarshalSSZ(original)
+	if err != nil {
+		t.Fatalf("MarshalSSZ failed: %v", err)
+	}
+
+	var decoded [3]string
+	err = dynssz.UnmarshalSSZ(&decoded, data)
+	if err != nil {
+		t.Fatalf("UnmarshalSSZ failed: %v", err)
+	}
+
+	for i, v := range decoded {
+		if v != original[i] {
+			t.Errorf("Element %d mismatch: got %q, want %q", i, v, original[i])
+		}
+	}
+}
+
+func TestStringSizeSSZ(t *testing.T) {
+	testCases := []struct {
+		name     string
+		value    string
+		expected int
+	}{
+		{"empty string", "", 0},
+		{"simple string", "hello", 5},
+		{"unicode string", "hello 世界", len("hello 世界")},
+	}
+
+	dynssz := NewDynSsz(nil)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			size, err := dynssz.SizeSSZ(tc.value)
+			if err != nil {
+				t.Fatalf("SizeSSZ failed: %v", err)
+			}
+			if size != tc.expected {
+				t.Errorf("SizeSSZ mismatch: got %d, want %d", size, tc.expected)
+			}
+		})
+	}
+}

--- a/treeroot.go
+++ b/treeroot.go
@@ -412,12 +412,7 @@ func (d *DynSsz) buildRootFromString(sourceType *TypeDescriptor, sourceValue ref
 		hh.MerkleizeWithMixin(subIndex, uint64(len(stringBytes)), limit)
 	} else {
 		// Dynamic string without hints: hash as basic type
-		if len(stringBytes) == 0 {
-			hh.Append(stringBytes)
-			hh.FillUpTo32()
-		} else {
-			hh.PutBytes(stringBytes)
-		}
+		hh.PutBytes(stringBytes)
 	}
 	
 	return nil

--- a/treeroot.go
+++ b/treeroot.go
@@ -131,6 +131,16 @@ func (d *DynSsz) buildRootFromType(sourceType *TypeDescriptor, sourceValue refle
 				hh.PutUint32(uint32(sourceValue.Uint()))
 			case reflect.Uint64:
 				hh.PutUint64(uint64(sourceValue.Uint()))
+			case reflect.String:
+				// Convert string to []byte and hash as bytes
+				stringBytes := []byte(sourceValue.String())
+				if len(stringBytes) == 0 {
+					// For empty strings, we still need to append empty bytes and fill to 32
+					hh.Append(stringBytes)
+					hh.FillUpTo32()
+				} else {
+					hh.PutBytes(stringBytes)
+				}
 			default:
 				return fmt.Errorf("unknown type: %v", sourceType)
 			}

--- a/typecache.go
+++ b/typecache.go
@@ -379,11 +379,11 @@ func (tc *TypeCache) buildSliceDescriptor(desc *TypeDescriptor, t reflect.Type, 
 // buildStringDescriptor builds a descriptor for string types
 func (tc *TypeCache) buildStringDescriptor(desc *TypeDescriptor, sizeHints []SszSizeHint, maxSizeHints []SszMaxSizeHint) error {
 	desc.IsString = true
-	
+
 	// Apply size hints
 	desc.SizeHints = sizeHints
 	desc.MaxSizeHints = maxSizeHints
-	
+
 	// Check if we have a size hint to make this a fixed-size string
 	if len(sizeHints) > 0 && !sizeHints[0].Dynamic && sizeHints[0].Size > 0 {
 		// Fixed-size string
@@ -392,9 +392,8 @@ func (tc *TypeCache) buildStringDescriptor(desc *TypeDescriptor, sizeHints []Ssz
 		// Dynamic string (default)
 		desc.Size = -1
 	}
-	
-	// Strings don't have dynamic size or max in the same way as slices/arrays
-	// They're either fixed-size (with ssz-size) or dynamic (default)
+
+	// Strings simply have to be determined if they dynamic or not.
 	if desc.Size < 0 {
 		// Dynamic strings might have spec values
 		if len(sizeHints) > 0 && sizeHints[0].SpecVal {
@@ -404,7 +403,7 @@ func (tc *TypeCache) buildStringDescriptor(desc *TypeDescriptor, sizeHints []Ssz
 			desc.HasDynamicMax = true
 		}
 	}
-	
+
 	return nil
 }
 

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -103,6 +103,10 @@ func (d *DynSsz) unmarshalType(targetType *TypeDescriptor, targetValue reflect.V
 		case reflect.Uint64:
 			targetValue.SetUint(uint64(unmarshallUint64(ssz)))
 			consumedBytes = 8
+		case reflect.String:
+			// Convert []byte to string and set
+			targetValue.SetString(string(ssz))
+			consumedBytes = len(ssz)
 
 		default:
 			return 0, fmt.Errorf("unknown type: %v", targetType)

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -104,30 +104,11 @@ func (d *DynSsz) unmarshalType(targetType *TypeDescriptor, targetValue reflect.V
 			targetValue.SetUint(uint64(unmarshallUint64(ssz)))
 			consumedBytes = 8
 		case reflect.String:
-			// Handle fixed-size vs dynamic strings
-			if targetType.Size > 0 {
-				// Fixed-size string: read exact number of bytes
-				fixedSize := int(targetType.Size)
-				if len(ssz) < fixedSize {
-					return 0, fmt.Errorf("not enough data for fixed-size string: need %d bytes, have %d", fixedSize, len(ssz))
-				}
-				// Read the fixed-size bytes and trim null padding
-				stringBytes := ssz[:fixedSize]
-				// Find the first null byte to trim padding
-				nullIndex := fixedSize
-				for i := 0; i < fixedSize; i++ {
-					if stringBytes[i] == 0 {
-						nullIndex = i
-						break
-					}
-				}
-				targetValue.SetString(string(stringBytes[:nullIndex]))
-				consumedBytes = fixedSize
-			} else {
-				// Dynamic string: use all available bytes
-				targetValue.SetString(string(ssz))
-				consumedBytes = len(ssz)
+			consumed, err := d.unmarshalString(targetType, targetValue, ssz, idt)
+			if err != nil {
+				return 0, err
 			}
+			consumedBytes = consumed
 
 		default:
 			return 0, fmt.Errorf("unknown type: %v", targetType)
@@ -501,4 +482,53 @@ func (d *DynSsz) unmarshalDynamicSlice(targetType *TypeDescriptor, targetValue r
 	targetValue.Set(newValue)
 
 	return offset, nil
+}
+
+// unmarshalString decodes SSZ-encoded data into a Go string value.
+//
+// Strings in SSZ can be either fixed-size or dynamic:
+//   - Fixed-size strings: Read exact number of bytes and trim null padding
+//   - Dynamic strings: Use all available bytes
+//
+// Parameters:
+//   - targetType: The TypeDescriptor containing string metadata and size constraints
+//   - targetValue: The reflect.Value where the decoded string will be stored
+//   - ssz: The SSZ-encoded data to decode
+//   - idt: Indentation level for verbose logging
+//
+// Returns:
+//   - int: The number of bytes consumed from the SSZ data
+//   - error: An error if decoding fails (e.g., insufficient data for fixed-size string)
+//
+// For fixed-size strings, the function reads exactly the specified number of bytes
+// and trims any null padding. For dynamic strings, all available bytes are used.
+func (d *DynSsz) unmarshalString(targetType *TypeDescriptor, targetValue reflect.Value, ssz []byte, idt int) (int, error) {
+	consumedBytes := 0
+	
+	// Handle fixed-size vs dynamic strings
+	if targetType.Size > 0 {
+		// Fixed-size string: read exact number of bytes
+		fixedSize := int(targetType.Size)
+		if len(ssz) < fixedSize {
+			return 0, fmt.Errorf("not enough data for fixed-size string: need %d bytes, have %d", fixedSize, len(ssz))
+		}
+		// Read the fixed-size bytes and trim null padding
+		stringBytes := ssz[:fixedSize]
+		// Find the first null byte to trim padding
+		nullIndex := fixedSize
+		for i := 0; i < fixedSize; i++ {
+			if stringBytes[i] == 0 {
+				nullIndex = i
+				break
+			}
+		}
+		targetValue.SetString(string(stringBytes[:nullIndex]))
+		consumedBytes = fixedSize
+	} else {
+		// Dynamic string: use all available bytes
+		targetValue.SetString(string(ssz))
+		consumedBytes = len(ssz)
+	}
+	
+	return consumedBytes, nil
 }


### PR DESCRIPTION
#18 i have no clue if this is the right way to do this, but here's my try at it. 

strings are handled by reflection differently from []byte, as they are not slices, so we need to distinguish IsString as a separate type.

the tests ensure that it acts the same as []byte when used within a container. 

i still need to look at what the behavior would be of no size annotation, but that would be invalid in ssz anyways, right, so i dont know if it really matters? but i think it would be trivial to make them the same if needed.
