### PR TITLE
fix(ci): compare new benchmarks with base

### DIFF
--- a/.github/workflows/benchmark-comment.yml
+++ b/.github/workflows/benchmark-comment.yml
@@ -25,11 +25,17 @@ jobs:
 
     - name: Get PR number
       id: pr
+      shell: bash
       run: |
+        set -euo pipefail
+
+        PR_NUMBER=''
+
         # Read PR number saved by the benchmark workflow
         if [ -f results/pr-number.txt ]; then
-          PR_NUMBER=$(cat results/pr-number.txt | tr -d '[:space:]')
+          PR_NUMBER=$(tr -d '[:space:]' < results/pr-number.txt)
         fi
+
         if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
           echo "Could not determine PR number, skipping comment"
           echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -41,29 +47,84 @@ jobs:
     - name: Build comment body
       if: steps.pr.outputs.skip != 'true'
       id: body
+      shell: bash
       run: |
-        # Filter benchstat output to only show metric sections with significant changes.
-        # Removes entries showing "~ (p=" (no change), keeps sections that have at least
-        # one entry with an actual percentage change.
+        set -euo pipefail
+
+        # Keep only metric sections with at least one significant benchmark row.
         filter_benchstat() {
           awk '
-          BEGIN { hdr=""; buf=""; geo=""; has=0; any=0 }
+          BEGIN { hdr=""; rows=""; geo=""; has=0; any=0 }
           /^(goos|goarch|pkg|cpu):/ { next }
           /^[[:space:]]*│/ { hdr = hdr $0 "\n"; next }
           /^[[:space:]]*$/ {
-            if (has) { printf "%s%s%s\n", hdr, buf, geo; any=1 }
-            hdr=""; buf=""; geo=""; has=0
+            if (has) {
+              printf "%s%s", hdr, rows
+              if (geo != "") {
+                printf "%s", geo
+              }
+              printf "\n"
+              any=1
+            }
+            hdr=""; rows=""; geo=""; has=0
             next
           }
           /^geomean/ { geo = $0 "\n"; next }
+          /^[[:space:]]*[[:digit:]¹²³]/ { next }
+          /^[[:space:]]*$/ { next }
           {
-            if ($0 !~ /~ \(p=/) { buf = buf $0 "\n"; has=1 }
+            if ($0 !~ /~ \(p=/) {
+              rows = rows $0 "\n"
+              has=1
+            }
           }
           END {
-            if (has) { printf "%s%s%s", hdr, buf, geo; any=1 }
-            if (!any) print "No significant performance changes detected."
+            if (has) {
+              printf "%s%s", hdr, rows
+              if (geo != "") {
+                printf "%s", geo
+              }
+              any=1
+            }
           }
           ' "$1"
+        }
+
+        render_benchstat_section() {
+          local title=$1
+          local stat_file=$2
+          local raw_file=$3
+
+          if [ -f "$stat_file" ] && [ -s "$stat_file" ]; then
+            local filtered
+            filtered=$(filter_benchstat "$stat_file")
+
+            if [ -n "$filtered" ]; then
+              echo "### $title"
+              echo ''
+              echo '```'
+              echo "$filtered"
+              echo '```'
+            else
+              echo "**$title:** No significant changes."
+              echo ''
+              echo "<details><summary>$title (full comparison)</summary>"
+              echo ''
+              echo '```'
+              cat "$stat_file"
+              echo '```'
+              echo ''
+              echo '</details>'
+            fi
+          elif [ -f "$raw_file" ]; then
+            echo "<details><summary>$title (no base to compare)</summary>"
+            echo ''
+            echo '```'
+            cat "$raw_file"
+            echo '```'
+            echo ''
+            echo '</details>'
+          fi
         }
 
         {
@@ -71,51 +132,11 @@ jobs:
           echo '## Benchmark Results'
           echo ''
 
-          # Library benchmarks
-          if [ -f results/lib-stat.txt ] && [ -s results/lib-stat.txt ]; then
-            LIB_FILTERED=$(filter_benchstat results/lib-stat.txt)
-            if echo "$LIB_FILTERED" | grep -q "No significant"; then
-              echo "**Library Benchmarks:** No significant changes."
-            else
-              echo '### Library Benchmarks'
-              echo ''
-              echo '```'
-              echo "$LIB_FILTERED"
-              echo '```'
-            fi
-          elif [ -f results/pr-lib.txt ]; then
-            echo '<details><summary>Library Benchmarks (no base to compare)</summary>'
-            echo ''
-            echo '```'
-            cat results/pr-lib.txt
-            echo '```'
-            echo ''
-            echo '</details>'
-          fi
+          render_benchstat_section "Library Benchmarks" results/lib-stat.txt results/pr-lib.txt
 
           echo ''
 
-          # Perf benchmarks
-          if [ -f results/perf-stat.txt ] && [ -s results/perf-stat.txt ]; then
-            PERF_FILTERED=$(filter_benchstat results/perf-stat.txt)
-            if echo "$PERF_FILTERED" | grep -q "No significant"; then
-              echo "**Performance Benchmarks:** No significant changes."
-            else
-              echo '### Performance Benchmarks'
-              echo ''
-              echo '```'
-              echo "$PERF_FILTERED"
-              echo '```'
-            fi
-          elif [ -f results/pr-perf.txt ]; then
-            echo '<details><summary>Performance Benchmarks (no base to compare)</summary>'
-            echo ''
-            echo '```'
-            cat results/pr-perf.txt
-            echo '```'
-            echo ''
-            echo '</details>'
-          fi
+          render_benchstat_section "Performance Benchmarks" results/perf-stat.txt results/pr-perf.txt
 
           echo 'EOF'
         } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -74,20 +74,45 @@ jobs:
             continue
           fi
 
-          rm -f "base/$dir"/*_test.go
+          mapfile -t pr_tests < <(
+            find "pr/$dir" -maxdepth 1 -type f -name '*_test.go' |
+              LC_ALL=C sort
+          )
+          mapfile -t base_tests < <(
+            find "base/$dir" -maxdepth 1 -type f -name '*_test.go' |
+              LC_ALL=C sort
+          )
 
-          copied=0
-          while IFS= read -r test_file; do
-            cp "pr/$test_file" "base/$test_file"
-            copied=$((copied + 1))
-          done < <(cd pr && git ls-files "$dir/*_test.go")
-
-          if [ "$copied" -eq 0 ]; then
+          if [ "${#pr_tests[@]}" -eq 0 ]; then
             continue
           fi
 
+          changed=0
+          if [ "${#pr_tests[@]}" -ne "${#base_tests[@]}" ]; then
+            changed=1
+          else
+            for i in "${!pr_tests[@]}"; do
+              pr_file="${pr_tests[$i]}"
+              base_file="${base_tests[$i]}"
+              if [ "${pr_file#pr/}" != "${base_file#base/}" ] || ! cmp -s "$pr_file" "$base_file"; then
+                changed=1
+                break
+              fi
+            done
+          fi
+
+          if [ "$changed" -eq 0 ]; then
+            continue
+          fi
+
+          rm -f "base/$dir"/*_test.go
+
+          for test_file in "${pr_tests[@]}"; do
+            cp "$test_file" "base/${test_file#pr/}"
+          done
+
           synced=$((synced + 1))
-          echo "Synced benchmark harness in $dir ($copied test files)"
+          echo "Synced benchmark harness in $dir (${#pr_tests[@]} test files)"
         done < <(
           cd pr
           git grep -l '^[[:space:]]*func Benchmark' -- '*_test.go' |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -64,6 +64,39 @@ jobs:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-bench-${{ hashFiles('pr/tests/perftests/go.sum') }}
 
+    - name: Sync benchmark harness to base
+      run: |
+        set -euo pipefail
+
+        synced=0
+        while IFS= read -r dir; do
+          if [ -z "$dir" ] || [ ! -d "base/$dir" ]; then
+            continue
+          fi
+
+          rm -f "base/$dir"/*_test.go
+
+          copied=0
+          while IFS= read -r test_file; do
+            cp "pr/$test_file" "base/$test_file"
+            copied=$((copied + 1))
+          done < <(cd pr && git ls-files "$dir/*_test.go")
+
+          if [ "$copied" -eq 0 ]; then
+            continue
+          fi
+
+          synced=$((synced + 1))
+          echo "Synced benchmark harness in $dir ($copied test files)"
+        done < <(
+          cd pr
+          git grep -l '^[[:space:]]*func Benchmark' -- '*_test.go' |
+            xargs -r -n1 dirname |
+            sort -u
+        )
+
+        echo "Synced benchmark harness for $synced packages from PR into base checkout"
+
     - name: Run library benchmarks (base)
       continue-on-error: true
       run: |


### PR DESCRIPTION
Issue:
The benchmark bot was not comparing the new `NodeProveMulti/...` and `NodeProve/...` benchmarks with base. The base run was using the older benchmark test harness, so base-lib.txt did not contain those benchmark names.

Fix:
This PR updates the benchmark workflow to sync benchmark test files from the PR checkout into the base checkout before running base benchmarks, only when those files differ. This lets the base run include the same benchmark names, so the bot can show proper comparisons without doing unnecessary sync work.