### PR TITLE
mixin variant in CompatibleUnion treeroot calculation

### DIFF
--- a/treeroot.go
+++ b/treeroot.go
@@ -398,10 +398,18 @@ func (d *DynSsz) buildRootFromCompatibleUnion(sourceType *TypeDescriptor, source
 	}
 	dataField = dataField.Elem()
 
+	hashIndex := hh.Index()
+
 	err := d.buildRootFromType(variantDesc, dataField, hh, false, idt+2)
 	if err != nil {
 		return fmt.Errorf("failed to hash union variant %d: %w", variant, err)
 	}
+
+	// mixin the selector
+	hh.PutUint8(variant)
+
+	// merkleize
+	hh.Merkleize(hashIndex)
 
 	return nil
 }

--- a/treeroot_test.go
+++ b/treeroot_test.go
@@ -291,7 +291,7 @@ var treerootTestMatrix = []struct {
 			Field1 uint32
 			Field2 [2]uint8
 		}]{Variant: 0, Data: uint32(0x12345678)}, 0x4242},
-		fromHex("0xf72856610b8e134c3abbeccf3a6545ef026d9f456a57618628e15c2863c0dc6a"),
+		fromHex("0x631276fc281634b5224241dd547762be15e2f54e361c6bdc8f921a4d5125e954"),
 	},
 
 	// string types


### PR DESCRIPTION
for compatibility with recent spec change:
https://eips.ethereum.org/EIPS/eip-8016