### PR TITLE
add suport for separate config file in dynssz-gen

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,7 @@ coverage:
 
 ignore:
   - "codegen/tests/**"
+  - "dynssz-gen/testpkg/**"
   - "tests/**"
 
 comment:

--- a/codegen/tests/gen_annotated.yaml
+++ b/codegen/tests/gen_annotated.yaml
@@ -1,0 +1,17 @@
+# Types that use sszutils.Annotate for non-struct SSZ annotations.
+package: github.com/pk910/dynamic-ssz/codegen/tests
+output: gen_annotated.go
+with-streaming: true
+
+types:
+  - AnnotatedList
+  - AnnotatedList2
+  - AnnotatedByteList
+  - AnnotatedWithSpecs
+  - AnnotatedContainer
+  - AnnotatedOverrideContainer
+  - AnnotatedSpecsContainer
+  - name: AnnotatedNestedContainer
+    output: gen_annotated.go
+  - name: AnnotatedNestedContainer_S
+    output: gen_annotated.go

--- a/codegen/tests/gen_extended.yaml
+++ b/codegen/tests/gen_extended.yaml
@@ -1,0 +1,13 @@
+# Extended-types batch: types that exercise signed ints, floats, big.Int, etc.
+package: github.com/pk910/dynamic-ssz/codegen/tests
+output: gen_extended.go
+with-streaming: true
+with-extended-types: true
+
+types:
+  - ExtendedTypes1
+  - CoverageTypes2
+  - CoverageTypes3
+  - CoverageTypes4
+  - CoverageTypes5
+  - CoverageTypes6

--- a/codegen/tests/gen_nodynexpr.yaml
+++ b/codegen/tests/gen_nodynexpr.yaml
@@ -1,0 +1,8 @@
+# Types generated without dynamic expressions — exercises static-only code.
+package: github.com/pk910/dynamic-ssz/codegen/tests
+output: gen_nodynexpr.go
+with-streaming: true
+without-dynamic-expressions: true
+
+types:
+  - NoDynExprTypes

--- a/codegen/tests/gen_ssz.yaml
+++ b/codegen/tests/gen_ssz.yaml
@@ -1,0 +1,68 @@
+# Config for the main batch of generated SSZ code.
+# Paths are resolved relative to this file's directory.
+#
+# The per-type `output` override groups related types into a single file so
+# cross-references between them (e.g. SimpleTypes1 ↔ SimpleTypes1_C1) are
+# emitted as method calls instead of inlined duplicates.
+
+package: github.com/pk910/dynamic-ssz/codegen/tests
+output: gen_ssz.go
+legacy: true
+with-streaming: true
+
+types:
+  - SimpleBool
+  - SimpleUint8
+  - SimpleUint16
+  - SimpleUint32
+  - SimpleUint64
+
+  - name: SimpleTypes1
+    output: gen_simple1.go
+  - name: SimpleTypes1_C1
+    output: gen_simple1.go
+
+  - name: SimpleTypes2
+    output: gen_simple2.go
+  - name: SimpleTypes3
+    output: gen_simple3.go
+
+  - name: SimpleTypesWithSpecs
+    output: gen_withspecs.go
+  - name: SimpleTypesWithSpecs_C1
+    output: gen_withspecs.go
+  - name: SimpleTypesWithSpecs_C2
+    output: gen_withspecs.go
+
+  - name: SimpleTypesWithSpecs2
+    output: gen_withspecs2.go
+  - name: SimpleTypesWithSpecs_C3
+    output: gen_withspecs2.go
+
+  - name: ProgressiveTypes
+    output: gen_progressive.go
+  - name: CustomTypes1
+    output: gen_custom.go
+  - name: CoverageTypes1
+    output: gen_coverage.go
+  - name: CoverageTypes7
+    output: gen_coverage7.go
+
+  - name: ViewTypes1_Base
+    output: gen_viewtypes1.go
+    views:
+      - ViewTypes1_View1
+      - ViewTypes1_View2
+      - github.com/pk910/dynamic-ssz/codegen/tests/views.ViewTypes1_View3
+
+  - name: ViewTypes2_Base
+    output: gen_viewtypes2.go
+    views:
+      - ViewTypes2_View1
+      - ViewTypes2_View2
+
+  - name: ViewTypes3_Base
+    output: gen_viewtypes3.go
+    view-only: true
+    views:
+      - ViewTypes3_View1

--- a/codegen/tests/gen_viewtypes4.yaml
+++ b/codegen/tests/gen_viewtypes4.yaml
@@ -1,0 +1,10 @@
+# Isolated view-type batch (kept separate to exercise multi-batch generation).
+package: github.com/pk910/dynamic-ssz/codegen/tests
+output: gen_viewtypes4.go
+with-streaming: true
+
+types:
+  - name: ViewTypes4_Base
+    output: gen_viewtypes4.go
+    views:
+      - ViewTypes4_View1

--- a/codegen/tests/generate.go
+++ b/codegen/tests/generate.go
@@ -1,7 +1,12 @@
 package tests
 
-//go:generate go run -cover ../../dynssz-gen -package . -with-streaming -types SimpleBool,SimpleUint8,SimpleUint16,SimpleUint32,SimpleUint64,SimpleTypes1:gen_simple1.go,SimpleTypes1_C1:gen_simple1.go,SimpleTypes2:gen_simple2.go,SimpleTypes3:gen_simple3.go,SimpleTypesWithSpecs:gen_withspecs.go,SimpleTypesWithSpecs_C1:gen_withspecs.go,SimpleTypesWithSpecs_C2:gen_withspecs.go,SimpleTypesWithSpecs2:gen_withspecs2.go,SimpleTypesWithSpecs_C3:gen_withspecs2.go,ProgressiveTypes:gen_progressive.go,CustomTypes1:gen_custom.go,CoverageTypes1:gen_coverage.go,CoverageTypes7:gen_coverage7.go,ViewTypes1_Base:gen_viewtypes1.go:views=ViewTypes1_View1;ViewTypes1_View2;github.com/pk910/dynamic-ssz/codegen/tests/views.ViewTypes1_View3,ViewTypes2_Base:gen_viewtypes2.go:views=ViewTypes2_View1;ViewTypes2_View2,ViewTypes3_Base:gen_viewtypes3.go:views=ViewTypes3_View1:viewonly -legacy -output gen_ssz.go
-//go:generate go run -cover ../../dynssz-gen -package . -with-streaming -with-extended-types -types ExtendedTypes1,CoverageTypes2,CoverageTypes3,CoverageTypes4,CoverageTypes5,CoverageTypes6 -output gen_extended.go
-//go:generate go run -cover ../../dynssz-gen -package . -with-streaming -types AnnotatedList,AnnotatedList2,AnnotatedByteList,AnnotatedWithSpecs,AnnotatedContainer,AnnotatedOverrideContainer,AnnotatedSpecsContainer,AnnotatedNestedContainer:gen_annotated.go,AnnotatedNestedContainer_S:gen_annotated.go -output gen_annotated.go
-//go:generate go run -cover ../../dynssz-gen -package . -with-streaming -types ViewTypes4_Base:gen_viewtypes4.go:views=ViewTypes4_View1 -output gen_viewtypes4.go
-//go:generate go run -cover ../../dynssz-gen -package . -with-streaming -without-dynamic-expressions -types NoDynExprTypes -output gen_nodynexpr.go
+// The directives below drive the code generator from YAML config files
+// rather than long inline CLI invocations. See the per-file .yaml configs
+// for what each batch generates; see docs/code-generator-config.md for the
+// config format reference.
+
+//go:generate go run -cover ../../dynssz-gen -config gen_ssz.yaml
+//go:generate go run -cover ../../dynssz-gen -config gen_extended.yaml
+//go:generate go run -cover ../../dynssz-gen -config gen_annotated.yaml
+//go:generate go run -cover ../../dynssz-gen -config gen_viewtypes4.yaml
+//go:generate go run -cover ../../dynssz-gen -config gen_nodynexpr.yaml

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@
 - **[Supported Types](supported-types.md)** - Type system reference (basic, collection, progressive, extended)
 - **[SSZ Annotations](ssz-annotations.md)** - Struct tags, dynamic expressions, and tag combinations
 - **[Code Generator](code-generator.md)** - CLI tool and programmatic code generation
+- **[Code Generator Config File](code-generator-config.md)** - YAML config file format for `dynssz-gen --config`
 - **[SSZ Views](views.md)** - Multiple SSZ schemas for fork handling
 - **[Merkle Proofs](merkle-proofs.md)** - Tree construction and proof generation
 - **[Streaming Support](streaming.md)** - Memory-efficient encoding/decoding via `io.Reader`/`io.Writer`

--- a/docs/code-generator-config.md
+++ b/docs/code-generator-config.md
@@ -1,0 +1,166 @@
+# Code Generator Config File
+
+`dynssz-gen` accepts a YAML config file via `--config <file>`. This is an
+alternative to the CLI flag form that scales better once you have more than a
+handful of types — especially when different types need different output
+files, view types, or codegen flag overrides.
+
+```bash
+dynssz-gen --config gen.yaml
+```
+
+## When to use
+
+Use a config file when any of the following apply:
+
+- The `-types` string is getting long and hard to diff (colon-separated
+  per-type options are hard to read).
+- Different types need different codegen flags (e.g. `-legacy` only for some
+  types).
+- You want the generation settings checked into the repo as a first-class
+  artifact rather than embedded in a `//go:generate` directive.
+
+For a single-type one-liner the CLI form remains shorter and is still
+supported.
+
+## Full example
+
+```yaml
+# Target Go package (required)
+package: github.com/myproject/beacon/types
+
+# Optional overrides
+package-name: types           # defaults to the source package name
+output: generated_ssz.go      # default output for types that don't specify their own
+verbose: false
+
+# Code-generation flags (defaults — applied to every type unless overridden)
+legacy: false
+without-dynamic-expressions: false
+without-fastssz: false
+with-streaming: false
+with-extended-types: false
+
+# Types to generate (at least one required)
+types:
+  # Shorthand: just a name. Inherits the top-level output and flags.
+  - BeaconBlockHeader
+
+  # Full form. Any omitted field inherits the top-level value.
+  - name: BeaconBlock
+    output: block_ssz.go
+    views:
+      - Phase0BlockView
+      - AltairBlockView
+      - github.com/myproject/views.BellatrixBlockView
+
+  # View-only: generates only the view methods (no base methods).
+  - name: BeaconState
+    output: state_ssz.go
+    view-only: true
+    views:
+      - Phase0StateView
+
+  # Per-type flag override: this type is generated without streaming methods
+  # even though with-streaming is true globally.
+  - name: Validator
+    output: validator_ssz.go
+    with-streaming: false
+```
+
+## Field reference
+
+### Top-level fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `package` | string | yes | Go import path of the package to analyze. |
+| `package-name` | string | no | Overrides the package name emitted into generated files. |
+| `output` | string | conditional | Default output path. Required if any type entry omits `output`. |
+| `verbose` | bool | no | Verbose logging during generation. |
+| `legacy` | bool | no | Generate legacy (non-`*Dyn`) fastssz-compatible methods. |
+| `without-dynamic-expressions` | bool | no | Emit only static legacy methods (no `*Dyn`). |
+| `without-fastssz` | bool | no | Don't call third-party fastssz methods on referenced types. |
+| `with-streaming` | bool | no | Emit streaming encoder/decoder methods. |
+| `with-extended-types` | bool | no | Allow extended types (signed ints, floats, big.Int, optionals). |
+| `types` | list | yes | At least one type entry (shorthand string or mapping). |
+
+### Type entries
+
+A `types:` list item is either **shorthand** (a bare string — the type name)
+or **full form** (a mapping).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Required in full form. Type name within the target package. |
+| `output` | string | Output file override. Falls back to the top-level `output`. |
+| `views` | list of strings | View types for view-aware generation. Local types are bare names; cross-package views use `pkg/path.TypeName`. |
+| `view-only` | bool | Generate only view methods, not the base methods. |
+| `legacy` | bool | Per-type override for the top-level `legacy`. |
+| `without-dynamic-expressions` | bool | Per-type override. |
+| `without-fastssz` | bool | Per-type override. |
+| `with-streaming` | bool | Per-type override. |
+| `with-extended-types` | bool | Per-type override. |
+
+Per-type boolean overrides can flip a flag in either direction (e.g. turn off
+`legacy` for one type while it is on globally, or vice versa).
+
+## Path resolution
+
+All relative `output` paths — both top-level and per-type — are resolved
+**relative to the config file's directory**, not the current working
+directory. Absolute paths are used as-is.
+
+This means `dynssz-gen --config ./codegen/tests/gen.yaml` works identically
+whether you run it from the repo root, from `codegen/`, or from anywhere
+else.
+
+## Combining with CLI flags
+
+The config file is the baseline. Any CLI flag **explicitly passed** overrides
+the corresponding config value. Flags that are *not* passed inherit the
+config value.
+
+Detection is based on whether the flag appears on the command line at all —
+so `--config gen.yaml -legacy=false` overrides the config even if the config
+had `legacy: true`, but `--config gen.yaml` alone leaves it untouched.
+
+Special cases:
+
+- `-types` on the CLI **fully replaces** the `types:` list from the config.
+  This is deliberate: merging the two is confusing and surprising. If you
+  need to add a one-off type ad hoc, use the CLI form directly.
+- `-output` on the CLI replaces the top-level `output:`. It does *not*
+  rewrite per-type `output` entries — those remain whatever the config
+  specified.
+
+## Validation
+
+The parser is strict about unknown keys. A typo like `view_only` instead of
+`view-only` is an error, not a silent skip:
+
+```
+failed to parse config file gen.yaml: line 8: unknown field "view_only" in type entry
+```
+
+At least one entry is required under `types:`; every entry must have a
+`name`; and every entry must resolve to a non-empty output path (either its
+own or the top-level default).
+
+## Examples from this repo
+
+The `codegen/tests/` directory uses config files for every generation batch.
+See `codegen/tests/gen_ssz.yaml` for a realistic multi-file, multi-view
+setup, and `codegen/tests/gen_nodynexpr.yaml` for a minimal static-only
+example.
+
+The generator is driven by `//go:generate` lines in
+`codegen/tests/generate.go` that simply reference each YAML file.
+
+## Related documentation
+
+- [Code Generator](code-generator.md) — full CLI reference and codegen
+  concepts.
+- [SSZ Views](views.md) — view-aware generation.
+- [SSZ Annotations](ssz-annotations.md) — the tags that the generator
+  respects.

--- a/docs/code-generator-config.md
+++ b/docs/code-generator-config.md
@@ -107,13 +107,35 @@ Per-type boolean overrides can flip a flag in either direction (e.g. turn off
 
 ## Path resolution
 
-All relative `output` paths — both top-level and per-type — are resolved
-**relative to the config file's directory**, not the current working
-directory. Absolute paths are used as-is.
+Paths in the config file are resolved **relative to the config file's
+directory**, not the current working directory. Absolute paths are used
+as-is. This makes configs portable across invocation sites — you can run
+`dynssz-gen --config ./codegen/tests/gen.yaml` from the repo root, from
+`codegen/`, or from anywhere else and get the same result.
 
-This means `dynssz-gen --config ./codegen/tests/gen.yaml` works identically
-whether you run it from the repo root, from `codegen/`, or from anywhere
-else.
+Three config fields participate in this rule:
+
+- `output` (top-level)
+- `output` (per type entry)
+- `package`, but **only when it looks like a filesystem path**. The go
+  tooling distinguishes import paths (`github.com/foo/bar`) from
+  filesystem paths (starting with `./`, `../`, or `/`, or equal to `.` /
+  `..`). Import paths pass through unchanged; filesystem paths are joined
+  with the config file's directory.
+
+Examples (config at `/work/myproj/gen.yaml`):
+
+| `package:` value | Resolved to | Why |
+|---|---|---|
+| `github.com/me/proj/types` | `github.com/me/proj/types` | import path — untouched |
+| `.` | `/work/myproj` | filesystem path |
+| `./internal/types` | `/work/myproj/internal/types` | filesystem path |
+| `../shared/types` | `/work/shared/types` | filesystem path (Clean'd) |
+| `/abs/pkg` | `/abs/pkg` | absolute — untouched |
+| `./...` | `/work/myproj/...` | recursive pattern is preserved |
+
+The CLI `-package` flag is always interpreted by the shell/go tooling
+relative to CWD — only config-file values get rewritten.
 
 ## Combining with CLI flags
 

--- a/docs/code-generator.md
+++ b/docs/code-generator.md
@@ -29,12 +29,23 @@ Generate SSZ methods for specific types:
 dynssz-gen -package /path/to/package -types BeaconBlock,BeaconState -output generated_ssz.go
 ```
 
+For larger configurations (many types, per-type options, per-type flag
+overrides), use a YAML config file instead of long CLI strings:
+
+```bash
+dynssz-gen --config gen.yaml
+```
+
+See [Code Generator Config File](code-generator-config.md) for the format
+reference.
+
 ### CLI Flags
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `-package` | Go package path to analyze | Required |
-| `-types` | Comma-separated list of types to generate (see extended format below) | Required |
+| `-config` | Path to a YAML config file (see [config reference](code-generator-config.md)) | — |
+| `-package` | Go package path to analyze | Required (unless supplied by config) |
+| `-types` | Comma-separated list of types to generate (see extended format below) | Required (unless supplied by config) |
 | `-output` | Output file path | Required if types don't specify files |
 | `-v` | Verbose output | `false` |
 | `-legacy` | Generate legacy compatibility methods | `false` |
@@ -42,6 +53,11 @@ dynssz-gen -package /path/to/package -types BeaconBlock,BeaconState -output gene
 | `-without-fastssz` | Generate code without using fast ssz generated methods | `false` |
 | `-with-streaming` | Generate streaming encoder/decoder functions | `false` |
 | `-with-extended-types` | Enable support for non-standard extended types (signed ints, floats, big.Int, optionals) | `false` |
+
+When both `--config` and CLI flags are provided, any CLI flag that is
+explicitly passed overrides the config file's value. See the
+[config file docs](code-generator-config.md#combining-with-cli-flags) for
+precedence details.
 
 ### Extended Type Specification Format
 
@@ -941,6 +957,7 @@ To migrate from fastssz code generation:
 ## Related Documentation
 
 - [Getting Started](getting-started.md) - Basic usage
+- [Code Generator Config File](code-generator-config.md) - YAML config file format
 - [API Reference](api-reference.md) - Generator API details
 - [SSZ Views](views.md) - Fork handling with view descriptors
 - [Streaming Support](streaming.md) - Streaming encoding/decoding

--- a/dynssz-gen/config.go
+++ b/dynssz-gen/config.go
@@ -1,0 +1,270 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the dynamic-ssz library.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pk910/dynamic-ssz/codegen"
+	"gopkg.in/yaml.v3"
+)
+
+// FileConfig is the on-disk YAML schema for dynssz-gen's --config flag.
+//
+// All fields are optional at the YAML layer; required-field enforcement happens
+// after CLI overrides are merged (so a required value can come from either
+// side). Boolean fields use pointers so "unset" is distinguishable from
+// "set to false" — that distinction is what makes per-type overrides work.
+type FileConfig struct {
+	Package     string `yaml:"package"`
+	PackageName string `yaml:"package-name"`
+	Output      string `yaml:"output"`
+	Verbose     *bool  `yaml:"verbose"`
+
+	Legacy                    *bool `yaml:"legacy"`
+	WithoutDynamicExpressions *bool `yaml:"without-dynamic-expressions"`
+	WithoutFastSsz            *bool `yaml:"without-fastssz"`
+	WithStreaming             *bool `yaml:"with-streaming"`
+	WithExtendedTypes         *bool `yaml:"with-extended-types"`
+
+	Types []TypeEntry `yaml:"types"`
+}
+
+// TypeEntry describes one type in the `types:` list.
+//
+// Each entry may be provided either as a bare string (shorthand — just the
+// type name, all other options default to the file-level values) or as a
+// mapping. See UnmarshalYAML for the shorthand handling.
+//
+// The per-type codegen flag fields (Legacy, WithoutDynamicExpressions, …)
+// override the file-level values when set. Because codegen's With* options
+// only set booleans to true (never false), overrides are resolved into an
+// effective boolean per type and applied only at the per-type level — never
+// at the file level — so that a type can opt *out* of a globally enabled
+// flag.
+type TypeEntry struct {
+	Name     string   `yaml:"name"`
+	Output   string   `yaml:"output"`
+	Views    []string `yaml:"views"`
+	ViewOnly bool     `yaml:"view-only"`
+
+	Legacy                    *bool `yaml:"legacy"`
+	WithoutDynamicExpressions *bool `yaml:"without-dynamic-expressions"`
+	WithoutFastSsz            *bool `yaml:"without-fastssz"`
+	WithStreaming             *bool `yaml:"with-streaming"`
+	WithExtendedTypes         *bool `yaml:"with-extended-types"`
+}
+
+// UnmarshalYAML accepts either a scalar (string) or a mapping for each type
+// entry, so users can write shorthand entries:
+//
+//	types:
+//	  - SimpleType                 # shorthand
+//	  - name: OtherType            # full form
+//	    output: other_ssz.go
+func (t *TypeEntry) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind == yaml.ScalarNode {
+		name := strings.TrimSpace(node.Value)
+		if name == "" {
+			return fmt.Errorf("line %d: type entry shorthand must be a non-empty string", node.Line)
+		}
+		t.Name = name
+		return nil
+	}
+
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("line %d: type entry must be a string or mapping", node.Line)
+	}
+
+	// yaml.v3's KnownFields strict-mode flag lives on the Decoder, not on the
+	// node. Node.Decode() spins up a fresh internal decoder that doesn't
+	// inherit the setting, so we have to check unknown keys ourselves to
+	// keep parity with the top-level parser.
+	knownKeys := map[string]bool{
+		"name": true, "output": true, "views": true, "view-only": true,
+		"legacy":                      true,
+		"without-dynamic-expressions": true,
+		"without-fastssz":             true,
+		"with-streaming":              true,
+		"with-extended-types":         true,
+	}
+	for i := 0; i < len(node.Content); i += 2 {
+		key := node.Content[i].Value
+		if !knownKeys[key] {
+			return fmt.Errorf("line %d: unknown field %q in type entry", node.Content[i].Line, key)
+		}
+	}
+
+	type typeEntryAlias TypeEntry
+	var alias typeEntryAlias
+	if err := node.Decode(&alias); err != nil {
+		return err
+	}
+	*t = TypeEntry(alias)
+	return nil
+}
+
+// LoadConfig parses a YAML config file from the given path.
+//
+// Unknown keys are rejected (strict mode) so that typos like `view_only`
+// surface as errors instead of being silently ignored.
+func LoadConfig(path string) (*FileConfig, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open config file %s: %w", path, err)
+	}
+	defer f.Close()
+
+	dec := yaml.NewDecoder(f)
+	dec.KnownFields(true)
+
+	cfg := &FileConfig{}
+	if err := dec.Decode(cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse config file %s: %w", path, err)
+	}
+	return cfg, nil
+}
+
+// applyToConfig merges the file config into the CLI-shaped Config.
+//
+// cliProvided tells which CLI flags were explicitly set (via flag.Visit).
+// Explicitly-set CLI flags override the file config; otherwise the file
+// config wins over the zero value that the flag package defaults to.
+//
+// baseDir is used to resolve relative output paths against the config file's
+// directory (not CWD), which keeps configs portable across invocations.
+func (fc *FileConfig) applyToConfig(cfg *Config, cliProvided map[string]bool, baseDir string) ([]typeSpec, error) {
+	// Scalars: CLI wins if provided, otherwise take the file value.
+	if !cliProvided["package"] && fc.Package != "" {
+		cfg.PackagePath = fc.Package
+	}
+	if !cliProvided["package-name"] && fc.PackageName != "" {
+		cfg.PackageName = fc.PackageName
+	}
+	if !cliProvided["output"] && fc.Output != "" {
+		cfg.OutputFile = resolvePath(fc.Output, baseDir)
+	}
+
+	// Booleans: CLI wins if provided, otherwise take file value (if set).
+	applyBool(&cfg.Verbose, fc.Verbose, cliProvided["v"])
+	applyBool(&cfg.Legacy, fc.Legacy, cliProvided["legacy"])
+	applyBool(&cfg.WithoutDynamicExpressions, fc.WithoutDynamicExpressions, cliProvided["without-dynamic-expressions"])
+	applyBool(&cfg.WithoutFastSsz, fc.WithoutFastSsz, cliProvided["without-fastssz"])
+	applyBool(&cfg.WithStreaming, fc.WithStreaming, cliProvided["with-streaming"])
+	applyBool(&cfg.WithExtendedTypes, fc.WithExtendedTypes, cliProvided["with-extended-types"])
+
+	// Types: if the CLI provided -types, it fully replaces the file list.
+	// Merging the two was considered but felt confusing — users that want to
+	// combine should just edit the file. The specs are parsed by the caller
+	// in that case and this function returns nil.
+	if cliProvided["types"] {
+		return nil, nil
+	}
+
+	specs := make([]typeSpec, 0, len(fc.Types))
+	for i, entry := range fc.Types {
+		if entry.Name == "" {
+			return nil, fmt.Errorf("types[%d]: name is required", i)
+		}
+
+		spec := typeSpec{
+			TypeName:   entry.Name,
+			OutputFile: entry.Output,
+			ViewTypes:  append([]string(nil), entry.Views...),
+			IsViewOnly: entry.ViewOnly,
+		}
+		if spec.OutputFile != "" {
+			spec.OutputFile = resolvePath(spec.OutputFile, baseDir)
+		} else {
+			if cfg.OutputFile == "" {
+				return nil, fmt.Errorf("types[%d] (%s): output file not set and no top-level output", i, entry.Name)
+			}
+			spec.OutputFile = cfg.OutputFile
+		}
+
+		spec.Legacy = resolveBool(entry.Legacy, cfg.Legacy)
+		spec.WithoutDynamicExpressions = resolveBool(entry.WithoutDynamicExpressions, cfg.WithoutDynamicExpressions)
+		spec.WithoutFastSsz = resolveBool(entry.WithoutFastSsz, cfg.WithoutFastSsz)
+		spec.WithStreaming = resolveBool(entry.WithStreaming, cfg.WithStreaming)
+		spec.WithExtendedTypes = resolveBool(entry.WithExtendedTypes, cfg.WithExtendedTypes)
+		spec.HasPerTypeOverrides = true
+
+		specs = append(specs, spec)
+	}
+
+	if len(specs) == 0 {
+		return nil, errors.New("config must specify at least one entry in `types`")
+	}
+
+	return specs, nil
+}
+
+// applyBool copies src into dst, unless the CLI already explicitly set dst
+// (in which case src is ignored). Nil src means "file config didn't specify".
+func applyBool(dst, src *bool, cliSet bool) {
+	if cliSet || src == nil {
+		return
+	}
+	*dst = *src
+}
+
+// resolveBool returns override if non-nil, otherwise the fallback value.
+// Used to compute per-type effective booleans from optional overrides.
+func resolveBool(override *bool, fallback bool) bool {
+	if override != nil {
+		return *override
+	}
+	return fallback
+}
+
+// resolvePath returns path if absolute, otherwise joined against baseDir.
+// An empty baseDir means paths are used as-is.
+func resolvePath(path, baseDir string) string {
+	if path == "" || baseDir == "" || filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(baseDir, path)
+}
+
+// codegenFlagOptions turns a set of effective codegen booleans into the
+// corresponding codegen.CodeGeneratorOption values. Only true-valued flags
+// emit options — codegen's With* helpers can only set booleans to true, so
+// "false" is represented by the absence of an option.
+func codegenFlagOptions(legacy, noDynExpr, noFastSsz, streaming, extended bool) []codegen.CodeGeneratorOption {
+	var opts []codegen.CodeGeneratorOption
+	if legacy {
+		opts = append(opts, codegen.WithCreateLegacyFn())
+	}
+	if noDynExpr {
+		opts = append(opts, codegen.WithoutDynamicExpressions())
+	}
+	if noFastSsz {
+		opts = append(opts, codegen.WithNoFastSsz())
+	}
+	if streaming {
+		opts = append(opts, codegen.WithCreateEncoderFn(), codegen.WithCreateDecoderFn())
+	}
+	if extended {
+		opts = append(opts, codegen.WithExtendedTypes())
+	}
+	return opts
+}
+
+// anyHasOverrides reports whether any spec in the slice carries per-type
+// codegen flag overrides. Used to decide whether file-level flags should
+// still be applied (they should be for the legacy CLI path, but not when
+// the config file has already fully resolved per-type flags).
+func anyHasOverrides(specs []typeSpec) bool {
+	for _, s := range specs {
+		if s.HasPerTypeOverrides {
+			return true
+		}
+	}
+	return false
+}

--- a/dynssz-gen/config.go
+++ b/dynssz-gen/config.go
@@ -142,7 +142,7 @@ func LoadConfig(path string) (*FileConfig, error) {
 func (fc *FileConfig) applyToConfig(cfg *Config, cliProvided map[string]bool, baseDir string) ([]typeSpec, error) {
 	// Scalars: CLI wins if provided, otherwise take the file value.
 	if !cliProvided["package"] && fc.Package != "" {
-		cfg.PackagePath = fc.Package
+		cfg.PackagePath = resolvePackagePath(fc.Package, baseDir)
 	}
 	if !cliProvided["package-name"] && fc.PackageName != "" {
 		cfg.PackageName = fc.PackageName
@@ -230,6 +230,33 @@ func resolvePath(path, baseDir string) string {
 		return path
 	}
 	return filepath.Join(baseDir, path)
+}
+
+// resolvePackagePath resolves a go/packages.Load pattern relative to the
+// config file's directory — but only when the pattern looks like a
+// filesystem path. Go package patterns split into three categories:
+//
+//  1. Import paths (e.g. "github.com/foo/bar") — left untouched, since
+//     joining them with a directory would turn a valid import path into a
+//     nonexistent on-disk path.
+//  2. Filesystem paths — anything starting with "./", "../", or equal to
+//     "." / ".." / absolute paths. These are the ones we normalize.
+//  3. "all"/"std" and similar meta-patterns — caught by the import-path
+//     branch (unchanged).
+//
+// The distinction matches the go tool's own rule (see `go help packages`):
+// "A pattern containing a filesystem path starts with './', '../', or '/'".
+// Recursive patterns such as "./..." work because filepath.Join preserves
+// the trailing "...".
+func resolvePackagePath(pkg, baseDir string) string {
+	if pkg == "" || baseDir == "" || filepath.IsAbs(pkg) {
+		return pkg
+	}
+	if pkg == "." || pkg == ".." ||
+		strings.HasPrefix(pkg, "./") || strings.HasPrefix(pkg, "../") {
+		return filepath.Join(baseDir, pkg)
+	}
+	return pkg
 }
 
 // codegenFlagOptions turns a set of effective codegen booleans into the

--- a/dynssz-gen/config_test.go
+++ b/dynssz-gen/config_test.go
@@ -588,7 +588,7 @@ func TestRun_ConfigPathVerbose(t *testing.T) {
 			Legacy:              true,
 		}},
 	}
-	if err := run(runCfg); err != nil {
+	if err := run(&runCfg); err != nil {
 		t.Fatalf("run: %v", err)
 	}
 	if _, err := os.Stat(outFile); err != nil {
@@ -624,7 +624,7 @@ types:
 	}
 	runCfg.TypeSpecs = specs
 
-	if runErr := run(runCfg); runErr != nil {
+	if runErr := run(&runCfg); runErr != nil {
 		t.Fatalf("run: %v", runErr)
 	}
 

--- a/dynssz-gen/config_test.go
+++ b/dynssz-gen/config_test.go
@@ -434,6 +434,68 @@ types:
 	}
 }
 
+func TestResolvePackagePath(t *testing.T) {
+	tests := []struct {
+		name    string
+		pkg     string
+		baseDir string
+		want    string
+	}{
+		{"empty pkg stays empty", "", "/base", ""},
+		{"empty base leaves as-is", "./foo", "", "./foo"},
+		{"absolute path preserved", "/abs/pkg", "/base", "/abs/pkg"},
+		{"import path left untouched", "github.com/foo/bar", "/base", "github.com/foo/bar"},
+		{"dot resolves to baseDir", ".", "/base", "/base"},
+		{"dotdot resolves to parent", "..", "/base/sub", "/base"},
+		{"./sub joined", "./sub", "/base", "/base/sub"},
+		{"../sibling joined", "../sibling", "/base/sub", "/base/sibling"},
+		{"recursive pattern preserved", "./...", "/base", "/base/..."},
+		{"single-segment non-path name untouched", "mypkg", "/base", "mypkg"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolvePackagePath(tt.pkg, tt.baseDir)
+			if got != tt.want {
+				t.Errorf("resolvePackagePath(%q, %q) = %q, want %q", tt.pkg, tt.baseDir, got, tt.want)
+			}
+		})
+	}
+}
+
+// End-to-end: a config with `package: ./sub` resolves against the config's
+// directory, not the caller's CWD. Uses the real codegen/tests package via
+// a relative ref from its parent directory so we can verify packages.Load
+// actually accepts the rewritten path.
+func TestApplyToConfig_RelativePackagePath(t *testing.T) {
+	repoTests, err := filepath.Abs("../codegen/tests")
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	baseDir := filepath.Dir(repoTests) // .../codegen
+
+	fc := &FileConfig{Package: "./tests"}
+	cfg := &Config{}
+	// applyToConfig will error on the missing types list; that's fine — the
+	// package path rewrite happens before the types check.
+	if _, err := fc.applyToConfig(cfg, map[string]bool{}, baseDir); err != nil &&
+		!strings.Contains(err.Error(), "at least one entry") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(baseDir, "tests")
+	if cfg.PackagePath != want {
+		t.Errorf("PackagePath = %q, want %q", cfg.PackagePath, want)
+	}
+}
+
+func TestApplyToConfig_ImportPathPackageUntouched(t *testing.T) {
+	fc := &FileConfig{Package: "github.com/pk910/dynamic-ssz/codegen/tests"}
+	cfg := &Config{}
+	_, _ = fc.applyToConfig(cfg, map[string]bool{}, "/does/not/matter")
+	if cfg.PackagePath != "github.com/pk910/dynamic-ssz/codegen/tests" {
+		t.Errorf("import path should pass through untouched, got %q", cfg.PackagePath)
+	}
+}
+
 func TestResolvePath(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/dynssz-gen/config_test.go
+++ b/dynssz-gen/config_test.go
@@ -1,0 +1,701 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the dynamic-ssz library.
+
+package main
+
+import (
+	"flag"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeTempConfig writes content to a file in tempDir and returns its path.
+// Using a shared tempDir lets each test keep multiple related files (the
+// config itself plus referenced outputs) side by side for realistic path
+// resolution.
+func writeTempConfig(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gen.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+	return path
+}
+
+func TestLoadConfig_FullForm(t *testing.T) {
+	path := writeTempConfig(t, `
+package: github.com/pk910/dynamic-ssz/codegen/tests
+package-name: tests
+output: default_ssz.go
+verbose: true
+legacy: true
+without-dynamic-expressions: false
+without-fastssz: true
+with-streaming: true
+with-extended-types: false
+
+types:
+  - name: BeaconBlock
+    output: block_ssz.go
+    views:
+      - Phase0View
+      - github.com/some/pkg.AltairView
+  - name: BeaconState
+    view-only: true
+    views: [StateView]
+    with-streaming: false
+  - Shorthand
+`)
+
+	fc, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	if fc.Package != "github.com/pk910/dynamic-ssz/codegen/tests" {
+		t.Errorf("Package = %q", fc.Package)
+	}
+	if fc.PackageName != "tests" {
+		t.Errorf("PackageName = %q", fc.PackageName)
+	}
+	if fc.Output != "default_ssz.go" {
+		t.Errorf("Output = %q", fc.Output)
+	}
+	if fc.Verbose == nil || !*fc.Verbose {
+		t.Error("expected Verbose=true")
+	}
+	if fc.Legacy == nil || !*fc.Legacy {
+		t.Error("expected Legacy=true")
+	}
+	if fc.WithoutDynamicExpressions == nil || *fc.WithoutDynamicExpressions {
+		t.Error("expected WithoutDynamicExpressions=false")
+	}
+	if len(fc.Types) != 3 {
+		t.Fatalf("len(types) = %d", len(fc.Types))
+	}
+
+	if fc.Types[0].Name != "BeaconBlock" {
+		t.Errorf("Types[0].Name = %q", fc.Types[0].Name)
+	}
+	if fc.Types[0].Output != "block_ssz.go" {
+		t.Errorf("Types[0].Output = %q", fc.Types[0].Output)
+	}
+	if len(fc.Types[0].Views) != 2 || fc.Types[0].Views[0] != "Phase0View" {
+		t.Errorf("Types[0].Views = %v", fc.Types[0].Views)
+	}
+	if fc.Types[1].ViewOnly != true {
+		t.Error("expected Types[1].ViewOnly=true")
+	}
+	if fc.Types[1].WithStreaming == nil || *fc.Types[1].WithStreaming {
+		t.Error("expected Types[1].WithStreaming=false override")
+	}
+	if fc.Types[2].Name != "Shorthand" {
+		t.Errorf("Types[2].Name = %q (shorthand)", fc.Types[2].Name)
+	}
+}
+
+func TestLoadConfig_FileNotFound(t *testing.T) {
+	_, err := LoadConfig("/definitely/does/not/exist.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !strings.Contains(err.Error(), "failed to open config file") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_InvalidYAML(t *testing.T) {
+	path := writeTempConfig(t, "package: foo\n  indented-wrong: bar\n")
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+	if !strings.Contains(err.Error(), "failed to parse config file") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_UnknownField(t *testing.T) {
+	path := writeTempConfig(t, `
+package: x
+types:
+  - name: T
+    view_only: true
+`) // note: view_only (snake) instead of view-only (kebab) → should error
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected error for unknown field")
+	}
+	if !strings.Contains(err.Error(), "view_only") {
+		t.Fatalf("expected error to name the unknown field, got: %v", err)
+	}
+}
+
+func TestLoadConfig_ShorthandEmpty(t *testing.T) {
+	path := writeTempConfig(t, `
+package: x
+output: out.go
+types:
+  - ""
+`)
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected error for empty shorthand string")
+	}
+	if !strings.Contains(err.Error(), "non-empty string") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_TypeEntryInvalidNode(t *testing.T) {
+	// A sequence value is not a valid type entry (must be scalar or mapping).
+	path := writeTempConfig(t, `
+package: x
+types:
+  - [1, 2, 3]
+`)
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected error for invalid type entry shape")
+	}
+	if !strings.Contains(err.Error(), "must be a string or mapping") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_TypeEntryFieldTypeMismatch(t *testing.T) {
+	// Known field, but the value type is wrong (views must be a list, not a scalar).
+	// Passes our manual key allowlist but then fails the struct decode.
+	path := writeTempConfig(t, `
+package: x
+output: o.go
+types:
+  - name: T
+    views: "NotAList"
+`)
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected error for wrong value type")
+	}
+}
+
+func TestApplyToConfig_BaselineFromFile(t *testing.T) {
+	path := writeTempConfig(t, `
+package: fmt
+package-name: mypkg
+output: out.go
+verbose: true
+legacy: true
+without-dynamic-expressions: true
+without-fastssz: true
+with-streaming: true
+with-extended-types: true
+types:
+  - Stringer
+`)
+	fc, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	cfg := Config{}
+	specs, err := fc.applyToConfig(&cfg, map[string]bool{}, filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("applyToConfig: %v", err)
+	}
+
+	if cfg.PackagePath != "fmt" {
+		t.Errorf("PackagePath = %q", cfg.PackagePath)
+	}
+	if cfg.PackageName != "mypkg" {
+		t.Errorf("PackageName = %q", cfg.PackageName)
+	}
+	if !filepath.IsAbs(cfg.OutputFile) {
+		t.Errorf("expected OutputFile resolved to absolute path, got %q", cfg.OutputFile)
+	}
+	if !strings.HasSuffix(cfg.OutputFile, "out.go") {
+		t.Errorf("OutputFile = %q", cfg.OutputFile)
+	}
+	for name, b := range map[string]bool{
+		"Verbose":                   cfg.Verbose,
+		"Legacy":                    cfg.Legacy,
+		"WithoutDynamicExpressions": cfg.WithoutDynamicExpressions,
+		"WithoutFastSsz":            cfg.WithoutFastSsz,
+		"WithStreaming":             cfg.WithStreaming,
+		"WithExtendedTypes":         cfg.WithExtendedTypes,
+	} {
+		if !b {
+			t.Errorf("expected cfg.%s=true", name)
+		}
+	}
+
+	if len(specs) != 1 {
+		t.Fatalf("len(specs) = %d", len(specs))
+	}
+	spec := specs[0]
+	if spec.TypeName != "Stringer" {
+		t.Errorf("TypeName = %q", spec.TypeName)
+	}
+	if !spec.HasPerTypeOverrides {
+		t.Error("expected HasPerTypeOverrides=true for config-file specs")
+	}
+	if !spec.Legacy || !spec.WithoutDynamicExpressions || !spec.WithoutFastSsz || !spec.WithStreaming || !spec.WithExtendedTypes {
+		t.Errorf("expected effective per-type flags to inherit globals, got %+v", spec)
+	}
+	if spec.OutputFile != cfg.OutputFile {
+		t.Errorf("expected spec to inherit default output, got %q", spec.OutputFile)
+	}
+}
+
+func TestApplyToConfig_CLIOverrides(t *testing.T) {
+	path := writeTempConfig(t, `
+package: fmt
+output: out.go
+legacy: true
+with-streaming: true
+types:
+  - Stringer
+`)
+	fc, _ := LoadConfig(path)
+
+	cfg := Config{
+		PackagePath: "github.com/foo/bar", // CLI gave a different package
+		OutputFile:  "/cli/out.go",        // CLI provided an output
+		Legacy:      false,                // CLI explicitly set -legacy=false
+	}
+	cliProvided := map[string]bool{
+		"package": true,
+		"output":  true,
+		"legacy":  true,
+	}
+
+	specs, err := fc.applyToConfig(&cfg, cliProvided, filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("applyToConfig: %v", err)
+	}
+
+	if cfg.PackagePath != "github.com/foo/bar" {
+		t.Errorf("CLI package should win, got %q", cfg.PackagePath)
+	}
+	if cfg.OutputFile != "/cli/out.go" {
+		t.Errorf("CLI output should win, got %q", cfg.OutputFile)
+	}
+	if cfg.Legacy {
+		t.Error("CLI -legacy=false should win over file's legacy=true")
+	}
+	if !cfg.WithStreaming {
+		t.Error("file with-streaming=true should apply (not CLI-provided)")
+	}
+
+	// Per-type flag should reflect effective merged booleans too.
+	if specs[0].Legacy {
+		t.Error("per-type effective Legacy should be false (CLI override)")
+	}
+	if !specs[0].WithStreaming {
+		t.Error("per-type effective WithStreaming should be true")
+	}
+}
+
+func TestApplyToConfig_CLIReplacesTypes(t *testing.T) {
+	path := writeTempConfig(t, `
+package: fmt
+output: out.go
+types:
+  - Stringer
+  - Other
+`)
+	fc, _ := LoadConfig(path)
+
+	cfg := Config{TypeNames: "CLIProvided", OutputFile: "out.go"}
+	specs, err := fc.applyToConfig(&cfg, map[string]bool{"types": true}, filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("applyToConfig: %v", err)
+	}
+	if specs != nil {
+		t.Errorf("when -types is CLI-provided, config specs should be ignored, got %v", specs)
+	}
+}
+
+func TestApplyToConfig_PerTypeOverrides(t *testing.T) {
+	path := writeTempConfig(t, `
+package: fmt
+output: out.go
+legacy: true
+with-streaming: true
+types:
+  - name: A
+    legacy: false
+    with-streaming: false
+  - name: B   # inherits globals
+  - name: C
+    without-fastssz: true
+`)
+	fc, _ := LoadConfig(path)
+	cfg := Config{}
+	specs, err := fc.applyToConfig(&cfg, map[string]bool{}, filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("applyToConfig: %v", err)
+	}
+
+	if specs[0].Legacy || specs[0].WithStreaming {
+		t.Errorf("A should have overridden both flags off, got %+v", specs[0])
+	}
+	if !specs[1].Legacy || !specs[1].WithStreaming {
+		t.Errorf("B should inherit globals, got %+v", specs[1])
+	}
+	if specs[1].WithoutFastSsz {
+		t.Error("B should have WithoutFastSsz=false (global default)")
+	}
+	if !specs[2].WithoutFastSsz {
+		t.Error("C should have WithoutFastSsz=true override")
+	}
+	if !specs[2].Legacy || !specs[2].WithStreaming {
+		t.Error("C should still inherit the global legacy/streaming flags")
+	}
+}
+
+func TestApplyToConfig_MissingTypeName(t *testing.T) {
+	path := writeTempConfig(t, `
+package: fmt
+output: out.go
+types:
+  - output: foo.go
+`)
+	fc, _ := LoadConfig(path)
+	cfg := Config{}
+	_, err := fc.applyToConfig(&cfg, map[string]bool{}, filepath.Dir(path))
+	if err == nil {
+		t.Fatal("expected error for missing type name")
+	}
+	if !strings.Contains(err.Error(), "name is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyToConfig_MissingOutput(t *testing.T) {
+	path := writeTempConfig(t, `
+package: fmt
+types:
+  - Stringer
+`)
+	fc, _ := LoadConfig(path)
+	cfg := Config{}
+	_, err := fc.applyToConfig(&cfg, map[string]bool{}, filepath.Dir(path))
+	if err == nil {
+		t.Fatal("expected error for missing output")
+	}
+	if !strings.Contains(err.Error(), "output file not set") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyToConfig_NoTypes(t *testing.T) {
+	path := writeTempConfig(t, `
+package: fmt
+output: out.go
+`)
+	fc, _ := LoadConfig(path)
+	cfg := Config{}
+	_, err := fc.applyToConfig(&cfg, map[string]bool{}, filepath.Dir(path))
+	if err == nil {
+		t.Fatal("expected error for empty types list")
+	}
+	if !strings.Contains(err.Error(), "at least one entry") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyToConfig_AbsoluteOutputNotRewritten(t *testing.T) {
+	tmpDir := t.TempDir()
+	absOut := filepath.Join(tmpDir, "abs_out.go")
+	path := writeTempConfig(t, `
+package: fmt
+output: `+absOut+`
+types:
+  - name: A
+    output: `+absOut+`
+`)
+	fc, _ := LoadConfig(path)
+	cfg := Config{}
+	specs, err := fc.applyToConfig(&cfg, map[string]bool{}, filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("applyToConfig: %v", err)
+	}
+	if cfg.OutputFile != absOut {
+		t.Errorf("absolute output mangled: %q vs %q", cfg.OutputFile, absOut)
+	}
+	if specs[0].OutputFile != absOut {
+		t.Errorf("absolute per-type output mangled: %q vs %q", specs[0].OutputFile, absOut)
+	}
+}
+
+func TestResolvePath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		baseDir string
+		want    string
+	}{
+		{"empty path stays empty", "", "/base", ""},
+		{"empty base leaves as-is", "rel.go", "", "rel.go"},
+		{"absolute path preserved", "/abs/out.go", "/base", "/abs/out.go"},
+		{"relative gets joined", "sub/out.go", "/base", "/base/sub/out.go"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolvePath(tt.path, tt.baseDir)
+			if got != tt.want {
+				t.Errorf("resolvePath(%q, %q) = %q, want %q", tt.path, tt.baseDir, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyBool(t *testing.T) {
+	tests := []struct {
+		name    string
+		initial bool
+		src     *bool
+		cliSet  bool
+		want    bool
+	}{
+		{"nil src leaves dst", false, nil, false, false},
+		{"CLI set blocks file", false, boolPtr(true), true, false},
+		{"file sets when CLI absent", false, boolPtr(true), false, true},
+		{"file sets false when CLI absent", true, boolPtr(false), false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dst := tt.initial
+			applyBool(&dst, tt.src, tt.cliSet)
+			if dst != tt.want {
+				t.Errorf("dst = %v, want %v", dst, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveBool(t *testing.T) {
+	if resolveBool(nil, true) != true {
+		t.Error("nil override should fall back")
+	}
+	if resolveBool(boolPtr(false), true) != false {
+		t.Error("override should win over fallback")
+	}
+	if resolveBool(boolPtr(true), false) != true {
+		t.Error("override should win over fallback")
+	}
+}
+
+func TestCodegenFlagOptions(t *testing.T) {
+	// Empty set produces no options.
+	if opts := codegenFlagOptions(false, false, false, false, false); len(opts) != 0 {
+		t.Errorf("expected 0 options for all-false, got %d", len(opts))
+	}
+	// Streaming emits two options (encoder + decoder).
+	if opts := codegenFlagOptions(false, false, false, true, false); len(opts) != 2 {
+		t.Errorf("expected 2 options for streaming, got %d", len(opts))
+	}
+	// All flags on → 6 options total (legacy, no-dyn, no-fastssz, encoder, decoder, extended).
+	if opts := codegenFlagOptions(true, true, true, true, true); len(opts) != 6 {
+		t.Errorf("expected 6 options, got %d", len(opts))
+	}
+}
+
+func TestAnyHasOverrides(t *testing.T) {
+	if anyHasOverrides(nil) {
+		t.Error("nil slice: expected false")
+	}
+	if anyHasOverrides([]typeSpec{{TypeName: "A"}}) {
+		t.Error("no overrides: expected false")
+	}
+	specs := []typeSpec{
+		{TypeName: "A"},
+		{TypeName: "B", HasPerTypeOverrides: true},
+	}
+	if !anyHasOverrides(specs) {
+		t.Error("expected true when one spec has overrides")
+	}
+}
+
+// TestProvidedFlagSet verifies flag.Visit-based detection of explicit flags.
+func TestProvidedFlagSet(t *testing.T) {
+	oldCmd := flag.CommandLine
+	defer func() { flag.CommandLine = oldCmd }()
+
+	flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+	_ = flag.String("foo", "", "")
+	_ = flag.Bool("bar", false, "")
+	_ = flag.Bool("baz", false, "")
+	if err := flag.CommandLine.Parse([]string{"-foo", "x", "-bar=true"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got := providedFlagSet()
+	if !got["foo"] || !got["bar"] {
+		t.Errorf("expected foo and bar, got %v", got)
+	}
+	if got["baz"] {
+		t.Errorf("baz should not be marked as provided")
+	}
+}
+
+// End-to-end: main() --config path loads and runs successfully.
+func TestMain_ConfigFlag_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	outFile := filepath.Join(tmpDir, "gen.go")
+	cfgPath := filepath.Join(tmpDir, "gen.yaml")
+	cfg := `package: github.com/pk910/dynamic-ssz/codegen/tests
+package-name: tests
+output: ` + outFile + `
+types:
+  - SimpleTypes1
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	oldArgs := os.Args
+	oldCmd := flag.CommandLine
+	defer func() { os.Args = oldArgs; flag.CommandLine = oldCmd }()
+
+	flag.CommandLine = flag.NewFlagSet("dynssz-gen", flag.ContinueOnError)
+	os.Args = []string{"dynssz-gen", "-config", cfgPath}
+	main()
+
+	if _, err := os.Stat(outFile); err != nil {
+		t.Fatalf("expected output file generated: %v", err)
+	}
+}
+
+// TestRun_ConfigPathVerbose covers the verbose-logging branch taken when
+// run() was invoked via the config-file path (TypeSpecs populated).
+func TestRun_ConfigPathVerbose(t *testing.T) {
+	tmpDir := t.TempDir()
+	outFile := filepath.Join(tmpDir, "gen.go")
+	runCfg := Config{
+		PackagePath: "github.com/pk910/dynamic-ssz/codegen/tests",
+		PackageName: "tests",
+		Verbose:     true,
+		TypeSpecs: []typeSpec{{
+			TypeName:            "SimpleTypes1",
+			OutputFile:          outFile,
+			HasPerTypeOverrides: true,
+			Legacy:              true,
+		}},
+	}
+	if err := run(runCfg); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if _, err := os.Stat(outFile); err != nil {
+		t.Fatalf("expected output: %v", err)
+	}
+}
+
+// End-to-end: per-type override flips a global flag off for a specific type.
+func TestRun_ConfigWithPerTypeOverrides(t *testing.T) {
+	tmpDir := t.TempDir()
+	outFile := filepath.Join(tmpDir, "gen.go")
+	cfgPath := filepath.Join(tmpDir, "gen.yaml")
+	cfg := `package: github.com/pk910/dynamic-ssz/codegen/tests
+package-name: tests
+output: ` + outFile + `
+legacy: true
+types:
+  - name: SimpleTypes1
+    legacy: false
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	fc, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	runCfg := Config{}
+	specs, err := fc.applyToConfig(&runCfg, map[string]bool{}, filepath.Dir(cfgPath))
+	if err != nil {
+		t.Fatalf("applyToConfig: %v", err)
+	}
+	runCfg.TypeSpecs = specs
+
+	if runErr := run(runCfg); runErr != nil {
+		t.Fatalf("run: %v", runErr)
+	}
+
+	// With Legacy=false overridden at the type level, the generated file
+	// should contain only the dynamic marshal method, not a legacy one.
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "MarshalSSZDyn") {
+		t.Error("expected MarshalSSZDyn in output")
+	}
+	// The legacy (non-Dyn) MarshalSSZ method should NOT appear because we
+	// overrode -legacy off for this type.
+	if strings.Contains(content, "func (") && strings.Contains(content, ") MarshalSSZ() (") {
+		t.Error("expected no legacy MarshalSSZ method when override disables it")
+	}
+}
+
+// End-to-end: config with an unknown field causes main() to log.Fatal.
+// Uses the subprocess technique used elsewhere in this package (the child
+// re-runs itself with TEST_* env set and exits non-zero from log.Fatal).
+func TestMain_ConfigFlag_LoadError(t *testing.T) {
+	if os.Getenv("TEST_DYNSSZ_MAIN_CFG_LOAD_ERR") == "1" {
+		cfgPath := os.Getenv("TEST_DYNSSZ_CFG_PATH")
+		flag.CommandLine = flag.NewFlagSet("dynssz-gen", flag.ContinueOnError)
+		os.Args = []string{"dynssz-gen", "-config", cfgPath}
+		main() // log.Fatal → os.Exit(1)
+		return
+	}
+
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "bad.yaml")
+	if err := os.WriteFile(cfgPath, []byte("unknown-field: 123\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestMain_ConfigFlag_LoadError$") //nolint:gosec // G204: test binary path, controlled input
+	cmd.Env = append(os.Environ(), "TEST_DYNSSZ_MAIN_CFG_LOAD_ERR=1", "TEST_DYNSSZ_CFG_PATH="+cfgPath)
+	if err := cmd.Run(); err == nil {
+		t.Fatal("expected non-zero exit from main() with bad config")
+	}
+}
+
+// End-to-end: valid YAML but applyToConfig fails (missing type name).
+func TestMain_ConfigFlag_ApplyError(t *testing.T) {
+	if os.Getenv("TEST_DYNSSZ_MAIN_CFG_APPLY_ERR") == "1" {
+		cfgPath := os.Getenv("TEST_DYNSSZ_CFG_PATH")
+		flag.CommandLine = flag.NewFlagSet("dynssz-gen", flag.ContinueOnError)
+		os.Args = []string{"dynssz-gen", "-config", cfgPath}
+		main()
+		return
+	}
+
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "bad.yaml")
+	content := `package: fmt
+output: out.go
+types:
+  - output: x.go
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestMain_ConfigFlag_ApplyError$") //nolint:gosec // G204: test binary path, controlled input
+	cmd.Env = append(os.Environ(), "TEST_DYNSSZ_MAIN_CFG_APPLY_ERR=1", "TEST_DYNSSZ_CFG_PATH="+cfgPath)
+	if err := cmd.Run(); err == nil {
+		t.Fatal("expected non-zero exit from main() with bad config apply")
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/dynssz-gen/main.go
+++ b/dynssz-gen/main.go
@@ -14,6 +14,7 @@ import (
 	"go/types"
 	"log"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -34,6 +35,10 @@ type Config struct {
 	WithoutFastSsz            bool
 	WithStreaming             bool
 	WithExtendedTypes         bool
+
+	// TypeSpecs, when non-nil, overrides TypeNames parsing. Populated by the
+	// config-file path so per-type override booleans carry through.
+	TypeSpecs []typeSpec
 }
 
 // typeSpec holds parsed information about a type specification
@@ -42,6 +47,18 @@ type typeSpec struct {
 	OutputFile string
 	ViewTypes  []string // view types for data+views mode (can include package paths)
 	IsViewOnly bool     // whether this is a view-only type
+
+	// Per-type effective codegen flags. When HasPerTypeOverrides is false
+	// these are unused and the global Config values apply. When true, each
+	// boolean is the resolved effective value (global default with optional
+	// override) and is applied at the per-type level only — never the file
+	// level — because codegen With* options can only set booleans to true.
+	HasPerTypeOverrides       bool
+	Legacy                    bool
+	WithoutDynamicExpressions bool
+	WithoutFastSsz            bool
+	WithStreaming             bool
+	WithExtendedTypes         bool
 }
 
 // viewTypeRef holds a parsed view type reference
@@ -86,6 +103,7 @@ func getVersionString() string {
 
 func main() {
 	var (
+		configPath                = flag.String("config", "", "Path to YAML config file")
 		packagePath               = flag.String("package", "", "Go package path to analyze")
 		packageName               = flag.String("package-name", "", "Package name for generated code")
 		typeNames                 = flag.String("types", "", "Comma-separated list of type names to generate code for")
@@ -104,7 +122,9 @@ func main() {
 		_, _ = fmt.Fprintf(w, "dynssz-gen %s\n\n", getVersionString())
 		_, _ = fmt.Fprintf(w, "Go code generator for dynamic SSZ marshaling, unmarshaling, and hash tree root.\n\n")
 		_, _ = fmt.Fprintf(w, "Usage:\n")
-		_, _ = fmt.Fprintf(w, "  dynssz-gen -package <path> -types <types> [-output <file>] [flags]\n\n")
+		_, _ = fmt.Fprintf(w, "  dynssz-gen -package <path> -types <types> [-output <file>] [flags]\n")
+		_, _ = fmt.Fprintf(w, "  dynssz-gen -config <file> [flags]\n\n")
+		_, _ = fmt.Fprintf(w, "See docs/code-generator-config.md for the config file format.\n\n")
 		_, _ = fmt.Fprintf(w, "Types syntax:\n")
 		_, _ = fmt.Fprintf(w, "  Comma-separated list of type names from the target package.\n")
 		_, _ = fmt.Fprintf(w, "  Each type can have colon-separated options:\n")
@@ -150,7 +170,7 @@ func main() {
 		return
 	}
 
-	if *packagePath == "" && *typeNames == "" {
+	if *configPath == "" && *packagePath == "" && *typeNames == "" {
 		flag.Usage()
 		return
 	}
@@ -168,22 +188,53 @@ func main() {
 		WithExtendedTypes:         *withExtendedTypes,
 	}
 
+	if *configPath != "" {
+		cliProvided := providedFlagSet()
+		fc, err := LoadConfig(*configPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+		baseDir := filepath.Dir(*configPath)
+		specs, err := fc.applyToConfig(&config, cliProvided, baseDir)
+		if err != nil {
+			log.Fatal(err)
+		}
+		config.TypeSpecs = specs
+	}
+
 	if err := run(config); err != nil {
 		log.Fatal(err)
 	}
+}
+
+// providedFlagSet returns the set of flags that the user explicitly passed on
+// the command line. The flag package otherwise exposes only the resolved
+// value, which makes it impossible to tell "user passed -legacy=false" from
+// "user did not pass -legacy at all" — we need that distinction for the
+// config-file precedence rules.
+func providedFlagSet() map[string]bool {
+	provided := map[string]bool{}
+	flag.Visit(func(f *flag.Flag) {
+		provided[f.Name] = true
+	})
+	return provided
 }
 
 func run(config Config) error {
 	if config.PackagePath == "" {
 		return errors.New("package path is required (-package)")
 	}
-	if config.TypeNames == "" {
+	if config.TypeNames == "" && len(config.TypeSpecs) == 0 {
 		return errors.New("type names are required (-types)")
 	}
 
 	if config.Verbose {
 		log.Printf("Analyzing package: %s", config.PackagePath)
-		log.Printf("Looking for types: %s", config.TypeNames)
+		if config.TypeNames != "" {
+			log.Printf("Looking for types: %s", config.TypeNames)
+		} else {
+			log.Printf("Looking for %d types (from config file)", len(config.TypeSpecs))
+		}
 	}
 
 	// Parse the Go package
@@ -212,9 +263,14 @@ func run(config Config) error {
 		log.Printf("Successfully loaded package: %s", pkg.Name)
 	}
 
-	typeSpecs, err := parseTypeSpecs(config.TypeNames, config.OutputFile)
-	if err != nil {
-		return err
+	var typeSpecs []typeSpec
+	if len(config.TypeSpecs) > 0 {
+		typeSpecs = config.TypeSpecs
+	} else {
+		typeSpecs, err = parseTypeSpecs(config.TypeNames, config.OutputFile)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Find the requested types in the package
@@ -376,24 +432,37 @@ func run(config Config) error {
 				typeSpecificOpts = append(typeSpecificOpts, codegen.WithViewOnly())
 			}
 
+			// When the config file populated per-type overrides, every codegen
+			// boolean is applied here at the per-type level. This is the only
+			// way for a specific type to opt *out* of a globally enabled flag:
+			// codegen's With* options can only set a boolean to true, so if
+			// we left the option on at the file level we could never turn it
+			// off for one type.
+			if spec.HasPerTypeOverrides {
+				typeSpecificOpts = append(typeSpecificOpts, codegenFlagOptions(
+					spec.Legacy,
+					spec.WithoutDynamicExpressions,
+					spec.WithoutFastSsz,
+					spec.WithStreaming,
+					spec.WithExtendedTypes,
+				)...)
+			}
+
 			// Add the type with its options
 			typeOptions = append(typeOptions, codegen.WithGoTypesType(goType, typeSpecificOpts...))
 		}
 
-		if config.Legacy {
-			typeOptions = append(typeOptions, codegen.WithCreateLegacyFn())
-		}
-		if config.WithoutDynamicExpressions {
-			typeOptions = append(typeOptions, codegen.WithoutDynamicExpressions())
-		}
-		if config.WithoutFastSsz {
-			typeOptions = append(typeOptions, codegen.WithNoFastSsz())
-		}
-		if config.WithStreaming {
-			typeOptions = append(typeOptions, codegen.WithCreateEncoderFn(), codegen.WithCreateDecoderFn())
-		}
-		if config.WithExtendedTypes {
-			typeOptions = append(typeOptions, codegen.WithExtendedTypes())
+		// File-level flags are only used when no per-type overrides are in
+		// play (i.e. the legacy CLI path). In the config-file path each type
+		// already carries its fully-resolved per-type options above.
+		if !anyHasOverrides(specs) {
+			typeOptions = append(typeOptions, codegenFlagOptions(
+				config.Legacy,
+				config.WithoutDynamicExpressions,
+				config.WithoutFastSsz,
+				config.WithStreaming,
+				config.WithExtendedTypes,
+			)...)
 		}
 
 		// Build the file with all types

--- a/dynssz-gen/main.go
+++ b/dynssz-gen/main.go
@@ -59,7 +59,20 @@ type typeSpec struct {
 	WithoutFastSsz            bool
 	WithStreaming             bool
 	WithExtendedTypes         bool
+
+	// Resolved during run()'s validation pass; reused when building codegen
+	// options so we don't look up or re-resolve the same symbols twice (and
+	// so the second pass doesn't need defensive error handling for cases the
+	// first pass already ruled out).
+	resolvedGoType    types.Type
+	resolvedViewTypes []types.Type
 }
+
+// loadPackages is the loader used by run() and its external-package helper.
+// It wraps packages.Load so tests can substitute a failing loader to
+// exercise the top-level error paths that packages.Load practically never
+// hits in production.
+var loadPackages = packages.Load
 
 // viewTypeRef holds a parsed view type reference
 type viewTypeRef struct {
@@ -202,7 +215,7 @@ func main() {
 		config.TypeSpecs = specs
 	}
 
-	if err := run(config); err != nil {
+	if err := run(&config); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -220,7 +233,7 @@ func providedFlagSet() map[string]bool {
 	return provided
 }
 
-func run(config Config) error {
+func run(config *Config) error {
 	if config.PackagePath == "" {
 		return errors.New("package path is required (-package)")
 	}
@@ -242,7 +255,7 @@ func run(config Config) error {
 		Mode: packages.NeedTypes | packages.NeedTypesInfo | packages.NeedSyntax | packages.NeedName,
 	}
 
-	pkgs, err := packages.Load(cfg, config.PackagePath)
+	pkgs, err := loadPackages(cfg, config.PackagePath)
 	if err != nil {
 		return fmt.Errorf("failed to load package %s: %v", config.PackagePath, err)
 	}
@@ -288,7 +301,7 @@ func run(config Config) error {
 			return cached, nil
 		}
 
-		extPkgs, err2 := packages.Load(cfg, pkgPath)
+		extPkgs, err2 := loadPackages(cfg, pkgPath)
 		if err2 != nil {
 			return nil, fmt.Errorf("failed to load external package %s: %w", pkgPath, err2)
 		}
@@ -338,7 +351,9 @@ func run(config Config) error {
 		return typeObj.Type(), nil
 	}
 
-	for _, spec := range typeSpecs {
+	for i := range typeSpecs {
+		spec := &typeSpecs[i]
+
 		// Validate that the main type exists
 		obj := mainScope.Lookup(spec.TypeName)
 		if obj == nil {
@@ -349,20 +364,27 @@ func run(config Config) error {
 		if !ok {
 			return fmt.Errorf("object %s is not a type in package %s", spec.TypeName, config.PackagePath)
 		}
-		_ = typeObj // validated above, used later in verbose logging
+		spec.resolvedGoType = typeObj.Type()
 
-		// Validate view types exist (can be local or external)
-		for _, viewTypeStr := range spec.ViewTypes {
-			ref := parseViewTypeRef(viewTypeStr)
-			if _, err2 := resolveTypeRef(ref); err2 != nil {
-				return fmt.Errorf("view type %s: %w", viewTypeStr, err2)
+		// Resolve view types exactly once; cache on the spec so the second
+		// pass doesn't need to repeat the lookup (or handle errors the first
+		// pass already rejected).
+		if len(spec.ViewTypes) > 0 {
+			spec.resolvedViewTypes = make([]types.Type, 0, len(spec.ViewTypes))
+			for _, viewTypeStr := range spec.ViewTypes {
+				ref := parseViewTypeRef(viewTypeStr)
+				viewType, err2 := resolveTypeRef(ref)
+				if err2 != nil {
+					return fmt.Errorf("view type %s: %w", viewTypeStr, err2)
+				}
+				spec.resolvedViewTypes = append(spec.resolvedViewTypes, viewType)
 			}
 		}
 
 		if _, ok := generateFiles[spec.OutputFile]; !ok {
 			generateFiles[spec.OutputFile] = make([]typeSpec, 0)
 		}
-		generateFiles[spec.OutputFile] = append(generateFiles[spec.OutputFile], spec)
+		generateFiles[spec.OutputFile] = append(generateFiles[spec.OutputFile], *spec)
 		typeCount++
 
 		if config.Verbose {
@@ -389,13 +411,10 @@ func run(config Config) error {
 		var typeOptions []codegen.CodeGeneratorOption
 
 		for _, spec := range specs {
-			// Look up the main type (already validated in the loop above)
-			obj := mainScope.Lookup(spec.TypeName)
-			typeObj, ok := obj.(*types.TypeName)
-			if !ok {
-				return fmt.Errorf("object %s is not a type", spec.TypeName)
-			}
-			goType := typeObj.Type()
+			// Type + view types were already resolved and cached on the spec
+			// during the first validation pass, so no lookup/error handling
+			// is needed here.
+			goType := spec.resolvedGoType
 
 			// Build type-specific options
 			var typeSpecificOpts []codegen.CodeGeneratorOption
@@ -413,18 +432,9 @@ func run(config Config) error {
 				}
 			}
 
-			// Add view types if specified
-			if len(spec.ViewTypes) > 0 {
-				viewTypes := make([]types.Type, 0, len(spec.ViewTypes))
-				for _, viewTypeStr := range spec.ViewTypes {
-					ref := parseViewTypeRef(viewTypeStr)
-					viewType, err2 := resolveTypeRef(ref)
-					if err2 != nil {
-						return fmt.Errorf("failed to resolve view type %s: %w", viewTypeStr, err2)
-					}
-					viewTypes = append(viewTypes, viewType)
-				}
-				typeSpecificOpts = append(typeSpecificOpts, codegen.WithGoTypesViewTypes(viewTypes...))
+			// Add view types if any were resolved.
+			if len(spec.resolvedViewTypes) > 0 {
+				typeSpecificOpts = append(typeSpecificOpts, codegen.WithGoTypesViewTypes(spec.resolvedViewTypes...))
 			}
 
 			// Add view-only flag if specified

--- a/dynssz-gen/main_test.go
+++ b/dynssz-gen/main_test.go
@@ -177,7 +177,7 @@ func TestRun_ValidationErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := run(tt.config)
+			err := run(&tt.config)
 			if err == nil {
 				t.Errorf("Expected error, got nil")
 				return
@@ -298,7 +298,7 @@ func TestRun_TypeNotFound(t *testing.T) {
 		OutputFile:  "output.go",
 	}
 
-	err := run(config)
+	err := run(&config)
 	if err == nil {
 		t.Fatal("expected error for type not found")
 	}
@@ -315,7 +315,7 @@ func TestRun_ObjectNotAType(t *testing.T) {
 		OutputFile:  "output.go",
 	}
 
-	err := run(config)
+	err := run(&config)
 	if err == nil {
 		t.Fatal("expected error for non-type object")
 	}
@@ -341,7 +341,7 @@ func TestRun_VerboseWithValidType(t *testing.T) {
 		WithExtendedTypes:         true,
 	}
 
-	err := run(config)
+	err := run(&config)
 	// We expect an error from codegen since fmt.Stringer is not an SSZ type
 	if err == nil {
 		t.Fatal("expected error from codegen for non-SSZ type")
@@ -363,7 +363,7 @@ func TestRun_FullSuccessPath(t *testing.T) {
 		PackageName: "tests",
 	}
 
-	err := run(config)
+	err := run(&config)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -383,7 +383,7 @@ func TestRun_WriteFileError(t *testing.T) {
 		PackageName: "tests",
 	}
 
-	err := run(config)
+	err := run(&config)
 	if err == nil {
 		t.Fatal("expected error for bad output path")
 	}
@@ -402,7 +402,7 @@ func TestRun_TypeSpecificOutputFile(t *testing.T) {
 		PackageName: "tests",
 	}
 
-	err := run(config)
+	err := run(&config)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -525,7 +525,7 @@ func TestRun_AnnotatedType(t *testing.T) {
 		PackageName: "tests",
 	}
 
-	err := run(config)
+	err := run(&config)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -558,7 +558,7 @@ func TestRun_AnnotatedTypeVerbose(t *testing.T) {
 		Verbose:     true,
 	}
 
-	err := run(config)
+	err := run(&config)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -673,7 +673,7 @@ func TestRun_ViewTypeNotFound(t *testing.T) {
 		PackageName: "tests",
 	}
 
-	err := run(config)
+	err := run(&config)
 	if err == nil {
 		t.Fatal("expected error for non-existent view type")
 	}
@@ -692,7 +692,7 @@ func TestRun_ExternalViewType(t *testing.T) {
 		PackageName: "tests",
 	}
 
-	err := run(config)
+	err := run(&config)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -706,7 +706,7 @@ func TestRun_ExternalViewTypeError(t *testing.T) {
 		PackageName: "tests",
 	}
 
-	err := run(config)
+	err := run(&config)
 	if err == nil {
 		t.Fatal("expected error for bad external view type")
 	}
@@ -723,7 +723,7 @@ func TestRun_VerboseViewTypes(t *testing.T) {
 		Verbose:     true,
 	}
 
-	err := run(config)
+	err := run(&config)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -739,7 +739,7 @@ func TestRun_ViewOnlyType(t *testing.T) {
 		PackageName: "tests",
 	}
 
-	err := run(config)
+	err := run(&config)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/dynssz-gen/main_test.go
+++ b/dynssz-gen/main_test.go
@@ -5,7 +5,11 @@
 package main
 
 import (
+	"errors"
 	"flag"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -742,5 +746,415 @@ func TestRun_ViewOnlyType(t *testing.T) {
 	err := run(&config)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+// -----------------------------------------------------------------------------
+// loadPackages swap — covers the top-level error branches in run() and
+// loadExternalPackage that the real go/packages.Load essentially never hits
+// in production.
+// -----------------------------------------------------------------------------
+
+func withLoader(t *testing.T, stub func(*packages.Config, ...string) ([]*packages.Package, error)) {
+	t.Helper()
+	old := loadPackages
+	loadPackages = stub
+	t.Cleanup(func() { loadPackages = old })
+}
+
+func TestRun_LoadPackagesError(t *testing.T) {
+	withLoader(t, func(_ *packages.Config, _ ...string) ([]*packages.Package, error) {
+		return nil, errors.New("boom")
+	})
+
+	err := run(&Config{
+		PackagePath: "github.com/pk910/dynamic-ssz/dynssz-gen/testpkg",
+		TypeNames:   "InvalidAnnotated",
+		OutputFile:  "out.go",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "failed to load package") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRun_LoadPackagesEmpty(t *testing.T) {
+	withLoader(t, func(_ *packages.Config, _ ...string) ([]*packages.Package, error) {
+		return nil, nil
+	})
+
+	err := run(&Config{
+		PackagePath: "anything",
+		TypeNames:   "Foo",
+		OutputFile:  "out.go",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "no packages found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// loadExternalPackage error path: delegate to the real loader for the main
+// package, but return an error when asked to load the external one.
+func TestRun_LoadExternalPackagesError(t *testing.T) {
+	realLoader := loadPackages
+	withLoader(t, func(cfg *packages.Config, paths ...string) ([]*packages.Package, error) {
+		if len(paths) == 1 && paths[0] == "github.com/pk910/dynamic-ssz/dynssz-gen/testpkg" {
+			return realLoader(cfg, paths...)
+		}
+		return nil, errors.New("external boom")
+	})
+
+	tmp := t.TempDir()
+	outFile := filepath.Join(tmp, "gen.go")
+	err := run(&Config{
+		PackagePath: "github.com/pk910/dynamic-ssz/dynssz-gen/testpkg",
+		PackageName: "testpkg",
+		TypeNames:   "InvalidAnnotated:" + outFile + ":views=github.com/unreachable/pkg.Foo",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "failed to load external package") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRun_LoadExternalPackagesEmpty(t *testing.T) {
+	realLoader := loadPackages
+	withLoader(t, func(cfg *packages.Config, paths ...string) ([]*packages.Package, error) {
+		if len(paths) == 1 && paths[0] == "github.com/pk910/dynamic-ssz/dynssz-gen/testpkg" {
+			return realLoader(cfg, paths...)
+		}
+		return nil, nil // empty slice + nil error ⇒ "not found"
+	})
+
+	tmp := t.TempDir()
+	outFile := filepath.Join(tmp, "gen.go")
+	err := run(&Config{
+		PackagePath: "github.com/pk910/dynamic-ssz/dynssz-gen/testpkg",
+		PackageName: "testpkg",
+		TypeNames:   "InvalidAnnotated:" + outFile + ":views=github.com/empty/pkg.Foo",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "external package") || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// External package caching + verbose external load — covers the
+// already-cached early return and the verbose-logging branch in
+// loadExternalPackage.
+// -----------------------------------------------------------------------------
+
+func TestRun_ExternalPackageCachedAndVerbose(t *testing.T) {
+	tmp := t.TempDir()
+	outFile := filepath.Join(tmp, "gen.go")
+
+	// Two view types from the same external package. The second resolve
+	// hits the externalPackages cache, covering the cache-hit early return.
+	err := run(&Config{
+		PackagePath: "github.com/pk910/dynamic-ssz/codegen/tests",
+		PackageName: "tests",
+		TypeNames:   "ViewTypes1_Base:" + outFile + ":views=github.com/pk910/dynamic-ssz/codegen/tests/views.ViewTypes1_View3;github.com/pk910/dynamic-ssz/codegen/tests/views.ViewTypes1_View4",
+		Verbose:     true,
+	})
+	// We don't care about the final generation result here — the path we
+	// need covered runs during spec validation before codegen.
+	// But a missing external view type will return an error; use a type
+	// that actually exists and rely on two distinct references to the same
+	// external package.
+	if err != nil && !strings.Contains(err.Error(), "view type") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// resolveTypeRef's "object exists but isn't a type" branch for external
+// packages — hit by using fmt.Println (a *types.Func) as a view type.
+// -----------------------------------------------------------------------------
+
+func TestRun_ExternalViewNotAType(t *testing.T) {
+	tmp := t.TempDir()
+	outFile := filepath.Join(tmp, "gen.go")
+	err := run(&Config{
+		PackagePath: "github.com/pk910/dynamic-ssz/codegen/tests",
+		PackageName: "tests",
+		TypeNames:   "ViewTypes1_Base:" + outFile + ":views=fmt.Println",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "not a type") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Verbose + view-only — covers the `mode = "view-only"` branch in the
+// per-type verbose log line.
+// -----------------------------------------------------------------------------
+
+func TestRun_VerboseViewOnly(t *testing.T) {
+	tmp := t.TempDir()
+	outFile := filepath.Join(tmp, "gen.go")
+	err := run(&Config{
+		PackagePath: "github.com/pk910/dynamic-ssz/codegen/tests",
+		PackageName: "tests",
+		TypeNames:   "ViewTypes3_Base:" + outFile + ":views=ViewTypes3_View1:viewonly",
+		Verbose:     true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Annotate-tag parse error — a testpkg type declares an Annotate tag whose
+// value can't be parsed numerically, forcing run() to return a wrapped
+// parseErr.
+// -----------------------------------------------------------------------------
+
+func TestRun_BadAnnotateTagInSource(t *testing.T) {
+	tmp := t.TempDir()
+	outFile := filepath.Join(tmp, "gen.go")
+	err := run(&Config{
+		PackagePath: "github.com/pk910/dynamic-ssz/dynssz-gen/testpkg",
+		PackageName: "testpkg",
+		TypeNames:   "InvalidAnnotated",
+		OutputFile:  outFile,
+	})
+	if err == nil {
+		t.Fatal("expected error for bad annotate tag")
+	}
+	if !strings.Contains(err.Error(), "failed to parse Annotate tag") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// findAnnotateCall: aliased sszutils import. testpkg/aliased.go imports the
+// package as `szs`, so the scanner picks up the alias from imp.Name.
+// -----------------------------------------------------------------------------
+
+func TestFindAnnotateCall_AliasedImport(t *testing.T) {
+	cfg := &packages.Config{
+		Mode: packages.NeedTypes | packages.NeedTypesInfo | packages.NeedSyntax | packages.NeedName,
+	}
+	pkgs, err := packages.Load(cfg, "github.com/pk910/dynamic-ssz/dynssz-gen/testpkg")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	tag := findAnnotateCall(pkgs[0], "AliasedAnnotated")
+	if tag != `ssz-max:"16"` {
+		t.Fatalf("expected aliased tag, got %q", tag)
+	}
+}
+
+// findAnnotateCall for a type whose Annotate lives inside an init() body
+// alongside an AssignStmt — covers the non-ExprStmt continue branch in
+// findAnnotateCallInDecl.
+func TestFindAnnotateCall_InitMixedStmts(t *testing.T) {
+	cfg := &packages.Config{
+		Mode: packages.NeedTypes | packages.NeedTypesInfo | packages.NeedSyntax | packages.NeedName,
+	}
+	pkgs, err := packages.Load(cfg, "github.com/pk910/dynamic-ssz/dynssz-gen/testpkg")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	// This type's Annotate is registered via an AssignStmt in init() — the
+	// scanner only finds Annotate in ExprStmts, so it must NOT match.
+	// But the loop must still iterate past the assign stmt without crashing
+	// and past the unrelated-call ExprStmt.
+	tag := findAnnotateCall(pkgs[0], "NonExprInitMarker")
+	if tag != "" {
+		t.Fatalf("expected empty tag (Annotate was in AssignStmt not ExprStmt), got %q", tag)
+	}
+
+	// Meanwhile InvalidAnnotated still resolves correctly, proving the
+	// scanner didn't get confused by the mixed init() body.
+	tag = findAnnotateCall(pkgs[0], "InvalidAnnotated")
+	if tag == "" {
+		t.Fatal("expected InvalidAnnotated tag to still be found")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Synthetic AST tests for findAnnotateCallInDecl / matchAnnotateCall
+// defensive branches that are unreachable via valid Go source.
+// -----------------------------------------------------------------------------
+
+// astExprFromString parses a single expression string into an ast.Expr.
+func astExprFromString(t *testing.T, src string) ast.Expr {
+	t.Helper()
+	expr, err := parser.ParseExpr(src)
+	if err != nil {
+		t.Fatalf("parse %q: %v", src, err)
+	}
+	return expr
+}
+
+// astFileFromString parses a full source string into an *ast.File.
+func astFileFromString(t *testing.T, src string) *ast.File {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "test.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return f
+}
+
+func TestMatchAnnotateCall_NotCall(t *testing.T) {
+	expr := astExprFromString(t, `42`)
+	if got := matchAnnotateCall(expr, "sszutils", "Foo"); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestMatchAnnotateCall_WrongArgCount(t *testing.T) {
+	expr := astExprFromString(t, `sszutils.Annotate[Foo]("a", "b")`)
+	if got := matchAnnotateCall(expr, "sszutils", "Foo"); got != "" {
+		t.Errorf("expected empty for 2-arg call, got %q", got)
+	}
+}
+
+func TestMatchAnnotateCall_NotIndexExpr(t *testing.T) {
+	// Plain call, no type-parameter index expression — takes the `!ok`
+	// branch on the IndexExpr type assertion.
+	expr := astExprFromString(t, `sszutils.Annotate("tag")`)
+	if got := matchAnnotateCall(expr, "sszutils", "Foo"); got != "" {
+		t.Errorf("expected empty for non-index call, got %q", got)
+	}
+}
+
+func TestMatchAnnotateCall_SelectorNameNotAnnotate(t *testing.T) {
+	expr := astExprFromString(t, `sszutils.Other[Foo]("tag")`)
+	if got := matchAnnotateCall(expr, "sszutils", "Foo"); got != "" {
+		t.Errorf("expected empty for non-Annotate selector, got %q", got)
+	}
+}
+
+func TestMatchAnnotateCall_SelectorXNotIdent(t *testing.T) {
+	// sel.X is pkg.sub (a SelectorExpr), not an Ident — takes the `!ok`
+	// branch on the X type assertion.
+	expr := astExprFromString(t, `pkg.sub.Annotate[Foo]("tag")`)
+	if got := matchAnnotateCall(expr, "sszutils", "Foo"); got != "" {
+		t.Errorf("expected empty for non-ident selector X, got %q", got)
+	}
+}
+
+func TestMatchAnnotateCall_AliasMismatch(t *testing.T) {
+	expr := astExprFromString(t, `other.Annotate[Foo]("tag")`)
+	if got := matchAnnotateCall(expr, "sszutils", "Foo"); got != "" {
+		t.Errorf("expected empty for wrong alias, got %q", got)
+	}
+}
+
+func TestMatchAnnotateCall_TypeArgNotIdent(t *testing.T) {
+	// Index is a non-identifier type expression (pointer).
+	expr := astExprFromString(t, `sszutils.Annotate[*Foo]("tag")`)
+	if got := matchAnnotateCall(expr, "sszutils", "Foo"); got != "" {
+		t.Errorf("expected empty for non-ident type arg, got %q", got)
+	}
+}
+
+func TestMatchAnnotateCall_TypeArgNameMismatch(t *testing.T) {
+	expr := astExprFromString(t, `sszutils.Annotate[Bar]("tag")`)
+	if got := matchAnnotateCall(expr, "sszutils", "Foo"); got != "" {
+		t.Errorf("expected empty for wrong type name, got %q", got)
+	}
+}
+
+func TestMatchAnnotateCall_ArgNotBasicLit(t *testing.T) {
+	expr := astExprFromString(t, `sszutils.Annotate[Foo](tagVar)`)
+	if got := matchAnnotateCall(expr, "sszutils", "Foo"); got != "" {
+		t.Errorf("expected empty for non-literal arg, got %q", got)
+	}
+}
+
+func TestMatchAnnotateCall_ArgNotStringLit(t *testing.T) {
+	// An integer BasicLit is not a string — covers lit.Kind != STRING.
+	expr := astExprFromString(t, `sszutils.Annotate[Foo](42)`)
+	if got := matchAnnotateCall(expr, "sszutils", "Foo"); got != "" {
+		t.Errorf("expected empty for non-string lit, got %q", got)
+	}
+}
+
+func TestMatchAnnotateCall_InterpretedStringUnquoteError(t *testing.T) {
+	// Hand-build a CallExpr whose string arg is syntactically invalid when
+	// unquoted. parser.ParseExpr won't produce this shape from real Go
+	// source (it would reject the literal), so we construct the AST nodes
+	// directly.
+	lit := &ast.BasicLit{
+		Kind:  token.STRING,
+		Value: `"unterminated`, // doesn't start with ` and has no closing quote
+	}
+	call := &ast.CallExpr{
+		Fun: &ast.IndexExpr{
+			X: &ast.SelectorExpr{
+				X:   &ast.Ident{Name: "sszutils"},
+				Sel: &ast.Ident{Name: "Annotate"},
+			},
+			Index: &ast.Ident{Name: "Foo"},
+		},
+		Args: []ast.Expr{lit},
+	}
+	if got := matchAnnotateCall(call, "sszutils", "Foo"); got != "" {
+		t.Errorf("expected empty when strconv.Unquote fails, got %q", got)
+	}
+}
+
+func TestMatchAnnotateCall_RawString(t *testing.T) {
+	// Happy-path raw-string branch for completeness (already covered
+	// indirectly, but nice to have explicit unit coverage here too).
+	expr := astExprFromString(t, "sszutils.Annotate[Foo](`tag-x`)")
+	if got := matchAnnotateCall(expr, "sszutils", "Foo"); got != "tag-x" {
+		t.Errorf("expected tag-x, got %q", got)
+	}
+}
+
+// findAnnotateCallInDecl has a `continue` for non-ValueSpec entries inside
+// a VAR GenDecl. Valid Go won't produce that, so we hand-craft a GenDecl
+// with mixed spec types.
+func TestFindAnnotateCallInDecl_NonValueSpec(t *testing.T) {
+	decl := &ast.GenDecl{
+		Tok: token.VAR,
+		Specs: []ast.Spec{
+			&ast.ImportSpec{}, // deliberately wrong spec type for a VAR decl
+		},
+	}
+	if got := findAnnotateCallInDecl(decl, "sszutils", "Foo"); got != "" {
+		t.Errorf("expected empty from GenDecl with non-ValueSpec, got %q", got)
+	}
+}
+
+func TestFindAnnotateCallInDecl_GenDeclNotVar(t *testing.T) {
+	// TYPE decls are ignored outright — exercises the early return at the
+	// top of findAnnotateCallInDecl.
+	src := `package p
+type T int
+`
+	f := astFileFromString(t, src)
+	for _, decl := range f.Decls {
+		if got := findAnnotateCallInDecl(decl, "sszutils", "T"); got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+	}
+}
+
+func TestFindAnnotateCallInDecl_OtherDeclKind(t *testing.T) {
+	// A LabeledStmt is not *ast.GenDecl or *ast.FuncDecl — it's also not a
+	// top-level Decl, but we can still hand it as an untyped Decl to force
+	// the switch's default (no branch taken). We use a BadDecl for clarity.
+	var d ast.Decl = &ast.BadDecl{}
+	if got := findAnnotateCallInDecl(d, "sszutils", "Foo"); got != "" {
+		t.Errorf("expected empty from BadDecl, got %q", got)
 	}
 }

--- a/dynssz-gen/main_test.go
+++ b/dynssz-gen/main_test.go
@@ -748,6 +748,7 @@ func TestRun_ViewOnlyType(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
 // -----------------------------------------------------------------------------
 // loadPackages swap — covers the top-level error branches in run() and
 // loadExternalPackage that the real go/packages.Load essentially never hits

--- a/dynssz-gen/testpkg/aliased.go
+++ b/dynssz-gen/testpkg/aliased.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the dynamic-ssz library.
+
+package testpkg
+
+// Import sszutils under an alias so dynssz-gen's AST scanner has to pick up
+// the alias name from imp.Name (rather than defaulting to the package name).
+// This exercises the aliased-import branch in findAnnotateCall.
+import szs "github.com/pk910/dynamic-ssz/sszutils"
+
+// AliasedAnnotated is a byte list whose Annotate call is routed through an
+// aliased sszutils import in this file's imports.
+type AliasedAnnotated []byte
+
+var _ = szs.Annotate[AliasedAnnotated](`ssz-max:"16"`)

--- a/dynssz-gen/testpkg/testpkg.go
+++ b/dynssz-gen/testpkg/testpkg.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the dynamic-ssz library.
+
+// Package testpkg is a fixture for dynssz-gen coverage tests.
+//
+// It intentionally contains types and patterns that only exist to exercise
+// code paths in dynssz-gen's AST scanning and tag parsing — specifically:
+//   - An SSZ type whose Annotate tag fails to parse (InvalidAnnotated).
+//   - An init() function with a non-ExprStmt (tests the "skip" branch in
+//     findAnnotateCallInDecl).
+//   - An unrelated sszutils call in init() (tests the "not Annotate" branch
+//     in matchAnnotateCall).
+//
+// None of these types are meant for real use. The file is kept outside
+// codegen/tests so their presence doesn't contaminate that package's
+// generated code.
+package testpkg
+
+import (
+	"github.com/pk910/dynamic-ssz/sszutils"
+)
+
+// InvalidAnnotated carries a syntactically valid ssz-size tag that fails
+// numeric parsing — lets tests trigger the Annotate-tag error path in
+// dynssz-gen's run().
+type InvalidAnnotated []byte
+
+var _ = sszutils.Annotate[InvalidAnnotated](`ssz-size:"notanumber"`)
+
+// NonExprInitMarker exists solely so there's a type whose name can be
+// searched for — the init() below contains a non-ExprStmt that the scanner
+// must skip over.
+type NonExprInitMarker []byte
+
+// unrelatedCall is a package-level helper used in the init() below so we
+// can have an ExprStmt that selects a function which is *not* Annotate
+// (hits the `sel.Sel.Name != "Annotate"` branch in matchAnnotateCall).
+func unrelatedCall() {}
+
+func init() {
+	// AssignStmt, not ExprStmt — the scanner must `continue` past this
+	// without crashing when looking for Annotate calls in init() bodies.
+	_ = sszutils.Annotate[NonExprInitMarker](`ssz-max:"4"`)
+
+	// ExprStmt whose call target is a selector but with Sel.Name != "Annotate".
+	// This sits under the same sszutils alias, so the scanner will recurse
+	// into the Sel check and take the "not Annotate" branch.
+	unrelatedCall()
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/casbin/govaluate v1.10.0
 	github.com/pk910/hashtree-bindings v0.1.0
 	golang.org/x/tools v0.30.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -14,3 +14,7 @@ golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/tools v0.30.0 h1:BgcpHewrV5AUp2G9MebG4XPFI1E2W41zU1SaqVA9vJY=
 golang.org/x/tools v0.30.0/go.mod h1:c347cR/OJfw5TI+GfX7RUPNMdDRRbjvYTS0jPyvsVtY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
# dynssz-gen: YAML config file support

Adds `--config <file>` to `dynssz-gen` so the generator can be driven from a
YAML file instead of ever-growing `-types` CLI strings. Pure addition — the
existing flag-only invocation remains unchanged.

## Motivation

Real-world usage quickly outgrows the CLI form. The main batch in this
repo's own `codegen/tests/` looked like this:

```
dynssz-gen -package . -with-streaming -types \
  SimpleBool,SimpleUint8,SimpleUint16,SimpleUint32,SimpleUint64,\
  SimpleTypes1:gen_simple1.go,SimpleTypes1_C1:gen_simple1.go,\
  SimpleTypes2:gen_simple2.go,SimpleTypes3:gen_simple3.go,\
  ... (18 more types, several with views, view-only, package-qualified view refs)
  -legacy -output gen_ssz.go
```

The colon/semicolon-delimited per-type syntax (`Type:out.go:views=A;B:viewonly`)
is dense, hard to diff, and can't express different codegen flags for
different types in the same batch. A config file fixes all three.

## What's new

### `--config gen.yaml`

```yaml
package: github.com/myproject/beacon/types
output: generated_ssz.go

# Global codegen flag defaults
legacy: true
with-streaming: true

types:
  # Shorthand — just the name
  - BeaconBlockHeader

  # Full form
  - name: BeaconBlock
    output: block_ssz.go
    views:
      - Phase0BlockView
      - AltairBlockView
      - github.com/myproject/views.BellatrixBlockView

  - name: BeaconState
    output: state_ssz.go
    view-only: true
    views: [Phase0StateView]

  # Per-type override: skip streaming just for this type
  - name: Validator
    output: validator_ssz.go
    with-streaming: false
```

All existing CLI flags have a YAML equivalent. Every top-level codegen
boolean (`legacy`, `without-dynamic-expressions`, `without-fastssz`,
`with-streaming`, `with-extended-types`) may also be set **per type**,
overriding the global default in either direction. Internally this resolves
to per-type effective booleans applied only at the per-type level in the
codegen API, so a type can opt *out* of a globally enabled flag — which was
not expressible with the old CLI.

### Strict parsing

Unknown keys are an error, not a silent skip:

```
failed to parse config file gen.yaml: line 8: unknown field "view_only" in type entry
```

### Path resolution

Relative `output` paths (both top-level and per-type) resolve against the
config file's directory, not CWD. Absolute paths pass through unchanged.
This keeps configs portable between `go:generate` in any package dir and
invocations from the repo root.

### CLI / config precedence

Both can be passed together. Any CLI flag that is **explicitly** set on the
command line (detected via `flag.Visit`) overrides the corresponding config
value; unset flags inherit from the config. A CLI `-types` fully replaces
the config's `types:` list (merging two lists was judged more confusing
than useful).

## Adoption in this repo

`codegen/tests/generate.go` is rewritten to drive codegen from five small
YAML files (one per batch) instead of five giant single-line
`//go:generate` directives. `go generate ./...` produces byte-identical
output to before; all existing tests in `codegen/tests` pass unchanged.

## Documentation

- New: [`docs/code-generator-config.md`](docs/code-generator-config.md) —
  full format reference, precedence rules, examples.
- Updated: [`docs/code-generator.md`](docs/code-generator.md) — `-config`
  added to the flag table, with pointer to the full config doc.
- Updated: [`docs/README.md`](docs/README.md) — config doc linked from the
  index.

## Compatibility

No breaking changes. The CLI-only form (`-package`, `-types`, `-output`,
all codegen flags) works exactly as before. Projects that don't adopt
`--config` see no difference.

## Dependencies

One new direct dep: `gopkg.in/yaml.v3` (BSD/MIT, widely used).
