### PR TITLE
dynssz-gen: share types across main + view-type package loads

### DIFF
--- a/dynssz-gen/main.go
+++ b/dynssz-gen/main.go
@@ -250,9 +250,15 @@ func run(config *Config) error {
 		}
 	}
 
-	// Parse the Go package
+	// Parse the Go package. NeedImports + NeedDeps make the main package's
+	// transitively-loaded dependencies (e.g. "spec/phase0" reached via
+	// "spec/all") available with the same *types.Named instances the main
+	// package uses. We seed them into the external-package cache below so
+	// that view types pointing into those same packages share types,
+	// preventing the parser from misclassifying nested fields as views.
 	cfg := &packages.Config{
-		Mode: packages.NeedTypes | packages.NeedTypesInfo | packages.NeedSyntax | packages.NeedName,
+		Mode: packages.NeedTypes | packages.NeedTypesInfo | packages.NeedSyntax | packages.NeedName |
+			packages.NeedImports | packages.NeedDeps,
 	}
 
 	pkgs, err := loadPackages(cfg, config.PackagePath)
@@ -292,10 +298,38 @@ func run(config *Config) error {
 	mainScope := pkg.Types.Scope()
 	typeCount := 0
 
-	// Cache for loaded external packages
+	// Cache for loaded external packages. Pre-populate it from the main
+	// package's transitive imports so that any view type that lives in a
+	// package the main package already depends on resolves to the same
+	// *types.Named instance the main package uses. Without this, separate
+	// packages.Load calls produce distinct *types.Named pointers for the
+	// same logical type, which causes the parser's pointer-equality check
+	// (data != schema) to misclassify every nested struct as a view —
+	// preventing fastssz delegation to per-fork generated methods.
 	externalPackages := make(map[string]*packages.Package)
+	var seedTransitiveImports func(p *packages.Package)
+	seedTransitiveImports = func(p *packages.Package) {
+		for impPath, impPkg := range p.Imports {
+			if _, ok := externalPackages[impPath]; ok {
+				continue
+			}
+			if impPkg == nil || impPkg.Types == nil {
+				continue
+			}
+			externalPackages[impPath] = impPkg
+			seedTransitiveImports(impPkg)
+		}
+	}
+	seedTransitiveImports(pkg)
+	if config.Verbose {
+		log.Printf("Seeded %d transitive packages from main", len(externalPackages))
+	}
 
-	// Helper to load and cache an external package
+	// Helper to load and cache an external package. Lookups go through the
+	// transitively-seeded cache first; on a miss we do a fresh packages.Load
+	// and then re-check the cache by the canonical PkgPath so a relative
+	// pattern like "../phase0" still resolves to the main-package's already
+	// loaded copy of "github.com/.../phase0".
 	loadExternalPackage := func(pkgPath string) (*packages.Package, error) {
 		if cached, ok := externalPackages[pkgPath]; ok {
 			return cached, nil
@@ -312,7 +346,17 @@ func run(config *Config) error {
 			return nil, fmt.Errorf("external package %s has errors: %v", pkgPath, extPkgs[0].Errors[0])
 		}
 
+		// If the canonical import path is already in our seeded cache (because
+		// the main package transitively imports it), use that copy so types
+		// are pointer-identical to the ones the main package sees.
+		canonical := extPkgs[0].PkgPath
+		if seeded, ok := externalPackages[canonical]; ok {
+			externalPackages[pkgPath] = seeded
+			return seeded, nil
+		}
+
 		externalPackages[pkgPath] = extPkgs[0]
+		externalPackages[canonical] = extPkgs[0]
 		if config.Verbose {
 			log.Printf("Loaded external package: %s", pkgPath)
 		}


### PR DESCRIPTION
# dynssz-gen: share types across main + view-type package loads

## Summary

When a generator config registers view types from external packages,
`dynssz-gen` previously loaded each view-type package via its own
`packages.Load` call, separate from the main package's load. Each load
builds its own `go/types` graph, so a type that both packages reference
(e.g. a shared primitive like `Hash32` or a nested struct like
`Checkpoint`) ended up as **two distinct `*types.Named` instances** —
one reached transitively via the main package, another reached directly
via the view's load.

The parser uses pointer equality on `types.Type` to detect view
descriptors. With distinct instances per load, every nested struct of a
view'd type was misclassified as a view, the codegen skipped fastssz
delegation, and the generated marshal/unmarshal/size/hashtree functions
inlined every nested field byte-by-byte instead of calling the per-package
generated methods.

This PR keeps the main package's transitively-loaded packages around and
reuses them when resolving view-type references that point into the same
import paths. Types stay pointer-identical, so the parser correctly
classifies nested fields and the generator emits compact delegations
again.

## Example

Given two packages:

```go
// fork_a/checkpoint.go
package fork_a

type Checkpoint struct { Epoch uint64; Root [32]byte }
func (c *Checkpoint) MarshalSSZTo(dst []byte) ([]byte, error) { ... }
func (c *Checkpoint) UnmarshalSSZ(buf []byte) error           { ... }
// + SizeSSZ, HashTreeRoot, ...

// fork_a/state.go
package fork_a

type State struct {
    Slot       uint64
    Checkpoint *Checkpoint
}
```

…and a fork-agnostic union type with a view config pointing back to
`fork_a.State`:

```go
// agnostic/state.go
package agnostic

type State struct {
    Slot       uint64
    Checkpoint *fork_a.Checkpoint
    // ... extra fields union'd from other forks
}
```

```yaml
# agnostic/generate.yaml
types:
  - name: State
    output: state_ssz.go
    view-only: true
    views:
      - ../fork_a.State
```

**Before this PR**, the generated `state_ssz.go` inlined the
`Checkpoint` body (`Epoch` and `Root` fields written field-by-field) into
the view marshaler/unmarshaler, even though `fork_a.Checkpoint` already
has its own SSZ methods.

**After this PR**, the generated code delegates:

```go
if dst, err = t.Checkpoint.MarshalSSZTo(dst); err != nil { ... }
```

Code size on real-world fork-agnostic union types (large beacon-state
schemas with 8–9 views referencing many shared sub-structs) drops by
roughly 25–45% per file, with the savings concentrated on the largest
files.

## Root cause

`go/packages.Load` builds a fresh `go/types.Importer` per call. Calling
it twice — once for the main package, once for an external view-type
package — produces independent type graphs. Even when both graphs end up
importing the same package, the resulting `*types.Named` for any shared
type is a different pointer instance.

Note that `types.Identical` would not have helped here — for named types
it ultimately compares `*types.TypeName` (`obj`) pointers, which are
also distinct across separate `Load` calls. The fix has to ensure types
**are** pointer-identical, by sharing the loader graph between the main
package and any view-type package that already lives in the main
package's import closure.

## Changes

`dynssz-gen/main.go` only:

1. Add `packages.NeedImports | packages.NeedDeps` to the loader `Mode`.
   This makes the main package's transitive imports reachable as
   fully-typed `*packages.Package` instances via `pkg.Imports` instead
   of placeholder stubs.

2. Walk the main package's transitive `Imports` graph once after load
   and seed the external-package cache with each
   `(canonical-import-path, *packages.Package)` pair. Subsequent
   external-package lookups whose path matches an already-seeded entry
   return the seeded copy directly with no extra `Load`.

3. For paths the seed map doesn't recognize (relative patterns like
   `../foo`, or genuinely external packages), fall back to the existing
   `packages.Load`. After the load, look up the seeded map by the
   resulting `pkg.PkgPath`. If the canonical path is already seeded,
   discard the freshly-loaded copy and use the seeded one — this catches
   the relative-path case where the main package already pulled in the
   target via its canonical path but the view reference was written
   relatively.

No public API changes. The parser's pointer-equality comparisons stay
unchanged — they now work correctly because the input pointers are
actually identical.

## Verification

- All existing `codegen/...` and `dynssz-gen/...` test suites pass
  unchanged.
- Manual regeneration of a representative fork-agnostic union package
  (13 view-only types with 2–9 views each) produces compact, building,
  vetting code with delegation calls in place of inlined struct bodies.

## Behavioural compatibility

The change is additive:

- Codegen runs without view types are unaffected (the seed loop still
  fires but the canonical-PkgPath path is never taken on cache miss
  because no external lookups occur).
- Runs whose view types live **outside** the main package's import
  closure are also unaffected: the seed map doesn't have them, the
  fresh `Load` populates the cache, and the parser proceeds exactly as
  before. The only observable difference is one extra cache write keyed
  on the canonical path, which short-circuits subsequent lookups via
  alternate path spellings — a pure perf win.
- Runs whose view types **are** in the main package's import closure
  (the case this PR fixes) stop misclassifying nested fields and emit
  delegations instead of inlined byte-twiddling. Functionally equivalent
  to what the per-fork generator already produces; only the shape of the
  emitted code changes.

No change to the SSZ wire format, the public API of generated methods,
or the codegen CLI.

## Risks

- **Memory / load time**: `NeedDeps` causes the loader to keep the full
  transitive type graph in memory. For typical projects this is on the
  order of a few MB. Cold-cache load time grows slightly because more
  type info has to be populated; warm cache is unaffected.
- No risk of incorrect output: the seeded cache entries are real
  `*packages.Package` instances from `go/packages`, not synthetic
  re-imports. Types and method sets are exactly what the main package
  sees.