### PR TITLE
prevent excessive buffer allocation in stream marshal/unmarshal

### DIFF
--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -168,7 +168,7 @@ Creates a new stream encoder:
 ```go
 import "github.com/pk910/dynamic-ssz/sszutils"
 
-encoder := sszutils.NewStreamEncoder(writer, 0) // 0 = default 2KB buffer
+encoder := sszutils.NewStreamEncoder(writer, 0, 0) // 0 = default 2KB write buffer, 0 = default 200KB max delegation buffer
 ```
 
 The `StreamEncoder`:
@@ -182,7 +182,7 @@ The `StreamEncoder`:
 Creates a new stream decoder:
 
 ```go
-decoder := sszutils.NewStreamDecoder(reader, totalSize, 0) // 0 = default 2KB buffer
+decoder := sszutils.NewStreamDecoder(reader, totalSize, 0, 0) // 0 = default 2KB read buffer, 0 = default 200KB max delegation buffer
 ```
 
 The `StreamDecoder`:

--- a/dynssz.go
+++ b/dynssz.go
@@ -397,7 +397,7 @@ func (d *DynSsz) MarshalSSZTo(source any, buf []byte, opts ...CallOption) ([]byt
 //	err = ds.MarshalSSZWriter(block, conn)
 func (d *DynSsz) MarshalSSZWriter(source any, w io.Writer, opts ...CallOption) error {
 	cfg := applyCallOptions(opts)
-	encoder := sszutils.NewStreamEncoder(w, d.options.StreamWriterBufferSize)
+	encoder := sszutils.NewStreamEncoder(w, d.options.StreamWriterBufferSize, d.options.StreamWriterMaxBufferSize)
 
 	// Skip view descriptor logic for types implementing DynamicEncoder
 	if cfg == nil || cfg.viewDescriptor == nil {
@@ -662,7 +662,7 @@ func (d *DynSsz) UnmarshalSSZ(target any, ssz []byte, opts ...CallOption) error 
 //	err = ds.UnmarshalSSZReader(&block, conn, -1)
 func (d *DynSsz) UnmarshalSSZReader(target any, r io.Reader, size int, opts ...CallOption) error {
 	cfg := applyCallOptions(opts)
-	decoder := sszutils.NewStreamDecoder(r, size, d.options.StreamReaderBufferSize)
+	decoder := sszutils.NewStreamDecoder(r, size, d.options.StreamReaderBufferSize, d.options.StreamReaderMaxBufferSize)
 	decoder.PushLimit(size)
 
 	// Skip view descriptor logic for types implementing DynamicDecoder

--- a/options.go
+++ b/options.go
@@ -10,13 +10,15 @@ type DynSszOption func(*DynSszOptions)
 
 // DynSszOptions holds the configuration options for a DynSsz instance.
 type DynSszOptions struct {
-	NoFastSsz              bool
-	NoFastHash             bool
-	ExtendedTypes          bool
-	Verbose                bool
-	LogCb                  func(format string, args ...any)
-	StreamWriterBufferSize int
-	StreamReaderBufferSize int
+	NoFastSsz                 bool
+	NoFastHash                bool
+	ExtendedTypes             bool
+	Verbose                   bool
+	LogCb                     func(format string, args ...any)
+	StreamWriterBufferSize    int
+	StreamWriterMaxBufferSize int
+	StreamReaderBufferSize    int
+	StreamReaderMaxBufferSize int
 }
 
 // WithNoFastSsz disables fastssz fallback for types that implement fastssz
@@ -68,11 +70,33 @@ func WithStreamWriterBufferSize(size int) DynSszOption {
 	}
 }
 
-// WithStreamReaderBufferSize sets the maximum internal buffer size for the
-// streaming SSZ decoder used by UnmarshalSSZReader. Defaults to 2KB if not set.
+// WithStreamWriterMaxBufferSize sets the maximum buffer size for delegating to
+// buffer-based marshal methods during streaming SSZ encoding. When a type's
+// serialized size exceeds this limit, the encoder falls through to
+// reflection-based field-by-field marshalling instead of buffering the entire
+// object. Defaults to 200KB if not set.
+func WithStreamWriterMaxBufferSize(size int) DynSszOption {
+	return func(opts *DynSszOptions) {
+		opts.StreamWriterMaxBufferSize = size
+	}
+}
+
+// WithStreamReaderBufferSize sets the internal buffer size for the streaming
+// SSZ decoder used by UnmarshalSSZReader. Defaults to 2KB if not set.
 func WithStreamReaderBufferSize(size int) DynSszOption {
 	return func(opts *DynSszOptions) {
 		opts.StreamReaderBufferSize = size
+	}
+}
+
+// WithStreamReaderMaxBufferSize sets the maximum buffer size for delegating to
+// buffer-based unmarshal methods during streaming SSZ decoding. When a type's
+// serialized size exceeds this limit, the decoder falls through to
+// reflection-based field-by-field unmarshalling instead of buffering the entire
+// object. Defaults to 200KB if not set.
+func WithStreamReaderMaxBufferSize(size int) DynSszOption {
+	return func(opts *DynSszOptions) {
+		opts.StreamReaderMaxBufferSize = size
 	}
 }
 

--- a/reflection/marshal.go
+++ b/reflection/marshal.go
@@ -74,12 +74,14 @@ func (ctx *ReflectionCtx) marshalType(sourceType *ssztypes.TypeDescriptor, sourc
 
 		if useFastSsz {
 			if marshaller, ok := getPtr(sourceValue).Interface().(sszutils.FastsszMarshaler); ok {
-				newBuf, err := marshaller.MarshalSSZTo(encoder.GetBuffer())
-				if err != nil {
-					return err
+				if int(sourceType.Size) <= encoder.MaxEncodeBufferSize() || sourceType.SszType == ssztypes.SszCustomType {
+					newBuf, err := marshaller.MarshalSSZTo(encoder.GetBuffer())
+					if err != nil {
+						return err
+					}
+					encoder.SetBuffer(newBuf)
+					return nil
 				}
-				encoder.SetBuffer(newBuf)
-				return nil
 			}
 		}
 
@@ -94,12 +96,14 @@ func (ctx *ReflectionCtx) marshalType(sourceType *ssztypes.TypeDescriptor, sourc
 
 		if useDynamicMarshal {
 			if marshaller, ok := getPtr(sourceValue).Interface().(sszutils.DynamicMarshaler); ok {
-				newBuf, err := marshaller.MarshalSSZDyn(ctx.ds, encoder.GetBuffer())
-				if err != nil {
-					return err
+				if encoder.Seekable() || (sourceType.Size > 0 && int(sourceType.Size) <= encoder.MaxEncodeBufferSize()) {
+					newBuf, err := marshaller.MarshalSSZDyn(ctx.ds, encoder.GetBuffer())
+					if err != nil {
+						return err
+					}
+					encoder.SetBuffer(newBuf)
+					return nil
 				}
-				encoder.SetBuffer(newBuf)
-				return nil
 			}
 		}
 	}
@@ -214,12 +218,14 @@ func (ctx *ReflectionCtx) tryMarshalView(sourceType *ssztypes.TypeDescriptor, so
 	if useViewMarshaler {
 		if marshaller, ok := getPtr(sourceValue).Interface().(sszutils.DynamicViewMarshaler); ok {
 			if marshalFn := marshaller.MarshalSSZDynView(*sourceType.CodegenInfo); marshalFn != nil {
-				newBuf, err := marshalFn(ctx.ds, encoder.GetBuffer())
-				if err != nil {
-					return true, err
+				if encoder.Seekable() || (sourceType.Size > 0 && int(sourceType.Size) <= encoder.MaxEncodeBufferSize()) {
+					newBuf, err := marshalFn(ctx.ds, encoder.GetBuffer())
+					if err != nil {
+						return true, err
+					}
+					encoder.SetBuffer(newBuf)
+					return true, nil
 				}
-				encoder.SetBuffer(newBuf)
-				return true, nil
 			}
 		}
 	}

--- a/reflection/marshal_test.go
+++ b/reflection/marshal_test.go
@@ -1504,7 +1504,7 @@ func TestMarshalDynamicListNonSeekableSizeError(t *testing.T) {
 	listDesc.ElemDesc = &elemDescCopy
 
 	ctx := reflection.NewReflectionCtx(nil, nil, false, true)
-	encoder := sszutils.NewStreamEncoder(bytes.NewBuffer(nil), 0)
+	encoder := sszutils.NewStreamEncoder(bytes.NewBuffer(nil), 0, 0)
 	data := []DynElem{{Value: 1}, {Value: 2}}
 	err = ctx.MarshalSSZ(listDesc, reflect.ValueOf(data), encoder)
 	if err == nil {

--- a/reflection/overflow_internal_test.go
+++ b/reflection/overflow_internal_test.go
@@ -306,7 +306,7 @@ func TestMarshalLargeVectorStreaming(t *testing.T) {
 	val := reflect.ValueOf(src)
 
 	// Use StreamEncoder writing to io.Discard so we don't buffer output.
-	enc := sszutils.NewStreamEncoder(io.Discard, 4096)
+	enc := sszutils.NewStreamEncoder(io.Discard, 4096, 0)
 
 	err := ctx.marshalType(td, val, enc, 0)
 	if err != nil {

--- a/reflection/unmarshal.go
+++ b/reflection/unmarshal.go
@@ -80,11 +80,13 @@ func (ctx *ReflectionCtx) unmarshalType(targetType *ssztypes.TypeDescriptor, tar
 			if unmarshaler, ok := targetValue.Addr().Interface().(sszutils.DynamicViewUnmarshaler); ok {
 				if unmarshalFn := unmarshaler.UnmarshalSSZDynView(*targetType.CodegenInfo); unmarshalFn != nil {
 					bufLen := decoder.GetLength()
-					buf, err := decoder.DecodeBytesBuf(bufLen)
-					if err != nil {
-						return err
+					if bufLen <= decoder.MaxDecodeBufferSize() {
+						buf, err := decoder.DecodeBytesBuf(bufLen)
+						if err != nil {
+							return err
+						}
+						return unmarshalFn(ctx.ds, buf)
 					}
-					return unmarshalFn(ctx.ds, buf)
 				}
 			}
 		}
@@ -109,11 +111,13 @@ func (ctx *ReflectionCtx) unmarshalType(targetType *ssztypes.TypeDescriptor, tar
 					}
 					sszLen = int(typeSize)
 				}
-				sszBuf, err := decoder.DecodeBytesBuf(sszLen)
-				if err != nil {
-					return err
+				if sszLen <= decoder.MaxDecodeBufferSize() || targetType.SszType == ssztypes.SszCustomType {
+					sszBuf, err := decoder.DecodeBytesBuf(sszLen)
+					if err != nil {
+						return err
+					}
+					return unmarshaller.UnmarshalSSZ(sszBuf)
 				}
-				return unmarshaller.UnmarshalSSZ(sszBuf)
 			}
 		}
 
@@ -136,11 +140,13 @@ func (ctx *ReflectionCtx) unmarshalType(targetType *ssztypes.TypeDescriptor, tar
 					}
 					sszLen = int(typeSize)
 				}
-				sszBuf, err := decoder.DecodeBytesBuf(sszLen)
-				if err != nil {
-					return err
+				if sszLen <= decoder.MaxDecodeBufferSize() {
+					sszBuf, err := decoder.DecodeBytesBuf(sszLen)
+					if err != nil {
+						return err
+					}
+					return unmarshaller.UnmarshalSSZDyn(ctx.ds, sszBuf)
 				}
-				return unmarshaller.UnmarshalSSZDyn(ctx.ds, sszBuf)
 			}
 		}
 	}

--- a/sszutils/decoder.go
+++ b/sszutils/decoder.go
@@ -22,4 +22,5 @@ type Decoder interface {
 	DecodeOffset() (uint32, error)
 	DecodeOffsetAt(pos int) uint32
 	SkipBytes(n int)
+	MaxDecodeBufferSize() int // max size for efficient DecodeBytesBuf without excessive allocation
 }

--- a/sszutils/decoder_buffer.go
+++ b/sszutils/decoder_buffer.go
@@ -6,6 +6,7 @@ package sszutils
 
 import (
 	"encoding/binary"
+	"math"
 )
 
 // BufferDecoder is a seekable Decoder implementation backed by an in-memory
@@ -37,6 +38,12 @@ func NewBufferDecoder(buffer []byte) *BufferDecoder {
 // offset reads via DecodeOffsetAt and byte skipping via SkipBytes.
 func (e *BufferDecoder) Seekable() bool {
 	return true
+}
+
+// MaxDecodeBufferSize returns math.MaxInt because the entire buffer is already
+// in memory and DecodeBytesBuf only returns a slice—no allocation needed.
+func (e *BufferDecoder) MaxDecodeBufferSize() int {
+	return math.MaxInt
 }
 
 // GetPosition returns the current read position in the buffer.

--- a/sszutils/decoder_stream.go
+++ b/sszutils/decoder_stream.go
@@ -9,9 +9,14 @@ import (
 	"io"
 )
 
-// DefaultStreamDecoderBufSize is the default maximum buffer size for
+// DefaultStreamDecoderBufSize is the default internal read buffer size for
 // StreamDecoder (2KB).
 const DefaultStreamDecoderBufSize = 2 * 1024
+
+// DefaultStreamDecoderMaxBufSize is the default maximum buffer size for
+// delegation to buffer-based unmarshal methods (200KB). Reads exceeding this
+// threshold fall through to reflection-based field-by-field unmarshalling.
+const DefaultStreamDecoderMaxBufSize = 200 * 1024
 
 // StreamDecoder is a non-seekable Decoder implementation that reads SSZ data
 // from an io.Reader. It uses an internal buffer for efficient sequential reads
@@ -24,23 +29,28 @@ type StreamDecoder struct {
 	position  int
 
 	// Internal buffer for reading from stream
-	buffer    []byte
-	bufferPos int // Current read position within buffer
-	bufferLen int // Amount of valid data in buffer
+	buffer     []byte
+	bufferPos  int // Current read position within buffer
+	bufferLen  int // Amount of valid data in buffer
+	maxBufSize int // Configured maximum buffer size
 }
 
 var _ Decoder = (*StreamDecoder)(nil)
 
 // NewStreamDecoder creates a new StreamDecoder that reads SSZ data from the
 // provided io.Reader. totalLen specifies the total expected byte length of the
-// SSZ payload. maxBufSize controls the maximum internal read buffer size; if
-// <= 0, DefaultStreamDecoderBufSize is used.
-func NewStreamDecoder(reader io.Reader, totalLen, maxBufSize int) *StreamDecoder {
+// SSZ payload. bufSize controls the internal read buffer size (defaults to 2KB
+// if <= 0). maxBufSize controls the maximum buffer size for delegation to
+// buffer-based unmarshal methods (defaults to 200KB if <= 0).
+func NewStreamDecoder(reader io.Reader, totalLen, bufSize, maxBufSize int) *StreamDecoder {
+	if bufSize <= 0 {
+		bufSize = DefaultStreamDecoderBufSize
+	}
 	if maxBufSize <= 0 {
-		maxBufSize = DefaultStreamDecoderBufSize
+		maxBufSize = DefaultStreamDecoderMaxBufSize
 	}
 	// Use smaller buffer for small streams
-	bufferSize := maxBufSize
+	bufferSize := bufSize
 	if totalLen < bufferSize {
 		bufferSize = totalLen
 	}
@@ -49,19 +59,27 @@ func NewStreamDecoder(reader io.Reader, totalLen, maxBufSize int) *StreamDecoder
 	}
 
 	return &StreamDecoder{
-		reader:    reader,
-		limits:    make([]int, 0, 16),
-		lastLimit: totalLen,
-		streamLen: totalLen,
-		position:  0,
-		buffer:    make([]byte, bufferSize),
-		bufferPos: 0,
-		bufferLen: 0,
+		reader:     reader,
+		limits:     make([]int, 0, 16),
+		lastLimit:  totalLen,
+		streamLen:  totalLen,
+		position:   0,
+		buffer:     make([]byte, bufferSize),
+		bufferPos:  0,
+		bufferLen:  0,
+		maxBufSize: maxBufSize,
 	}
 }
 
 func (e *StreamDecoder) Seekable() bool {
 	return false
+}
+
+// MaxDecodeBufferSize returns the configured maximum buffer size. Callers
+// should avoid DecodeBytesBuf calls that exceed this size to prevent the
+// stream decoder from allocating large temporary buffers.
+func (e *StreamDecoder) MaxDecodeBufferSize() int {
+	return e.maxBufSize
 }
 
 func (e *StreamDecoder) GetPosition() int {

--- a/sszutils/encoder.go
+++ b/sszutils/encoder.go
@@ -20,4 +20,5 @@ type Encoder interface {
 	EncodeOffset(v uint32)
 	EncodeOffsetAt(pos int, v uint32)
 	EncodeZeroPadding(n int)
+	MaxEncodeBufferSize() int // max size for efficient GetBuffer/SetBuffer delegation
 }

--- a/sszutils/encoder_buffer.go
+++ b/sszutils/encoder_buffer.go
@@ -6,6 +6,7 @@ package sszutils
 
 import (
 	"encoding/binary"
+	"math"
 )
 
 // BufferEncoder is a seekable Encoder implementation backed by an in-memory
@@ -31,6 +32,12 @@ func NewBufferEncoder(buffer []byte) *BufferEncoder {
 // offset writes via EncodeOffsetAt.
 func (e *BufferEncoder) Seekable() bool {
 	return true
+}
+
+// MaxEncodeBufferSize returns math.MaxInt because the entire output is already
+// buffered in memory—no additional allocation overhead from delegation.
+func (e *BufferEncoder) MaxEncodeBufferSize() int {
+	return math.MaxInt
 }
 
 // GetPosition returns the current write position in the buffer.

--- a/sszutils/encoder_stream.go
+++ b/sszutils/encoder_stream.go
@@ -14,35 +14,53 @@ import (
 // StreamEncoder (2KB).
 const DefaultStreamEncoderBufSize = 2 * 1024
 
+// DefaultStreamEncoderMaxBufSize is the default maximum buffer size for
+// delegation to buffer-based marshal methods (200KB). Outputs exceeding this
+// threshold fall through to reflection-based field-by-field marshalling.
+const DefaultStreamEncoderMaxBufSize = 200 * 1024
+
 // StreamEncoder is a non-seekable Encoder implementation that writes SSZ data
 // to an io.Writer with internal buffering. It does not support EncodeOffsetAt.
 type StreamEncoder struct {
-	writer   io.Writer
-	position int
-	scratch  []byte // small scratch buffer for GetBuffer/SetBuffer
-	writeBuf []byte
-	bufPos   int
-	writeErr error
+	writer     io.Writer
+	position   int
+	scratch    []byte // small scratch buffer for GetBuffer/SetBuffer
+	writeBuf   []byte
+	bufPos     int
+	writeErr   error
+	maxBufSize int // Configured maximum buffer size for delegation
 }
 
 var _ Encoder = (*StreamEncoder)(nil)
 
 // NewStreamEncoder creates a new StreamEncoder that writes SSZ data to the
-// provided io.Writer. bufSize controls the internal write buffer size; if <= 0,
-// DefaultStreamEncoderBufSize is used.
-func NewStreamEncoder(writer io.Writer, bufSize int) *StreamEncoder {
+// provided io.Writer. bufSize controls the internal write buffer size (defaults
+// to 2KB if <= 0). maxBufSize controls the maximum buffer size for delegation
+// to buffer-based marshal methods (defaults to 200KB if <= 0).
+func NewStreamEncoder(writer io.Writer, bufSize, maxBufSize int) *StreamEncoder {
 	if bufSize <= 0 {
 		bufSize = DefaultStreamEncoderBufSize
 	}
+	if maxBufSize <= 0 {
+		maxBufSize = DefaultStreamEncoderMaxBufSize
+	}
 	return &StreamEncoder{
-		writer:   writer,
-		scratch:  make([]byte, 0, 32),
-		writeBuf: make([]byte, bufSize),
+		writer:     writer,
+		scratch:    make([]byte, 0, 32),
+		writeBuf:   make([]byte, bufSize),
+		maxBufSize: maxBufSize,
 	}
 }
 
 func (e *StreamEncoder) Seekable() bool {
 	return false
+}
+
+// MaxEncodeBufferSize returns the configured maximum buffer size. Callers
+// should avoid GetBuffer/SetBuffer delegation for outputs exceeding this size
+// to prevent large temporary allocations.
+func (e *StreamEncoder) MaxEncodeBufferSize() int {
+	return e.maxBufSize
 }
 
 func (e *StreamEncoder) GetPosition() int {

--- a/sszutils/stream_test.go
+++ b/sszutils/stream_test.go
@@ -104,7 +104,7 @@ func (r *shortReader) Read(p []byte) (n int, err error) {
 
 func TestStreamEncoder_NewStreamEncoder(t *testing.T) {
 	var buf bytes.Buffer
-	enc := NewStreamEncoder(&buf, 0)
+	enc := NewStreamEncoder(&buf, 0, 0)
 
 	if enc == nil {
 		t.Fatal("expected non-nil encoder")
@@ -119,7 +119,7 @@ func TestStreamEncoder_NewStreamEncoder(t *testing.T) {
 
 func TestStreamEncoder_GetBuffer(t *testing.T) {
 	var buf bytes.Buffer
-	enc := NewStreamEncoder(&buf, 0)
+	enc := NewStreamEncoder(&buf, 0, 0)
 
 	buffer := enc.GetBuffer()
 	if buffer == nil {
@@ -132,7 +132,7 @@ func TestStreamEncoder_GetBuffer(t *testing.T) {
 
 func TestStreamEncoder_SetBuffer(t *testing.T) {
 	var buf bytes.Buffer
-	enc := NewStreamEncoder(&buf, 0)
+	enc := NewStreamEncoder(&buf, 0, 0)
 
 	testData := []byte{0x01, 0x02, 0x03}
 	enc.SetBuffer(testData)
@@ -152,7 +152,7 @@ func TestStreamEncoder_SetBuffer(t *testing.T) {
 func TestStreamEncoder_EncodeBool_WriteError(t *testing.T) {
 	testErr := errors.New("write error")
 	w := &errWriter{errAfter: 0, err: testErr}
-	enc := NewStreamEncoder(w, 0)
+	enc := NewStreamEncoder(w, 0, 0)
 
 	enc.EncodeBool(true)
 	enc.Flush()
@@ -164,7 +164,7 @@ func TestStreamEncoder_EncodeBool_WriteError(t *testing.T) {
 
 func TestStreamEncoder_EncodeBool_ShortWrite(t *testing.T) {
 	w := &shortWriter{maxWrite: 0}
-	enc := NewStreamEncoder(w, 0)
+	enc := NewStreamEncoder(w, 0, 0)
 
 	enc.EncodeBool(true)
 	enc.Flush()
@@ -180,7 +180,7 @@ func TestStreamEncoder_EncodeBool_ShortWrite(t *testing.T) {
 func TestStreamEncoder_EncodeUint8_WriteError(t *testing.T) {
 	testErr := errors.New("write error")
 	w := &errWriter{errAfter: 0, err: testErr}
-	enc := NewStreamEncoder(w, 0)
+	enc := NewStreamEncoder(w, 0, 0)
 
 	enc.EncodeUint8(42)
 	enc.Flush()
@@ -192,7 +192,7 @@ func TestStreamEncoder_EncodeUint8_WriteError(t *testing.T) {
 
 func TestStreamEncoder_EncodeUint8_ShortWrite(t *testing.T) {
 	w := &shortWriter{maxWrite: 0}
-	enc := NewStreamEncoder(w, 0)
+	enc := NewStreamEncoder(w, 0, 0)
 
 	enc.EncodeUint8(42)
 	enc.Flush()
@@ -208,7 +208,7 @@ func TestStreamEncoder_EncodeUint8_ShortWrite(t *testing.T) {
 func TestStreamEncoder_EncodeUint16_WriteError(t *testing.T) {
 	testErr := errors.New("write error")
 	w := &errWriter{errAfter: 0, err: testErr}
-	enc := NewStreamEncoder(w, 0)
+	enc := NewStreamEncoder(w, 0, 0)
 
 	enc.EncodeUint16(1000)
 	enc.Flush()
@@ -220,7 +220,7 @@ func TestStreamEncoder_EncodeUint16_WriteError(t *testing.T) {
 
 func TestStreamEncoder_EncodeUint16_ShortWrite(t *testing.T) {
 	w := &shortWriter{maxWrite: 1}
-	enc := NewStreamEncoder(w, 0)
+	enc := NewStreamEncoder(w, 0, 0)
 
 	enc.EncodeUint16(1000)
 	enc.Flush()
@@ -236,7 +236,7 @@ func TestStreamEncoder_EncodeUint16_ShortWrite(t *testing.T) {
 func TestStreamEncoder_EncodeUint32_WriteError(t *testing.T) {
 	testErr := errors.New("write error")
 	w := &errWriter{errAfter: 0, err: testErr}
-	enc := NewStreamEncoder(w, 0)
+	enc := NewStreamEncoder(w, 0, 0)
 
 	enc.EncodeUint32(100000)
 	enc.Flush()
@@ -248,7 +248,7 @@ func TestStreamEncoder_EncodeUint32_WriteError(t *testing.T) {
 
 func TestStreamEncoder_EncodeUint32_ShortWrite(t *testing.T) {
 	w := &shortWriter{maxWrite: 3}
-	enc := NewStreamEncoder(w, 0)
+	enc := NewStreamEncoder(w, 0, 0)
 
 	enc.EncodeUint32(100000)
 	enc.Flush()
@@ -264,7 +264,7 @@ func TestStreamEncoder_EncodeUint32_ShortWrite(t *testing.T) {
 func TestStreamEncoder_EncodeUint64_WriteError(t *testing.T) {
 	testErr := errors.New("write error")
 	w := &errWriter{errAfter: 0, err: testErr}
-	enc := NewStreamEncoder(w, 0)
+	enc := NewStreamEncoder(w, 0, 0)
 
 	enc.EncodeUint64(1000000000)
 	enc.Flush()
@@ -276,7 +276,7 @@ func TestStreamEncoder_EncodeUint64_WriteError(t *testing.T) {
 
 func TestStreamEncoder_EncodeUint64_ShortWrite(t *testing.T) {
 	w := &shortWriter{maxWrite: 7}
-	enc := NewStreamEncoder(w, 0)
+	enc := NewStreamEncoder(w, 0, 0)
 
 	enc.EncodeUint64(1000000000)
 	enc.Flush()
@@ -292,7 +292,7 @@ func TestStreamEncoder_EncodeUint64_ShortWrite(t *testing.T) {
 func TestStreamEncoder_EncodeBytes_WriteError(t *testing.T) {
 	testErr := errors.New("write error")
 	w := &errWriter{errAfter: 0, err: testErr}
-	enc := NewStreamEncoder(w, 0)
+	enc := NewStreamEncoder(w, 0, 0)
 
 	enc.EncodeBytes([]byte{0x01, 0x02, 0x03})
 	enc.Flush()
@@ -304,7 +304,7 @@ func TestStreamEncoder_EncodeBytes_WriteError(t *testing.T) {
 
 func TestStreamEncoder_EncodeBytes_ShortWrite(t *testing.T) {
 	w := &shortWriter{maxWrite: 2}
-	enc := NewStreamEncoder(w, 0)
+	enc := NewStreamEncoder(w, 0, 0)
 
 	enc.EncodeBytes([]byte{0x01, 0x02, 0x03})
 	enc.Flush()
@@ -320,7 +320,7 @@ func TestStreamEncoder_EncodeBytes_ShortWrite(t *testing.T) {
 func TestStreamEncoder_EncodeOffset_WriteError(t *testing.T) {
 	testErr := errors.New("write error")
 	w := &errWriter{errAfter: 0, err: testErr}
-	enc := NewStreamEncoder(w, 0)
+	enc := NewStreamEncoder(w, 0, 0)
 
 	enc.EncodeOffset(100)
 	enc.Flush()
@@ -332,7 +332,7 @@ func TestStreamEncoder_EncodeOffset_WriteError(t *testing.T) {
 
 func TestStreamEncoder_EncodeOffset_ShortWrite(t *testing.T) {
 	w := &shortWriter{maxWrite: 3}
-	enc := NewStreamEncoder(w, 0)
+	enc := NewStreamEncoder(w, 0, 0)
 
 	enc.EncodeOffset(100)
 	enc.Flush()
@@ -347,7 +347,7 @@ func TestStreamEncoder_EncodeOffset_ShortWrite(t *testing.T) {
 
 func TestStreamEncoder_EncodeOffsetAt_NotSupported(t *testing.T) {
 	var buf bytes.Buffer
-	enc := NewStreamEncoder(&buf, 0)
+	enc := NewStreamEncoder(&buf, 0, 0)
 
 	enc.EncodeOffsetAt(0, 100)
 
@@ -362,7 +362,7 @@ func TestStreamEncoder_EncodeOffsetAt_NotSupported(t *testing.T) {
 func TestStreamEncoder_EncodeZeroPadding_WriteError(t *testing.T) {
 	testErr := errors.New("write error")
 	w := &errWriter{errAfter: 0, err: testErr}
-	enc := NewStreamEncoder(w, 0)
+	enc := NewStreamEncoder(w, 0, 0)
 
 	// Write enough to trigger a flush (> buffer size)
 	enc.EncodeZeroPadding(DefaultStreamEncoderBufSize + 10)
@@ -374,7 +374,7 @@ func TestStreamEncoder_EncodeZeroPadding_WriteError(t *testing.T) {
 
 func TestStreamEncoder_EncodeZeroPadding_ShortWrite(t *testing.T) {
 	w := &shortWriter{maxWrite: 5}
-	enc := NewStreamEncoder(w, 0)
+	enc := NewStreamEncoder(w, 0, 0)
 
 	// Write enough to trigger a flush
 	enc.EncodeZeroPadding(DefaultStreamEncoderBufSize + 10)
@@ -389,7 +389,7 @@ func TestStreamEncoder_EncodeZeroPadding_ShortWrite(t *testing.T) {
 
 func TestStreamEncoder_EncodeZeroPadding_LargeBuffer(t *testing.T) {
 	var buf bytes.Buffer
-	enc := NewStreamEncoder(&buf, 0)
+	enc := NewStreamEncoder(&buf, 0, 0)
 
 	enc.EncodeZeroPadding(2048)
 	enc.Flush()
@@ -413,7 +413,7 @@ func TestStreamEncoder_EncodeZeroPadding_LargeBuffer(t *testing.T) {
 func TestStreamEncoder_EncodeZeroPadding_LargeBuffer_WriteError(t *testing.T) {
 	testErr := errors.New("write error")
 	w := &errWriter{errAfter: 1024, err: testErr}
-	enc := NewStreamEncoder(w, 0)
+	enc := NewStreamEncoder(w, 0, 0)
 
 	// Write enough to trigger multiple flushes
 	enc.EncodeZeroPadding(DefaultStreamEncoderBufSize + 1024)
@@ -436,7 +436,7 @@ func TestStreamEncoder_EncodeBool_Values(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			enc := NewStreamEncoder(&buf, 0)
+			enc := NewStreamEncoder(&buf, 0, 0)
 
 			enc.EncodeBool(tt.value)
 			enc.Flush()
@@ -463,7 +463,7 @@ func TestStreamEncoder_EncodeBool_Values(t *testing.T) {
 
 func TestStreamDecoder_NewStreamDecoder(t *testing.T) {
 	reader := bytes.NewReader([]byte{0x01})
-	dec := NewStreamDecoder(reader, 1, 0)
+	dec := NewStreamDecoder(reader, 1, 0, 0)
 
 	if dec == nil {
 		t.Fatal("expected non-nil decoder")
@@ -482,7 +482,7 @@ func TestStreamDecoder_NewStreamDecoder(t *testing.T) {
 func TestStreamDecoder_DecodeBool_ReadError(t *testing.T) {
 	testErr := errors.New("read error")
 	r := &errReader{data: []byte{0x01}, errAfter: 0, err: testErr}
-	dec := NewStreamDecoder(r, 1, 0)
+	dec := NewStreamDecoder(r, 1, 0, 0)
 
 	_, err := dec.DecodeBool()
 
@@ -493,7 +493,7 @@ func TestStreamDecoder_DecodeBool_ReadError(t *testing.T) {
 
 func TestStreamDecoder_DecodeBool_ShortRead(t *testing.T) {
 	r := &shortReader{data: []byte{0x01}, maxRead: 0}
-	dec := NewStreamDecoder(r, 1, 0)
+	dec := NewStreamDecoder(r, 1, 0, 0)
 
 	_, err := dec.DecodeBool()
 
@@ -504,7 +504,7 @@ func TestStreamDecoder_DecodeBool_ShortRead(t *testing.T) {
 
 func TestStreamDecoder_DecodeBool_InvalidValue(t *testing.T) {
 	reader := bytes.NewReader([]byte{0x02})
-	dec := NewStreamDecoder(reader, 1, 0)
+	dec := NewStreamDecoder(reader, 1, 0, 0)
 
 	_, err := dec.DecodeBool()
 
@@ -526,7 +526,7 @@ func TestStreamDecoder_DecodeBool_ValidValues(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			reader := bytes.NewReader([]byte{tt.input})
-			dec := NewStreamDecoder(reader, 1, 0)
+			dec := NewStreamDecoder(reader, 1, 0, 0)
 
 			result, err := dec.DecodeBool()
 
@@ -546,7 +546,7 @@ func TestStreamDecoder_DecodeBool_ValidValues(t *testing.T) {
 func TestStreamDecoder_DecodeUint8_ReadError(t *testing.T) {
 	testErr := errors.New("read error")
 	r := &errReader{data: []byte{0x01}, errAfter: 0, err: testErr}
-	dec := NewStreamDecoder(r, 1, 0)
+	dec := NewStreamDecoder(r, 1, 0, 0)
 
 	_, err := dec.DecodeUint8()
 
@@ -557,7 +557,7 @@ func TestStreamDecoder_DecodeUint8_ReadError(t *testing.T) {
 
 func TestStreamDecoder_DecodeUint8_ShortRead(t *testing.T) {
 	r := &shortReader{data: []byte{0x01}, maxRead: 0}
-	dec := NewStreamDecoder(r, 1, 0)
+	dec := NewStreamDecoder(r, 1, 0, 0)
 
 	_, err := dec.DecodeUint8()
 
@@ -569,7 +569,7 @@ func TestStreamDecoder_DecodeUint8_ShortRead(t *testing.T) {
 func TestStreamDecoder_DecodeUint16_ReadError(t *testing.T) {
 	testErr := errors.New("read error")
 	r := &errReader{data: []byte{0x01, 0x02}, errAfter: 0, err: testErr}
-	dec := NewStreamDecoder(r, 2, 0)
+	dec := NewStreamDecoder(r, 2, 0, 0)
 
 	_, err := dec.DecodeUint16()
 
@@ -581,7 +581,7 @@ func TestStreamDecoder_DecodeUint16_ReadError(t *testing.T) {
 func TestStreamDecoder_DecodeUint16_ShortRead(t *testing.T) {
 	// Reader has only 1 byte but we need 2
 	r := &shortReader{data: []byte{0x01}, maxRead: 1}
-	dec := NewStreamDecoder(r, 2, 0)
+	dec := NewStreamDecoder(r, 2, 0, 0)
 
 	_, err := dec.DecodeUint16()
 
@@ -593,7 +593,7 @@ func TestStreamDecoder_DecodeUint16_ShortRead(t *testing.T) {
 func TestStreamDecoder_DecodeUint32_ReadError(t *testing.T) {
 	testErr := errors.New("read error")
 	r := &errReader{data: []byte{0x01, 0x02, 0x03, 0x04}, errAfter: 0, err: testErr}
-	dec := NewStreamDecoder(r, 4, 0)
+	dec := NewStreamDecoder(r, 4, 0, 0)
 
 	_, err := dec.DecodeUint32()
 
@@ -605,7 +605,7 @@ func TestStreamDecoder_DecodeUint32_ReadError(t *testing.T) {
 func TestStreamDecoder_DecodeUint32_ShortRead(t *testing.T) {
 	// Reader has only 3 bytes but we need 4
 	r := &shortReader{data: []byte{0x01, 0x02, 0x03}, maxRead: 3}
-	dec := NewStreamDecoder(r, 4, 0)
+	dec := NewStreamDecoder(r, 4, 0, 0)
 
 	_, err := dec.DecodeUint32()
 
@@ -617,7 +617,7 @@ func TestStreamDecoder_DecodeUint32_ShortRead(t *testing.T) {
 func TestStreamDecoder_DecodeUint64_ReadError(t *testing.T) {
 	testErr := errors.New("read error")
 	r := &errReader{data: make([]byte, 8), errAfter: 0, err: testErr}
-	dec := NewStreamDecoder(r, 8, 0)
+	dec := NewStreamDecoder(r, 8, 0, 0)
 
 	_, err := dec.DecodeUint64()
 
@@ -629,7 +629,7 @@ func TestStreamDecoder_DecodeUint64_ReadError(t *testing.T) {
 func TestStreamDecoder_DecodeUint64_ShortRead(t *testing.T) {
 	// Reader has only 7 bytes but we need 8
 	r := &shortReader{data: make([]byte, 7), maxRead: 7}
-	dec := NewStreamDecoder(r, 8, 0)
+	dec := NewStreamDecoder(r, 8, 0, 0)
 
 	_, err := dec.DecodeUint64()
 
@@ -641,7 +641,7 @@ func TestStreamDecoder_DecodeUint64_ShortRead(t *testing.T) {
 func TestStreamDecoder_DecodeBytes_ReadError(t *testing.T) {
 	testErr := errors.New("read error")
 	r := &errReader{data: []byte{0x01, 0x02, 0x03}, errAfter: 0, err: testErr}
-	dec := NewStreamDecoder(r, 3, 0)
+	dec := NewStreamDecoder(r, 3, 0, 0)
 
 	buf := make([]byte, 3)
 	_, err := dec.DecodeBytes(buf)
@@ -654,7 +654,7 @@ func TestStreamDecoder_DecodeBytes_ReadError(t *testing.T) {
 func TestStreamDecoder_DecodeBytes_ShortRead(t *testing.T) {
 	// Reader has only 2 bytes but we need 3
 	r := &shortReader{data: []byte{0x01, 0x02}, maxRead: 2}
-	dec := NewStreamDecoder(r, 3, 0)
+	dec := NewStreamDecoder(r, 3, 0, 0)
 
 	buf := make([]byte, 3)
 	_, err := dec.DecodeBytes(buf)
@@ -666,7 +666,7 @@ func TestStreamDecoder_DecodeBytes_ShortRead(t *testing.T) {
 
 func TestStreamDecoder_DecodeBytesBuf_LengthExceedsLimit(t *testing.T) {
 	reader := bytes.NewReader([]byte{0x01, 0x02, 0x03})
-	dec := NewStreamDecoder(reader, 3, 0)
+	dec := NewStreamDecoder(reader, 3, 0, 0)
 
 	_, err := dec.DecodeBytesBuf(10)
 
@@ -677,7 +677,7 @@ func TestStreamDecoder_DecodeBytesBuf_LengthExceedsLimit(t *testing.T) {
 
 func TestStreamDecoder_DecodeBytesBuf_NegativeLength(t *testing.T) {
 	reader := bytes.NewReader([]byte{0x01, 0x02, 0x03})
-	dec := NewStreamDecoder(reader, 3, 0)
+	dec := NewStreamDecoder(reader, 3, 0, 0)
 
 	result, err := dec.DecodeBytesBuf(-1)
 
@@ -695,7 +695,7 @@ func TestStreamDecoder_DecodeBytesBuf_NegativeLength(t *testing.T) {
 func TestStreamDecoder_DecodeBytesBuf_ReadError(t *testing.T) {
 	testErr := errors.New("read error")
 	r := &errReader{data: []byte{0x01, 0x02, 0x03}, errAfter: 0, err: testErr}
-	dec := NewStreamDecoder(r, 3, 0)
+	dec := NewStreamDecoder(r, 3, 0, 0)
 
 	_, err := dec.DecodeBytesBuf(3)
 
@@ -707,7 +707,7 @@ func TestStreamDecoder_DecodeBytesBuf_ReadError(t *testing.T) {
 func TestStreamDecoder_DecodeBytesBuf_ShortRead(t *testing.T) {
 	// Reader has only 2 bytes but we need 3
 	r := &shortReader{data: []byte{0x01, 0x02}, maxRead: 2}
-	dec := NewStreamDecoder(r, 3, 0)
+	dec := NewStreamDecoder(r, 3, 0, 0)
 
 	_, err := dec.DecodeBytesBuf(3)
 
@@ -720,7 +720,7 @@ func TestStreamDecoder_DecodeBytesBuf_BufferReuse(t *testing.T) {
 	// First call with larger buffer
 	data := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
 	reader := bytes.NewReader(data)
-	dec := NewStreamDecoder(reader, 6, 0)
+	dec := NewStreamDecoder(reader, 6, 0, 0)
 
 	result1, err := dec.DecodeBytesBuf(4)
 	if err != nil {
@@ -746,7 +746,7 @@ func TestStreamDecoder_DecodeBytesBuf_BufferReuse(t *testing.T) {
 func TestStreamDecoder_DecodeOffset_ReadError(t *testing.T) {
 	testErr := errors.New("read error")
 	r := &errReader{data: []byte{0x01, 0x02, 0x03, 0x04}, errAfter: 0, err: testErr}
-	dec := NewStreamDecoder(r, 4, 0)
+	dec := NewStreamDecoder(r, 4, 0, 0)
 
 	_, err := dec.DecodeOffset()
 
@@ -758,7 +758,7 @@ func TestStreamDecoder_DecodeOffset_ReadError(t *testing.T) {
 func TestStreamDecoder_DecodeOffset_ShortRead(t *testing.T) {
 	// Reader has only 3 bytes but we need 4
 	r := &shortReader{data: []byte{0x01, 0x02, 0x03}, maxRead: 3}
-	dec := NewStreamDecoder(r, 4, 0)
+	dec := NewStreamDecoder(r, 4, 0, 0)
 
 	_, err := dec.DecodeOffset()
 
@@ -769,7 +769,7 @@ func TestStreamDecoder_DecodeOffset_ShortRead(t *testing.T) {
 
 func TestStreamDecoder_DecodeOffsetAt_NotSupported(t *testing.T) {
 	reader := bytes.NewReader([]byte{0x01, 0x02, 0x03, 0x04})
-	dec := NewStreamDecoder(reader, 4, 0)
+	dec := NewStreamDecoder(reader, 4, 0, 0)
 
 	result := dec.DecodeOffsetAt(0)
 
@@ -780,7 +780,7 @@ func TestStreamDecoder_DecodeOffsetAt_NotSupported(t *testing.T) {
 
 func TestStreamDecoder_SkipBytes_NotSupported(t *testing.T) {
 	reader := bytes.NewReader([]byte{0x01, 0x02, 0x03})
-	dec := NewStreamDecoder(reader, 3, 0)
+	dec := NewStreamDecoder(reader, 3, 0, 0)
 
 	// SkipBytes does nothing but should not panic
 	dec.SkipBytes(2)
@@ -793,7 +793,7 @@ func TestStreamDecoder_SkipBytes_NotSupported(t *testing.T) {
 
 func TestStreamDecoder_PushLimit_ClampToLastLimit(t *testing.T) {
 	reader := bytes.NewReader(make([]byte, 10))
-	dec := NewStreamDecoder(reader, 10, 0)
+	dec := NewStreamDecoder(reader, 10, 0, 0)
 
 	// Push a limit that exceeds the stream length
 	dec.PushLimit(20)
@@ -806,7 +806,7 @@ func TestStreamDecoder_PushLimit_ClampToLastLimit(t *testing.T) {
 
 func TestStreamDecoder_PopLimit_EmptyLimits(t *testing.T) {
 	reader := bytes.NewReader(make([]byte, 10))
-	dec := NewStreamDecoder(reader, 10, 0)
+	dec := NewStreamDecoder(reader, 10, 0, 0)
 
 	// Pop from empty limits
 	remaining := dec.PopLimit()
@@ -818,7 +818,7 @@ func TestStreamDecoder_PopLimit_EmptyLimits(t *testing.T) {
 
 func TestStreamDecoder_PopLimit_SingleLimit(t *testing.T) {
 	reader := bytes.NewReader(make([]byte, 10))
-	dec := NewStreamDecoder(reader, 10, 0)
+	dec := NewStreamDecoder(reader, 10, 0, 0)
 
 	dec.PushLimit(5)
 	if dec.GetLength() != 5 {
@@ -837,7 +837,7 @@ func TestStreamDecoder_PopLimit_SingleLimit(t *testing.T) {
 
 func TestStreamDecoder_PopLimit_MultipleLimits(t *testing.T) {
 	reader := bytes.NewReader(make([]byte, 10))
-	dec := NewStreamDecoder(reader, 10, 0)
+	dec := NewStreamDecoder(reader, 10, 0, 0)
 
 	dec.PushLimit(8) // limit at position 8
 	dec.PushLimit(3) // limit at position 3
@@ -868,7 +868,7 @@ func TestStreamDecoder_PopLimit_MultipleLimits(t *testing.T) {
 func TestStreamDecoder_Uint16_Success(t *testing.T) {
 	// Little endian: 0x0102 = 258
 	reader := bytes.NewReader([]byte{0x02, 0x01})
-	dec := NewStreamDecoder(reader, 2, 0)
+	dec := NewStreamDecoder(reader, 2, 0, 0)
 
 	result, err := dec.DecodeUint16()
 
@@ -886,7 +886,7 @@ func TestStreamDecoder_Uint16_Success(t *testing.T) {
 func TestStreamDecoder_Uint32_Success(t *testing.T) {
 	// Little endian: 0x01020304 = 16909060
 	reader := bytes.NewReader([]byte{0x04, 0x03, 0x02, 0x01})
-	dec := NewStreamDecoder(reader, 4, 0)
+	dec := NewStreamDecoder(reader, 4, 0, 0)
 
 	result, err := dec.DecodeUint32()
 
@@ -904,7 +904,7 @@ func TestStreamDecoder_Uint32_Success(t *testing.T) {
 func TestStreamDecoder_Uint64_Success(t *testing.T) {
 	// Little endian value
 	reader := bytes.NewReader([]byte{0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01})
-	dec := NewStreamDecoder(reader, 8, 0)
+	dec := NewStreamDecoder(reader, 8, 0, 0)
 
 	result, err := dec.DecodeUint64()
 
@@ -921,7 +921,7 @@ func TestStreamDecoder_Uint64_Success(t *testing.T) {
 
 func TestStreamDecoder_DecodeBytes_Success(t *testing.T) {
 	reader := bytes.NewReader([]byte{0x01, 0x02, 0x03})
-	dec := NewStreamDecoder(reader, 3, 0)
+	dec := NewStreamDecoder(reader, 3, 0, 0)
 
 	buf := make([]byte, 3)
 	result, err := dec.DecodeBytes(buf)
@@ -939,7 +939,7 @@ func TestStreamDecoder_DecodeBytes_Success(t *testing.T) {
 
 func TestStreamDecoder_DecodeOffset_Success(t *testing.T) {
 	reader := bytes.NewReader([]byte{0x04, 0x03, 0x02, 0x01})
-	dec := NewStreamDecoder(reader, 4, 0)
+	dec := NewStreamDecoder(reader, 4, 0, 0)
 
 	result, err := dec.DecodeOffset()
 
@@ -956,7 +956,7 @@ func TestStreamDecoder_DecodeOffset_Success(t *testing.T) {
 
 func TestStreamDecoder_DecodeUint8_Success(t *testing.T) {
 	reader := bytes.NewReader([]byte{0x42})
-	dec := NewStreamDecoder(reader, 1, 0)
+	dec := NewStreamDecoder(reader, 1, 0, 0)
 
 	result, err := dec.DecodeUint8()
 
@@ -973,7 +973,7 @@ func TestStreamDecoder_DecodeUint8_Success(t *testing.T) {
 
 func TestStreamEncoder_Position_Tracking(t *testing.T) {
 	var buf bytes.Buffer
-	enc := NewStreamEncoder(&buf, 0)
+	enc := NewStreamEncoder(&buf, 0, 0)
 
 	if enc.GetPosition() != 0 {
 		t.Errorf("expected position 0, got %d", enc.GetPosition())
@@ -1030,7 +1030,7 @@ func TestStreamEncoder_Position_Tracking(t *testing.T) {
 
 func TestStreamEncoder_EncodeZeroPadding_Zero(t *testing.T) {
 	var buf bytes.Buffer
-	enc := NewStreamEncoder(&buf, 0)
+	enc := NewStreamEncoder(&buf, 0, 0)
 
 	enc.EncodeZeroPadding(0)
 
@@ -1048,7 +1048,7 @@ func TestStreamEncoder_EncodeZeroPadding_Zero(t *testing.T) {
 func TestStreamEncoder_TinyBuffer_FlushOnEncodeBool(t *testing.T) {
 	var buf bytes.Buffer
 	// Buffer size 1: first EncodeBool fills it, second triggers flush
-	enc := NewStreamEncoder(&buf, 1)
+	enc := NewStreamEncoder(&buf, 1, 0)
 
 	enc.EncodeBool(true)
 	enc.EncodeBool(false)
@@ -1070,7 +1070,7 @@ func TestStreamEncoder_TinyBuffer_FlushOnEncodeBool(t *testing.T) {
 
 func TestStreamEncoder_TinyBuffer_FlushOnEncodeUint8(t *testing.T) {
 	var buf bytes.Buffer
-	enc := NewStreamEncoder(&buf, 1)
+	enc := NewStreamEncoder(&buf, 1, 0)
 
 	enc.EncodeUint8(0xAA)
 	enc.EncodeUint8(0xBB)
@@ -1087,7 +1087,7 @@ func TestStreamEncoder_TinyBuffer_FlushOnEncodeUint8(t *testing.T) {
 func TestStreamEncoder_TinyBuffer_FlushOnEncodeUint16(t *testing.T) {
 	var buf bytes.Buffer
 	// Buffer size 2: first uint16 fills it, second triggers flush
-	enc := NewStreamEncoder(&buf, 2)
+	enc := NewStreamEncoder(&buf, 2, 0)
 
 	enc.EncodeUint16(0x0102)
 	enc.EncodeUint16(0x0304)
@@ -1103,7 +1103,7 @@ func TestStreamEncoder_TinyBuffer_FlushOnEncodeUint16(t *testing.T) {
 
 func TestStreamEncoder_TinyBuffer_FlushOnEncodeUint32(t *testing.T) {
 	var buf bytes.Buffer
-	enc := NewStreamEncoder(&buf, 4)
+	enc := NewStreamEncoder(&buf, 4, 0)
 
 	enc.EncodeUint32(1)
 	enc.EncodeUint32(2)
@@ -1119,7 +1119,7 @@ func TestStreamEncoder_TinyBuffer_FlushOnEncodeUint32(t *testing.T) {
 
 func TestStreamEncoder_TinyBuffer_FlushOnEncodeUint64(t *testing.T) {
 	var buf bytes.Buffer
-	enc := NewStreamEncoder(&buf, 8)
+	enc := NewStreamEncoder(&buf, 8, 0)
 
 	enc.EncodeUint64(1)
 	enc.EncodeUint64(2)
@@ -1135,7 +1135,7 @@ func TestStreamEncoder_TinyBuffer_FlushOnEncodeUint64(t *testing.T) {
 
 func TestStreamEncoder_TinyBuffer_FlushOnEncodeOffset(t *testing.T) {
 	var buf bytes.Buffer
-	enc := NewStreamEncoder(&buf, 4)
+	enc := NewStreamEncoder(&buf, 4, 0)
 
 	enc.EncodeOffset(10)
 	enc.EncodeOffset(20)
@@ -1153,7 +1153,7 @@ func TestStreamEncoder_EncodeBytes_FlushError(t *testing.T) {
 	testErr := errors.New("write error")
 	// Buffer size 4: write 2 bytes, then write 4 bytes to trigger flush+early return
 	w := &errWriter{errAfter: 0, err: testErr}
-	enc := NewStreamEncoder(w, 4)
+	enc := NewStreamEncoder(w, 4, 0)
 
 	enc.EncodeBytes([]byte{0x01, 0x02})       // fits in buffer
 	enc.EncodeBytes([]byte{0x03, 0x04, 0x05}) // triggers flush, flush fails
@@ -1168,7 +1168,7 @@ func TestStreamEncoder_EncodeBytes_LargeDirectWriteError(t *testing.T) {
 	// errWriter succeeds on flush (errAfter > 4) but fails on direct write.
 	testErr := errors.New("disk full")
 	w := &errWriter{errAfter: 4, err: testErr}
-	enc := NewStreamEncoder(w, 4)
+	enc := NewStreamEncoder(w, 4, 0)
 
 	enc.EncodeBytes(make([]byte, 8))
 
@@ -1181,7 +1181,7 @@ func TestStreamEncoder_EncodeBytes_LargeDirectShortWrite(t *testing.T) {
 	// Buffer size 4: writing 8 bytes goes to direct write path.
 	// shortWriter writes fewer bytes than requested.
 	w := &shortWriter{maxWrite: 3}
-	enc := NewStreamEncoder(w, 4)
+	enc := NewStreamEncoder(w, 4, 0)
 
 	enc.EncodeBytes(make([]byte, 8))
 
@@ -1240,7 +1240,7 @@ func TestStreamDecoder_EnsureBuffered_BufferShift(t *testing.T) {
 		data[i] = byte(i % 256)
 	}
 	reader := bytes.NewReader(data)
-	dec := NewStreamDecoder(reader, totalLen, 0)
+	dec := NewStreamDecoder(reader, totalLen, 0, 0)
 
 	// Prime the buffer (ensureBuffered fills it to 2048 bytes)
 	_, err := dec.DecodeUint8()
@@ -1268,7 +1268,7 @@ func TestStreamDecoder_EnsureBuffered_BufferShift(t *testing.T) {
 func TestStreamDecoder_EnsureBuffered_StreamExhausted(t *testing.T) {
 	data := []byte{0x01, 0x02}
 	reader := bytes.NewReader(data)
-	dec := NewStreamDecoder(reader, 2, 0)
+	dec := NewStreamDecoder(reader, 2, 0, 0)
 
 	_, err := dec.DecodeUint32()
 	if !errors.Is(err, ErrUnexpectedEOF) {
@@ -1279,7 +1279,7 @@ func TestStreamDecoder_EnsureBuffered_StreamExhausted(t *testing.T) {
 func TestStreamDecoder_EnsureBuffered_EOFWithEnoughData(t *testing.T) {
 	data := []byte{0x04, 0x03, 0x02, 0x01}
 	reader := &partialThenEOFReader{data: data}
-	dec := NewStreamDecoder(reader, 4, 0)
+	dec := NewStreamDecoder(reader, 4, 0, 0)
 
 	val, err := dec.DecodeUint32()
 	if err != nil {
@@ -1293,7 +1293,7 @@ func TestStreamDecoder_EnsureBuffered_EOFWithEnoughData(t *testing.T) {
 func TestStreamDecoder_EnsureBuffered_EOFInsufficientData(t *testing.T) {
 	data := []byte{0x01, 0x02}
 	reader := &partialThenEOFReader{data: data}
-	dec := NewStreamDecoder(reader, 8, 0)
+	dec := NewStreamDecoder(reader, 8, 0, 0)
 
 	_, err := dec.DecodeUint64()
 	if !errors.Is(err, ErrUnexpectedEOF) {
@@ -1304,7 +1304,7 @@ func TestStreamDecoder_EnsureBuffered_EOFInsufficientData(t *testing.T) {
 func TestStreamDecoder_EnsureBuffered_ZeroReadReturnsEOF(t *testing.T) {
 	data := []byte{0x42}
 	reader := &zeroAfterNReader{data: data, stallAfter: 0}
-	dec := NewStreamDecoder(reader, 1, 0)
+	dec := NewStreamDecoder(reader, 1, 0, 0)
 
 	_, err := dec.DecodeUint8()
 	if !errors.Is(err, ErrUnexpectedEOF) {
@@ -1315,7 +1315,7 @@ func TestStreamDecoder_EnsureBuffered_ZeroReadReturnsEOF(t *testing.T) {
 func TestStreamDecoder_EnsureBuffered_NonEOFError(t *testing.T) {
 	testErr := errors.New("network error")
 	reader := &errReader{data: make([]byte, 8), errAfter: 0, err: testErr}
-	dec := NewStreamDecoder(reader, 8, 0)
+	dec := NewStreamDecoder(reader, 8, 0, 0)
 
 	_, err := dec.DecodeUint32()
 	if !errors.Is(err, testErr) {
@@ -1326,7 +1326,7 @@ func TestStreamDecoder_EnsureBuffered_NonEOFError(t *testing.T) {
 func TestStreamDecoder_ReadBytes_ExceedsStreamLength(t *testing.T) {
 	data := []byte{0x01, 0x02, 0x03}
 	reader := bytes.NewReader(data)
-	dec := NewStreamDecoder(reader, 3, 0)
+	dec := NewStreamDecoder(reader, 3, 0, 0)
 
 	_, err := dec.DecodeUint8()
 	if err != nil {
@@ -1346,7 +1346,7 @@ func TestStreamDecoder_ReadBytes_ZeroByteRead(t *testing.T) {
 		data[i] = byte(i)
 	}
 	stallReader := &zeroAfterNReader{data: data, stallAfter: 8}
-	dec := NewStreamDecoder(stallReader, 16, 0)
+	dec := NewStreamDecoder(stallReader, 16, 0, 0)
 
 	_, err := dec.DecodeUint64()
 	if err != nil {
@@ -1366,7 +1366,7 @@ func TestStreamDecoder_ReadBytes_DirectReadWithPartialReads(t *testing.T) {
 		data[i] = byte(i)
 	}
 	reader := &shortReader{data: data, maxRead: 3}
-	dec := NewStreamDecoder(reader, 30, 0)
+	dec := NewStreamDecoder(reader, 30, 0, 0)
 
 	_, err := dec.DecodeUint64()
 	if err != nil {
@@ -1388,7 +1388,7 @@ func TestStreamDecoder_ReadBytes_DirectReadWithPartialReads(t *testing.T) {
 func TestStreamDecoder_ReadBytes_EOFDuringDirectRead(t *testing.T) {
 	data := make([]byte, 12)
 	reader := &errReader{data: data, errAfter: 10, err: io.EOF}
-	dec := NewStreamDecoder(reader, 12, 0)
+	dec := NewStreamDecoder(reader, 12, 0, 0)
 
 	_, err := dec.DecodeUint64()
 	if err != nil {
@@ -1407,7 +1407,7 @@ func TestStreamDecoder_ReadBytes_NonEOFErrorDuringDirectRead(t *testing.T) {
 	data := make([]byte, totalLen)
 	testErr := errors.New("disk error")
 	reader := &errReader{data: data, errAfter: DefaultStreamDecoderBufSize + 100, err: testErr}
-	dec := NewStreamDecoder(reader, totalLen, 0)
+	dec := NewStreamDecoder(reader, totalLen, 0, 0)
 
 	buf := make([]byte, DefaultStreamDecoderBufSize)
 	_, err := dec.DecodeBytes(buf)
@@ -1429,7 +1429,7 @@ func TestStreamDecoder_DecodeBytesBuf_LargeBufferGrowth(t *testing.T) {
 		data[i] = byte(i % 256)
 	}
 	reader := bytes.NewReader(data)
-	dec := NewStreamDecoder(reader, size, 0)
+	dec := NewStreamDecoder(reader, size, 0, 0)
 
 	result, err := dec.DecodeBytesBuf(size)
 	if err != nil {
@@ -1449,7 +1449,7 @@ func TestStreamDecoder_DecodeBytesBuf_LargeGrowthDoubling(t *testing.T) {
 		data[i] = byte(i % 256)
 	}
 	reader := bytes.NewReader(data)
-	dec := NewStreamDecoder(reader, size, 0)
+	dec := NewStreamDecoder(reader, size, 0, 0)
 
 	result, err := dec.DecodeBytesBuf(size)
 	if err != nil {
@@ -1462,7 +1462,7 @@ func TestStreamDecoder_DecodeBytesBuf_LargeGrowthDoubling(t *testing.T) {
 
 func TestStreamDecoder_GetLength_WithLimits(t *testing.T) {
 	reader := bytes.NewReader(make([]byte, 100))
-	dec := NewStreamDecoder(reader, 100, 0)
+	dec := NewStreamDecoder(reader, 100, 0, 0)
 
 	if dec.GetLength() != 100 {
 		t.Errorf("expected length 100, got %d", dec.GetLength())


### PR DESCRIPTION
## Prevent excessive buffer allocation in stream marshal/unmarshal

### Problem

When using `MarshalSSZWriter` or `UnmarshalSSZReader` with types that have generated buffer-based methods (`DynamicMarshaler`/`DynamicUnmarshaler`) but no streaming methods (`DynamicEncoder`/`DynamicDecoder`), the reflection layer immediately delegates to the buffer-based method for the entire object. For large types like BeaconState (200MB+), this defeats the purpose of streaming by allocating the full object size into a temporary buffer.

### Solution

Introduce a **max delegation buffer size** threshold (default 200KB) that controls when the stream encoder/decoder skips buffer-based delegation and falls through to reflection-based field-by-field processing instead. This is decoupled from the existing initial buffer size (default 2KB) which controls the internal I/O buffer.

When a type's serialized size exceeds the max delegation buffer, individual fields are processed via reflection — each field may still delegate to buffer-based methods if it fits within the threshold, so only the top-level container avoids the large allocation.

### Changes

**New `Decoder`/`Encoder` interface methods:**
- `MaxDecodeBufferSize() int` — returns the configured max buffer for delegation decisions
- `MaxEncodeBufferSize() int` — returns the configured max buffer for delegation decisions
- `BufferDecoder`/`BufferEncoder` return `math.MaxInt` (data already in memory, no concern)
- `StreamDecoder`/`StreamEncoder` return the configured max (default 200KB)

**Decoupled buffer sizes in `StreamDecoder` and `StreamEncoder`:**
- `NewStreamDecoder(reader, totalLen, bufSize, maxBufSize)` — separate initial read buffer from max delegation buffer
- `NewStreamEncoder(writer, bufSize, maxBufSize)` — separate internal write buffer from max delegation buffer
- New constants: `DefaultStreamDecoderMaxBufSize`, `DefaultStreamEncoderMaxBufSize` (200KB)

**New configuration options:**
- `WithStreamReaderMaxBufferSize(size)` — controls max delegation buffer for `UnmarshalSSZReader`
- `WithStreamWriterMaxBufferSize(size)` — controls max delegation buffer for `MarshalSSZWriter`

**Guard checks in `reflection/unmarshal.go` (3 delegation points):**
- `DynamicViewUnmarshaler`: skip if `bufLen > decoder.MaxDecodeBufferSize()`
- `FastsszUnmarshaler`: skip if `sszLen > decoder.MaxDecodeBufferSize()` (except `SszCustomType`)
- `DynamicUnmarshaler`: skip if `sszLen > decoder.MaxDecodeBufferSize()`

**Guard checks in `reflection/marshal.go` (3 delegation points):**
- `FastsszMarshaler`: skip if `sourceType.Size > encoder.MaxEncodeBufferSize()` (except `SszCustomType`)
- `DynamicMarshaler`: skip unless encoder is seekable or static size fits within limit
- `DynamicViewMarshaler`: skip unless encoder is seekable or static size fits within limit

For the marshal path, dynamic types (unknown output size) on stream encoders conservatively skip delegation since the output size cannot be determined without marshalling. Buffer-based encoders (`Seekable() == true`) always delegate since the data is already in memory.

### Breaking changes

- `NewStreamDecoder` signature changed from `(reader, totalLen, maxBufSize)` to `(reader, totalLen, bufSize, maxBufSize)`
- `NewStreamEncoder` signature changed from `(writer, bufSize)` to `(writer, bufSize, maxBufSize)`
- Existing callers passing `0` for defaults need an additional `0` argument