### PR TITLE
implement optionals as `List[T,1]`

### DIFF
--- a/codegen/gen_decoder.go
+++ b/codegen/gen_decoder.go
@@ -1118,7 +1118,7 @@ func (ctx *decoderContext) unmarshalOptionalList(desc *ssztypes.TypeDescriptor, 
 	}
 	valVar := ctx.getValVar()
 	ctx.appendCode(indent+1, "var %s %s\n", valVar, ctx.typePrinter.TypeString(desc.ElemDesc))
-	if err := ctx.unmarshalType(desc.ElemDesc, valVar, typePath, indent+1, false, true); err != nil {
+	if err := ctx.unmarshalType(desc.ElemDesc, valVar, typePath.append("[0]"), indent+1, false, true); err != nil {
 		return err
 	}
 	ctx.appendCode(indent+1, "%s = &%s\n", varName, valVar)

--- a/codegen/gen_decoder.go
+++ b/codegen/gen_decoder.go
@@ -412,6 +412,8 @@ func (ctx *decoderContext) unmarshalType(desc *ssztypes.TypeDescriptor, varName 
 		ctx.appendCode(indent, "}\n")
 	case ssztypes.SszOptionalType:
 		return ctx.unmarshalOptional(desc, varName, typePath, indent)
+	case ssztypes.SszOptionalListType:
+		return ctx.unmarshalOptionalList(desc, varName, typePath, indent)
 	case ssztypes.SszBigIntType:
 		return ctx.unmarshalBigInt(desc, varName, typePath, indent)
 
@@ -491,7 +493,8 @@ func (ctx *decoderContext) unmarshalContainer(desc *ssztypes.TypeDescriptor, var
 			} else {
 				ctx.appendCode(indent, "// Field #%d '%s' (static)\n", idx, field.Name)
 			}
-			if field.Type.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 {
+			// Optional and optional-list manage their own pointer allocation: nil means absent.
+			if field.Type.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 && field.Type.SszType != ssztypes.SszOptionalType && field.Type.SszType != ssztypes.SszOptionalListType {
 				ctx.appendCode(indent+inlineIndent, "if %s == nil {\n\t%s = new(%s)\n}\n", valVar, valVar, ctx.typePrinter.InnerTypeString(field.Type))
 			}
 
@@ -526,7 +529,8 @@ func (ctx *decoderContext) unmarshalContainer(desc *ssztypes.TypeDescriptor, var
 		valVar := ctx.getValVar()
 		ctx.appendCode(indent+1, "%s := %s.%s\n", valVar, varName, field.Name)
 
-		if field.Type.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 {
+		// Optional and optional-list manage their own pointer allocation: nil means absent.
+		if field.Type.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 && field.Type.SszType != ssztypes.SszOptionalType && field.Type.SszType != ssztypes.SszOptionalListType {
 			ctx.appendCode(indent+1, "if %s == nil {\n\t%s = new(%s)\n}\n", valVar, valVar, ctx.typePrinter.InnerTypeString(field.Type))
 		}
 
@@ -1075,18 +1079,49 @@ func (ctx *decoderContext) unmarshalOptional(desc *ssztypes.TypeDescriptor, varN
 	ctx.appendCode(indent, "if hasVal, err := dec.DecodeBool(); err != nil {\n")
 	ctx.appendCode(indent+1, "return %s\n", typePath.getErrorWith("err"))
 	ctx.appendCode(indent, "} else if hasVal {\n")
-	ptrVarName := varName
-	if desc.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 {
-		ptrVarName = fmt.Sprintf("*(%s)", varName)
-	}
 	valVar := ctx.getValVar()
-	ctx.appendCode(indent+1, "\tvar %s %s\n", valVar, ctx.typePrinter.TypeString(desc.ElemDesc))
+	ctx.appendCode(indent+1, "var %s %s\n", valVar, ctx.typePrinter.TypeString(desc.ElemDesc))
 	if err := ctx.unmarshalType(desc.ElemDesc, valVar, typePath, indent+1, false, true); err != nil {
 		return err
 	}
-	ctx.appendCode(indent+1, "\t%s = %s\n", ptrVarName, valVar)
+	// Assign a fresh pointer rather than dereferencing varName — varName may be
+	// nil here since optional manages its own allocation.
+	if desc.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 {
+		ctx.appendCode(indent+1, "%s = &%s\n", varName, valVar)
+	} else {
+		ctx.appendCode(indent+1, "%s = %s\n", varName, valVar)
+	}
 	ctx.appendCode(indent, "} else {\n")
-	ctx.appendCode(indent+1, "\t%s = nil\n", varName)
+	ctx.appendCode(indent+1, "%s = nil\n", varName)
+	ctx.appendCode(indent, "}\n")
+	return nil
+}
+
+// unmarshalOptionalList generates unmarshal code for optional-list (canonical List[T, 1]).
+//
+// Empty buffer → nil pointer. Otherwise: if the element is dynamic, read and
+// validate a 4-byte offset header (must equal 4); then unmarshal the single
+// element and assign a fresh pointer to it.
+func (ctx *decoderContext) unmarshalOptionalList(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int) error {
+	ctx.appendCode(indent, "if dec.GetLength() == 0 {\n")
+	ctx.appendCode(indent+1, "%s = nil\n", varName)
+	ctx.appendCode(indent, "} else {\n")
+	if desc.ElemDesc.SszTypeFlags&ssztypes.SszTypeFlagIsDynamic != 0 {
+		errCodeEOF := "sszutils.ErrListOffsetsEOFFn(dec.GetLength(), 4)"
+		ctx.appendCode(indent+1, "if dec.GetLength() < 4 {\n\treturn %s\n}\n", typePath.getErrorWith(errCodeEOF))
+		ctx.appendCode(indent+1, "if firstOffset, err := dec.DecodeOffset(); err != nil {\n")
+		ctx.appendCode(indent+2, "return %s\n", typePath.getErrorWith("err"))
+		ctx.appendCode(indent+1, "} else if firstOffset != 4 {\n")
+		errCodeOffset := "sszutils.ErrFirstOffsetMismatchFn(firstOffset, uint32(4))"
+		ctx.appendCode(indent+2, "return %s\n", typePath.getErrorWith(errCodeOffset))
+		ctx.appendCode(indent+1, "}\n")
+	}
+	valVar := ctx.getValVar()
+	ctx.appendCode(indent+1, "var %s %s\n", valVar, ctx.typePrinter.TypeString(desc.ElemDesc))
+	if err := ctx.unmarshalType(desc.ElemDesc, valVar, typePath, indent+1, false, true); err != nil {
+		return err
+	}
+	ctx.appendCode(indent+1, "%s = &%s\n", varName, valVar)
 	ctx.appendCode(indent, "}\n")
 	return nil
 }

--- a/codegen/gen_encoder.go
+++ b/codegen/gen_encoder.go
@@ -274,7 +274,7 @@ func (ctx *encoderContext) generateEncodeContext(indent int) string {
 
 // marshalType generates marshal code for any SSZ type, delegating to specific marshalers.
 func (ctx *encoderContext) marshalType(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int, isRoot bool) error {
-	if desc.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 && desc.SszType != ssztypes.SszOptionalType {
+	if desc.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 && desc.SszType != ssztypes.SszOptionalType && desc.SszType != ssztypes.SszOptionalListType {
 		ctx.appendCode(indent, "if %s == nil {\n\t%s = new(%s)\n}\n", varName, varName, ctx.typePrinter.InnerTypeString(desc))
 	}
 
@@ -395,6 +395,8 @@ func (ctx *encoderContext) marshalType(desc *ssztypes.TypeDescriptor, varName st
 		ctx.appendCode(indent, "enc.EncodeUint64(%s.Float64bits(%s))\n", mathImport, ctx.getValueVar(desc, varName, "float64"))
 	case ssztypes.SszOptionalType:
 		return ctx.marshalOptional(desc, varName, typePath, indent)
+	case ssztypes.SszOptionalListType:
+		return ctx.marshalOptionalList(desc, varName, typePath, indent)
 	case ssztypes.SszBigIntType:
 		return ctx.marshalBigInt(desc, varName, indent)
 
@@ -411,6 +413,23 @@ func (ctx *encoderContext) marshalOptional(desc *ssztypes.TypeDescriptor, varNam
 	ctx.appendCode(indent+1, "enc.EncodeBool(false)\n")
 	ctx.appendCode(indent, "} else {\n")
 	ctx.appendCode(indent+1, "enc.EncodeBool(true)\n")
+	innerVarName := fmt.Sprintf("(*%s)", varName)
+	if err := ctx.marshalType(desc.ElemDesc, innerVarName, typePath, indent+1, false); err != nil {
+		return err
+	}
+	ctx.appendCode(indent, "}\n")
+	return nil
+}
+
+// marshalOptionalList generates marshal code for optional-list (canonical List[T, 1]).
+//
+// nil → empty list (no bytes); non-nil → single-element list. When the element
+// is dynamic, a 4-byte offset (=4) precedes the element bytes.
+func (ctx *encoderContext) marshalOptionalList(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int) error {
+	ctx.appendCode(indent, "if %s != nil {\n", varName)
+	if desc.ElemDesc.SszTypeFlags&ssztypes.SszTypeFlagIsDynamic != 0 {
+		ctx.appendCode(indent+1, "enc.EncodeOffset(4)\n")
+	}
 	innerVarName := fmt.Sprintf("(*%s)", varName)
 	if err := ctx.marshalType(desc.ElemDesc, innerVarName, typePath, indent+1, false); err != nil {
 		return err

--- a/codegen/gen_encoder.go
+++ b/codegen/gen_encoder.go
@@ -431,7 +431,7 @@ func (ctx *encoderContext) marshalOptionalList(desc *ssztypes.TypeDescriptor, va
 		ctx.appendCode(indent+1, "enc.EncodeOffset(4)\n")
 	}
 	innerVarName := fmt.Sprintf("(*%s)", varName)
-	if err := ctx.marshalType(desc.ElemDesc, innerVarName, typePath, indent+1, false); err != nil {
+	if err := ctx.marshalType(desc.ElemDesc, innerVarName, typePath.append("[0]"), indent+1, false); err != nil {
 		return err
 	}
 	ctx.appendCode(indent, "}\n")

--- a/codegen/gen_hashtreeroot.go
+++ b/codegen/gen_hashtreeroot.go
@@ -228,7 +228,7 @@ func (ctx *hashTreeRootContext) getPtrPrefix(desc *ssztypes.TypeDescriptor, pref
 
 // hashType generates hash tree root code for any SSZ type, delegating to specific hashers.
 func (ctx *hashTreeRootContext) hashType(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int, isRoot, pack bool) error {
-	if desc.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 && desc.SszType != ssztypes.SszOptionalType {
+	if desc.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 && desc.SszType != ssztypes.SszOptionalType && desc.SszType != ssztypes.SszOptionalListType {
 		ctx.appendCode(indent, "if %s == nil {\n\t%s = new(%s)\n}\n", varName, varName, ctx.typePrinter.InnerTypeString(desc))
 	}
 
@@ -393,6 +393,8 @@ func (ctx *hashTreeRootContext) hashType(desc *ssztypes.TypeDescriptor, varName 
 		}
 	case ssztypes.SszOptionalType:
 		return ctx.hashOptional(desc, varName, typePath, indent)
+	case ssztypes.SszOptionalListType:
+		return ctx.hashOptionalList(desc, varName, typePath, indent)
 	case ssztypes.SszBigIntType:
 		return ctx.hashBigInt(desc, varName, indent)
 
@@ -412,6 +414,29 @@ func (ctx *hashTreeRootContext) hashOptional(desc *ssztypes.TypeDescriptor, varN
 	if err := ctx.hashType(desc.ElemDesc, innerVarName, typePath, indent+1, false, false); err != nil {
 		return err
 	}
+	ctx.appendCode(indent, "}\n")
+	return nil
+}
+
+// hashOptionalList generates hash tree root code for optional-list (canonical List[T, 1]).
+//
+// Builds a binary tree containing zero or one element chunk, then mixes in
+// the length (0 or 1). The merkleization limit is always 1 (one chunk for
+// basic elements ≤32 bytes, or one element for complex elements).
+func (ctx *hashTreeRootContext) hashOptionalList(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int) error {
+	// Wrap in braces so `idx` and `vlen` don't collide with any caller's locals.
+	ctx.appendCode(indent, "{\n")
+	ctx.appendCode(indent+1, "idx := hh.StartTree(sszutils.TreeTypeBinary)\n")
+	ctx.appendCode(indent+1, "vlen := uint64(0)\n")
+	ctx.appendCode(indent+1, "if %s != nil {\n", varName)
+	innerVarName := fmt.Sprintf("(*%s)", varName)
+	if err := ctx.hashType(desc.ElemDesc, innerVarName, typePath.append("[0]"), indent+2, false, true); err != nil {
+		return err
+	}
+	ctx.appendCode(indent+2, "vlen = 1\n")
+	ctx.appendCode(indent+1, "}\n")
+	ctx.appendCode(indent+1, "hh.FillUpTo32()\n")
+	ctx.appendCode(indent+1, "hh.MerkleizeWithMixin(idx, vlen, 1)\n")
 	ctx.appendCode(indent, "}\n")
 	return nil
 }

--- a/codegen/gen_marshal.go
+++ b/codegen/gen_marshal.go
@@ -408,7 +408,7 @@ func (ctx *marshalContext) marshalOptionalList(desc *ssztypes.TypeDescriptor, va
 		ctx.appendCode(indent+1, "dst = %s.LittleEndian.AppendUint32(dst, 4)\n", binaryPkg)
 	}
 	innerVarName := fmt.Sprintf("(*%s)", varName)
-	if err := ctx.marshalType(desc.ElemDesc, innerVarName, typePath, indent+1, false); err != nil {
+	if err := ctx.marshalType(desc.ElemDesc, innerVarName, typePath.append("[0]"), indent+1, false); err != nil {
 		return err
 	}
 	ctx.appendCode(indent, "}\n")

--- a/codegen/gen_marshal.go
+++ b/codegen/gen_marshal.go
@@ -202,7 +202,7 @@ func (ctx *marshalContext) isInlineable(desc *ssztypes.TypeDescriptor) bool {
 
 // marshalType generates marshal code for any SSZ type, delegating to specific marshalers.
 func (ctx *marshalContext) marshalType(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int, isRoot bool) error {
-	if desc.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 && desc.SszType != ssztypes.SszOptionalType {
+	if desc.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 && desc.SszType != ssztypes.SszOptionalType && desc.SszType != ssztypes.SszOptionalListType {
 		ctx.appendCode(indent, "if %s == nil {\n\t%s = new(%s)\n}\n", varName, varName, ctx.typePrinter.InnerTypeString(desc))
 	}
 
@@ -371,6 +371,8 @@ func (ctx *marshalContext) marshalType(desc *ssztypes.TypeDescriptor, varName st
 		)
 	case ssztypes.SszOptionalType:
 		return ctx.marshalOptional(desc, varName, typePath, indent)
+	case ssztypes.SszOptionalListType:
+		return ctx.marshalOptionalList(desc, varName, typePath, indent)
 	case ssztypes.SszBigIntType:
 		return ctx.marshalBigInt(desc, varName, indent)
 
@@ -387,6 +389,24 @@ func (ctx *marshalContext) marshalOptional(desc *ssztypes.TypeDescriptor, varNam
 	ctx.appendCode(indent+1, "dst = sszutils.MarshalBool(dst, false)\n")
 	ctx.appendCode(indent, "} else {\n")
 	ctx.appendCode(indent+1, "dst = sszutils.MarshalBool(dst, true)\n")
+	innerVarName := fmt.Sprintf("(*%s)", varName)
+	if err := ctx.marshalType(desc.ElemDesc, innerVarName, typePath, indent+1, false); err != nil {
+		return err
+	}
+	ctx.appendCode(indent, "}\n")
+	return nil
+}
+
+// marshalOptionalList generates marshal code for optional-list (canonical List[T, 1]).
+//
+// nil → empty list (no bytes); non-nil → single-element list. When the element
+// is dynamic, a 4-byte offset (=4) precedes the element bytes.
+func (ctx *marshalContext) marshalOptionalList(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int) error {
+	ctx.appendCode(indent, "if %s != nil {\n", varName)
+	if desc.ElemDesc.SszTypeFlags&ssztypes.SszTypeFlagIsDynamic != 0 {
+		binaryPkg := ctx.typePrinter.AddImport("encoding/binary", "binary")
+		ctx.appendCode(indent+1, "dst = %s.LittleEndian.AppendUint32(dst, 4)\n", binaryPkg)
+	}
 	innerVarName := fmt.Sprintf("(*%s)", varName)
 	if err := ctx.marshalType(desc.ElemDesc, innerVarName, typePath, indent+1, false); err != nil {
 		return err

--- a/codegen/gen_size.go
+++ b/codegen/gen_size.go
@@ -244,7 +244,7 @@ func (ctx *sizeContext) sizeType(desc *ssztypes.TypeDescriptor, varName, sizeVar
 	}
 
 	// create temporary instance for nil pointers
-	if desc.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 && desc.SszType != ssztypes.SszOptionalType {
+	if desc.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 && desc.SszType != ssztypes.SszOptionalType && desc.SszType != ssztypes.SszOptionalListType {
 		if len(varName) > 1 {
 			ctx.appendCode(indent, "t := %s\n", varName)
 			varName = "t"
@@ -308,6 +308,8 @@ func (ctx *sizeContext) sizeType(desc *ssztypes.TypeDescriptor, varName, sizeVar
 		ctx.appendCode(indent, "%s += 8\n", sizeVar)
 	case ssztypes.SszOptionalType:
 		return ctx.sizeOptional(desc, varName, sizeVar, indent)
+	case ssztypes.SszOptionalListType:
+		return ctx.sizeOptionalList(desc, varName, sizeVar, indent)
 	case ssztypes.SszBigIntType:
 		ctx.appendCode(indent, "%s += len(%s.Bytes())\n", sizeVar, varName)
 
@@ -322,6 +324,23 @@ func (ctx *sizeContext) sizeType(desc *ssztypes.TypeDescriptor, varName, sizeVar
 func (ctx *sizeContext) sizeOptional(desc *ssztypes.TypeDescriptor, varName, sizeVar string, indent int) error {
 	ctx.appendCode(indent, "%s += 1 // presence byte\n", sizeVar)
 	ctx.appendCode(indent, "if %s != nil {\n", varName)
+	innerVarName := fmt.Sprintf("(*%s)", varName)
+	if err := ctx.sizeType(desc.ElemDesc, innerVarName, sizeVar, indent+1, false); err != nil {
+		return err
+	}
+	ctx.appendCode(indent, "}\n")
+	return nil
+}
+
+// sizeOptionalList generates size calculation code for optional-list (canonical List[T, 1]).
+//
+// nil → 0 bytes. Non-nil → size of the single element, plus 4 bytes for the
+// offset header when the element is dynamic.
+func (ctx *sizeContext) sizeOptionalList(desc *ssztypes.TypeDescriptor, varName, sizeVar string, indent int) error {
+	ctx.appendCode(indent, "if %s != nil {\n", varName)
+	if desc.ElemDesc.SszTypeFlags&ssztypes.SszTypeFlagIsDynamic != 0 {
+		ctx.appendCode(indent+1, "%s += 4 // optional-list offset header\n", sizeVar)
+	}
 	innerVarName := fmt.Sprintf("(*%s)", varName)
 	if err := ctx.sizeType(desc.ElemDesc, innerVarName, sizeVar, indent+1, false); err != nil {
 		return err

--- a/codegen/gen_unmarshal.go
+++ b/codegen/gen_unmarshal.go
@@ -534,7 +534,7 @@ func (ctx *unmarshalContext) unmarshalOptionalList(desc *ssztypes.TypeDescriptor
 	}
 	valVar := ctx.getValVar()
 	ctx.appendCode(indent+1, "var %s %s\n", valVar, ctx.typePrinter.TypeString(desc.ElemDesc))
-	if err := ctx.unmarshalType(desc.ElemDesc, valVar, typePath, indent+1, false, true); err != nil {
+	if err := ctx.unmarshalType(desc.ElemDesc, valVar, typePath.append("[0]"), indent+1, false, true); err != nil {
 		return err
 	}
 	ctx.appendCode(indent+1, "%s = &%s\n", varName, valVar)

--- a/codegen/gen_unmarshal.go
+++ b/codegen/gen_unmarshal.go
@@ -477,6 +477,8 @@ func (ctx *unmarshalContext) unmarshalType(desc *ssztypes.TypeDescriptor, varNam
 		)
 	case ssztypes.SszOptionalType:
 		return ctx.unmarshalOptional(desc, varName, typePath, indent)
+	case ssztypes.SszOptionalListType:
+		return ctx.unmarshalOptionalList(desc, varName, typePath, indent)
 	case ssztypes.SszBigIntType:
 		return ctx.unmarshalBigInt(desc, varName, indent)
 
@@ -507,6 +509,35 @@ func (ctx *unmarshalContext) unmarshalOptional(desc *ssztypes.TypeDescriptor, va
 	ctx.appendCode(indent+1, "%s = &%s\n", varName, valVar)
 	ctx.appendCode(indent, "} else {\n")
 	ctx.appendCode(indent+1, "%s = nil\n", varName)
+	ctx.appendCode(indent, "}\n")
+	return nil
+}
+
+// unmarshalOptionalList generates unmarshal code for optional-list (canonical List[T, 1]).
+//
+// Empty buf → nil pointer. Otherwise: if the element is dynamic, validate that
+// buf has at least 4 bytes for the offset header, check the offset equals 4,
+// then slice buf to skip the header. Finally allocate the pointer and
+// unmarshal the single element from the remaining bytes.
+func (ctx *unmarshalContext) unmarshalOptionalList(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int) error {
+	ctx.appendCode(indent, "if len(buf) == 0 {\n")
+	ctx.appendCode(indent+1, "%s = nil\n", varName)
+	ctx.appendCode(indent, "} else {\n")
+	if desc.ElemDesc.SszTypeFlags&ssztypes.SszTypeFlagIsDynamic != 0 {
+		errEOF := "sszutils.ErrListOffsetsEOFFn(len(buf), 4)"
+		ctx.appendCode(indent+1, "if len(buf) < 4 {\n\treturn %s\n}\n", typePath.getErrorWith(errEOF))
+		binaryImport := ctx.typePrinter.AddImport("encoding/binary", "binary")
+		ctx.appendCode(indent+1, "firstOffset := %s.LittleEndian.Uint32(buf[:4])\n", binaryImport)
+		errOffset := "sszutils.ErrFirstOffsetMismatchFn(firstOffset, uint32(4))"
+		ctx.appendCode(indent+1, "if firstOffset != 4 {\n\treturn %s\n}\n", typePath.getErrorWith(errOffset))
+		ctx.appendCode(indent+1, "buf := buf[4:]\n")
+	}
+	valVar := ctx.getValVar()
+	ctx.appendCode(indent+1, "var %s %s\n", valVar, ctx.typePrinter.TypeString(desc.ElemDesc))
+	if err := ctx.unmarshalType(desc.ElemDesc, valVar, typePath, indent+1, false, true); err != nil {
+		return err
+	}
+	ctx.appendCode(indent+1, "%s = &%s\n", varName, valVar)
 	ctx.appendCode(indent, "}\n")
 	return nil
 }
@@ -608,7 +639,8 @@ func (ctx *unmarshalContext) unmarshalContainer(desc *ssztypes.TypeDescriptor, v
 				valVar = ctx.getValVar()
 				ctx.appendCode(indent, "\t%s := %s.%s\n", valVar, varName, field.Name)
 			}
-			if field.Type.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 {
+			// Optional and optional-list manage their own pointer allocation: nil means absent.
+			if field.Type.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 && field.Type.SszType != ssztypes.SszOptionalType && field.Type.SszType != ssztypes.SszOptionalListType {
 				ctx.appendCode(indent+1, "if %s == nil {\n\t%s = new(%s)\n}\n", valVar, valVar, ctx.typePrinter.InnerTypeString(field.Type))
 			}
 
@@ -641,7 +673,8 @@ func (ctx *unmarshalContext) unmarshalContainer(desc *ssztypes.TypeDescriptor, v
 			ctx.appendCode(indent, "\t%s := %s.%s\n", valVar, varName, field.Name)
 		}
 
-		if field.Type.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 {
+		// Optional and optional-list manage their own pointer allocation: nil means absent.
+		if field.Type.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 && field.Type.SszType != ssztypes.SszOptionalType && field.Type.SszType != ssztypes.SszOptionalListType {
 			ctx.appendCode(indent+1, "if %s == nil {\n\t%s = new(%s)\n}\n", valVar, valVar, ctx.typePrinter.InnerTypeString(field.Type))
 		}
 

--- a/codegen/parser.go
+++ b/codegen/parser.go
@@ -681,7 +681,7 @@ func (p *Parser) buildTypeDescriptor(dataType, schemaType types.Type, typeHints 
 		if ptrType == nil {
 			return nil, fmt.Errorf("optional ssz type can only be represented by pointer types, got %v", desc.Kind)
 		}
-		err := p.buildOptionalDescriptor(desc, innerDataType, sizeHints, maxSizeHints, typeHints)
+		err := p.buildOptionalDescriptor(desc, innerDataType, innerSchemaType, sizeHints, maxSizeHints, typeHints)
 		if err != nil {
 			return nil, err
 		}
@@ -690,7 +690,7 @@ func (p *Parser) buildTypeDescriptor(dataType, schemaType types.Type, typeHints 
 		if ptrType == nil {
 			return nil, fmt.Errorf("optional-list ssz type can only be represented by pointer types, got %v", desc.Kind)
 		}
-		err := p.buildOptionalListDescriptor(desc, innerDataType, sizeHints, maxSizeHints, typeHints)
+		err := p.buildOptionalListDescriptor(desc, innerDataType, innerSchemaType, sizeHints, maxSizeHints, typeHints)
 		if err != nil {
 			return nil, err
 		}
@@ -1388,7 +1388,7 @@ func (p *Parser) buildTypeWrapperDescriptor(desc *ssztypes.TypeDescriptor, dataN
 	return nil
 }
 
-func (p *Parser) buildOptionalDescriptor(desc *ssztypes.TypeDescriptor, typ types.Type, sizeHints []ssztypes.SszSizeHint, maxSizeHints []ssztypes.SszMaxSizeHint, typeHints []ssztypes.SszTypeHint) error {
+func (p *Parser) buildOptionalDescriptor(desc *ssztypes.TypeDescriptor, dataType, schemaType types.Type, sizeHints []ssztypes.SszSizeHint, maxSizeHints []ssztypes.SszMaxSizeHint, typeHints []ssztypes.SszTypeHint) error {
 	// Optional is always dynamic size (1 byte for presence + variable data)
 	desc.Size = 0
 	desc.SszTypeFlags |= ssztypes.SszTypeFlagIsDynamic
@@ -1412,7 +1412,7 @@ func (p *Parser) buildOptionalDescriptor(desc *ssztypes.TypeDescriptor, typ type
 		childTypeHints = typeHints[1:]
 	}
 
-	elemDesc, err := p.buildTypeDescriptor(typ, typ, childTypeHints, childSizeHints, childMaxSizeHints)
+	elemDesc, err := p.buildTypeDescriptor(dataType, schemaType, childTypeHints, childSizeHints, childMaxSizeHints)
 	if err != nil {
 		return err
 	}
@@ -1431,7 +1431,7 @@ func (p *Parser) buildOptionalDescriptor(desc *ssztypes.TypeDescriptor, typ type
 // nil encodes as an empty list (no bytes), non-nil encodes as a list with a
 // single element. Unlike SszOptionalType, this is a canonical SSZ encoding
 // with no custom presence flag and is allowed regardless of ExtendedTypes.
-func (p *Parser) buildOptionalListDescriptor(desc *ssztypes.TypeDescriptor, typ types.Type, sizeHints []ssztypes.SszSizeHint, maxSizeHints []ssztypes.SszMaxSizeHint, typeHints []ssztypes.SszTypeHint) error {
+func (p *Parser) buildOptionalListDescriptor(desc *ssztypes.TypeDescriptor, dataType, schemaType types.Type, sizeHints []ssztypes.SszSizeHint, maxSizeHints []ssztypes.SszMaxSizeHint, typeHints []ssztypes.SszTypeHint) error {
 	if desc.GoTypeFlags&ssztypes.GoTypeFlagIsPointer == 0 {
 		return fmt.Errorf("optional-list ssz type can only be represented by pointer types, got %v", desc.Kind)
 	}
@@ -1451,7 +1451,7 @@ func (p *Parser) buildOptionalListDescriptor(desc *ssztypes.TypeDescriptor, typ 
 		childTypeHints = typeHints[1:]
 	}
 
-	elemDesc, err := p.buildTypeDescriptor(typ, typ, childTypeHints, childSizeHints, childMaxSizeHints)
+	elemDesc, err := p.buildTypeDescriptor(dataType, schemaType, childTypeHints, childSizeHints, childMaxSizeHints)
 	if err != nil {
 		return err
 	}

--- a/codegen/parser.go
+++ b/codegen/parser.go
@@ -681,7 +681,16 @@ func (p *Parser) buildTypeDescriptor(dataType, schemaType types.Type, typeHints 
 		if ptrType == nil {
 			return nil, fmt.Errorf("optional ssz type can only be represented by pointer types, got %v", desc.Kind)
 		}
-		err := p.buildOptionalDescriptor(desc, dataType, sizeHints, maxSizeHints, typeHints)
+		err := p.buildOptionalDescriptor(desc, innerDataType, sizeHints, maxSizeHints, typeHints)
+		if err != nil {
+			return nil, err
+		}
+	case ssztypes.SszOptionalListType:
+		// optional-list expresses a pointer as a canonical List[T, 1]; allowed without ExtendedTypes
+		if ptrType == nil {
+			return nil, fmt.Errorf("optional-list ssz type can only be represented by pointer types, got %v", desc.Kind)
+		}
+		err := p.buildOptionalListDescriptor(desc, innerDataType, sizeHints, maxSizeHints, typeHints)
 		if err != nil {
 			return nil, err
 		}
@@ -761,6 +770,22 @@ func (p *Parser) buildTypeDescriptor(dataType, schemaType types.Type, typeHints 
 	}
 
 	desc.SszCompatFlags |= p.getCompatFlag(innerDataType, innerSchemaType)
+
+	// Optional and optional-list reshape the encoding around the inner type
+	// (presence byte / List[T,1] framing). The inner type's own SSZ methods
+	// must not be invoked at this level — they would skip the framing and
+	// emit the inner value as if it were the canonical encoding.
+	if desc.SszType == ssztypes.SszOptionalType || desc.SszType == ssztypes.SszOptionalListType {
+		desc.SszCompatFlags &^= ssztypes.SszCompatFlagDynamicMarshaler |
+			ssztypes.SszCompatFlagDynamicUnmarshaler |
+			ssztypes.SszCompatFlagDynamicSizer |
+			ssztypes.SszCompatFlagDynamicHashRoot |
+			ssztypes.SszCompatFlagDynamicEncoder |
+			ssztypes.SszCompatFlagDynamicDecoder |
+			ssztypes.SszCompatFlagFastSSZMarshaler |
+			ssztypes.SszCompatFlagFastSSZHasher |
+			ssztypes.SszCompatFlagHashTreeRootWith
+	}
 
 	if desc.SszType == ssztypes.SszCustomType {
 		isCompatible := desc.SszCompatFlags&ssztypes.SszCompatFlagFastSSZMarshaler != 0 && desc.SszCompatFlags&ssztypes.SszCompatFlagFastSSZHasher != 0
@@ -1396,6 +1421,47 @@ func (p *Parser) buildOptionalDescriptor(desc *ssztypes.TypeDescriptor, typ type
 
 	// The Optional inherits properties from the child type
 	desc.SszTypeFlags |= elemDesc.SszTypeFlags & (ssztypes.SszTypeFlagIsDynamic | ssztypes.SszTypeFlagHasDynamicSize | ssztypes.SszTypeFlagHasDynamicMax | ssztypes.SszTypeFlagHasSizeExpr | ssztypes.SszTypeFlagHasMaxExpr)
+
+	return nil
+}
+
+// buildOptionalListDescriptor builds a descriptor for optional-list types.
+//
+// An optional-list expresses a Go pointer as a canonical SSZ List[T, 1]:
+// nil encodes as an empty list (no bytes), non-nil encodes as a list with a
+// single element. Unlike SszOptionalType, this is a canonical SSZ encoding
+// with no custom presence flag and is allowed regardless of ExtendedTypes.
+func (p *Parser) buildOptionalListDescriptor(desc *ssztypes.TypeDescriptor, typ types.Type, sizeHints []ssztypes.SszSizeHint, maxSizeHints []ssztypes.SszMaxSizeHint, typeHints []ssztypes.SszTypeHint) error {
+	if desc.GoTypeFlags&ssztypes.GoTypeFlagIsPointer == 0 {
+		return fmt.Errorf("optional-list ssz type can only be represented by pointer types, got %v", desc.Kind)
+	}
+
+	childSizeHints := []ssztypes.SszSizeHint{}
+	if len(sizeHints) > 1 {
+		childSizeHints = sizeHints[1:]
+	}
+
+	childMaxSizeHints := []ssztypes.SszMaxSizeHint{}
+	if len(maxSizeHints) > 1 {
+		childMaxSizeHints = maxSizeHints[1:]
+	}
+
+	childTypeHints := []ssztypes.SszTypeHint{}
+	if len(typeHints) > 1 {
+		childTypeHints = typeHints[1:]
+	}
+
+	elemDesc, err := p.buildTypeDescriptor(typ, typ, childTypeHints, childSizeHints, childMaxSizeHints)
+	if err != nil {
+		return err
+	}
+
+	desc.ElemDesc = elemDesc
+	// canonical List[T, 1]: always dynamic, limit fixed at 1 element
+	desc.Size = 0
+	desc.Limit = 1
+	desc.SszTypeFlags |= ssztypes.SszTypeFlagIsDynamic | ssztypes.SszTypeFlagHasLimit
+	desc.SszTypeFlags |= elemDesc.SszTypeFlags & (ssztypes.SszTypeFlagHasDynamicSize | ssztypes.SszTypeFlagHasDynamicMax | ssztypes.SszTypeFlagHasSizeExpr | ssztypes.SszTypeFlagHasMaxExpr)
 
 	return nil
 }

--- a/codegen/tests/codegen_test.go
+++ b/codegen/tests/codegen_test.go
@@ -210,6 +210,25 @@ func TestCodegenNoDynExprTypes(t *testing.T) {
 	testCodegenPayloadByReflection(t, NoDynExprTypes_Payload, nil)
 }
 
+// TestCodegenOptionalListTypes verifies generated code for ssz-type:"optional-list"
+// matches the reflection implementation. Optional-list expresses a pointer as
+// a canonical SSZ List[T, 1] and works without extended types.
+func TestCodegenOptionalListTypes(t *testing.T) {
+	payloads := []struct {
+		name    string
+		payload OptionalListTypes
+	}{
+		{"BothSet", OptionalListTypes_Payload1},
+		{"BothNil", OptionalListTypes_Payload2},
+		{"StaticOnly", OptionalListTypes_Payload3},
+	}
+	for _, tc := range payloads {
+		t.Run(tc.name, func(t *testing.T) {
+			testCodegenPayloadByReflection(t, tc.payload, nil)
+		})
+	}
+}
+
 // TestCodegenViewTypes2 tests nested view dispatch: a container whose child
 // has view dispatch methods. This exercises the isView code paths in all
 // generators (marshal, unmarshal, encoder, decoder, size, hash).

--- a/codegen/tests/gen_ssz.yaml
+++ b/codegen/tests/gen_ssz.yaml
@@ -48,6 +48,11 @@ types:
   - name: CoverageTypes7
     output: gen_coverage7.go
 
+  - name: OptionalListTypes
+    output: gen_optionallist.go
+  - name: OptionalListTypes_Inner
+    output: gen_optionallist.go
+
   - name: ViewTypes1_Base
     output: gen_viewtypes1.go
     views:

--- a/codegen/tests/types.go
+++ b/codegen/tests/types.go
@@ -438,6 +438,44 @@ var ViewTypes1_Payload = ViewTypes1_Base{
 	},
 }
 
+// OptionalListTypes exercises ssz-type:"optional-list" — pointers encoded as
+// canonical List[T, 1]. Static and dynamic element pointers are covered, and
+// optional-list works without extended types.
+type OptionalListTypes struct {
+	StaticOpt  *uint32                  `ssz-type:"optional-list"`
+	DynamicOpt *OptionalListTypes_Inner `ssz-type:"optional-list"`
+}
+
+type OptionalListTypes_Inner struct {
+	Tag  uint16
+	Data []byte `ssz-max:"16"`
+}
+
+var optListInner = &OptionalListTypes_Inner{
+	Tag:  0xbeef,
+	Data: []byte{1, 2, 3, 4, 5},
+}
+
+var optListU32 = uint32(1337)
+
+// Both pointers populated.
+var OptionalListTypes_Payload1 = OptionalListTypes{
+	StaticOpt:  &optListU32,
+	DynamicOpt: optListInner,
+}
+
+// Both pointers nil.
+var OptionalListTypes_Payload2 = OptionalListTypes{
+	StaticOpt:  nil,
+	DynamicOpt: nil,
+}
+
+// Mixed: static populated, dynamic nil.
+var OptionalListTypes_Payload3 = OptionalListTypes{
+	StaticOpt:  &optListU32,
+	DynamicOpt: nil,
+}
+
 type ExtendedTypes1 struct {
 	I8   int8
 	I16  int16

--- a/docs/extended-types.md
+++ b/docs/extended-types.md
@@ -138,6 +138,8 @@ Optional types use Go pointer types to represent values that may or may not be p
 
 > **Important**: Pointer types are **not** automatically treated as optional. You **must** annotate pointer fields with `ssz-type:"optional"` to enable optional encoding. Without this annotation, pointer fields follow standard SSZ behavior where a `nil` pointer is expanded to a zero-valued instance of the pointed-to type.
 
+> **Note**: `ssz-type:"optional"` is a **non-canonical** SSZ extension (1-byte presence flag) and requires extended types. For the canonical SSZ representation of optional pointer fields, use [`ssz-type:"optional-list"`](supported-types.md#optional-lists-canonical-listt-1) instead — it encodes the pointer as a canonical `List[T, 1]` and works without `WithExtendedTypes()`.
+
 **Encoding format**:
 - If `nil`: `0x00` (1 byte)
 - If present: `0x01` followed by the serialized value

--- a/docs/ssz-annotations.md
+++ b/docs/ssz-annotations.md
@@ -197,6 +197,8 @@ Explicitly specifies the SSZ type for a field. When omitted, the type is auto-de
 
 **Progressive types** (EIP-7916/7495): `progressive-list`, `progressive-bitlist`, `progressive-container`, `compatible-union` (or `union`)
 
+**Pointer encoding**: `optional-list` — encodes a pointer as canonical `List[T, 1]`
+
 **Extended types** (non-standard, requires `WithExtendedTypes()`): `int8`, `int16`, `int32`, `int64`, `float32`, `float64`, `bigint`, `optional`
 
 **Special values**: `custom` (type implements SSZ interfaces), `wrapper`/`type-wrapper` (TypeWrapper pattern), `?`/`auto` (auto-detect)

--- a/docs/supported-types.md
+++ b/docs/supported-types.md
@@ -189,6 +189,34 @@ type Block struct {
 }
 ```
 
+### Optional Lists (canonical `List[T, 1]`)
+
+Annotating a pointer field with `ssz-type:"optional-list"` encodes it as the canonical SSZ `List[T, 1]` — the encoding the Ethereum spec uses for canonical optional fields:
+
+- `nil` pointer → empty list (no bytes)
+- non-`nil` pointer → single-element list
+
+This is **standard SSZ** and works without `WithExtendedTypes()`. It is distinct from the extended `ssz-type:"optional"` annotation, which uses a non-canonical presence-byte format.
+
+```go
+type Block struct {
+    Slot uint64
+    // nil   → empty list
+    // &val  → List[T, 1] containing val
+    Sidecar *Sidecar `ssz-type:"optional-list"`
+}
+```
+
+Encoding:
+
+| Case                     | Bytes                                                 |
+|--------------------------|-------------------------------------------------------|
+| `nil`                    | (empty)                                               |
+| non-nil, fixed element   | `<element bytes>`                                     |
+| non-nil, dynamic element | `0x04 0x00 0x00 0x00 || <element bytes>` (offset = 4) |
+
+The hash tree root matches `List[T, 1]` exactly.
+
 ## Progressive Types (EIP-7916 & EIP-7495)
 
 ### Progressive Lists (M1)

--- a/reflection/common_test.go
+++ b/reflection/common_test.go
@@ -757,6 +757,47 @@ var commonTestMatrix = []struct {
 		fromHex("0x01000000000000000c000000010000000000000002000000010400050000000000000006000000010800"),
 		fromHex("0x80b99000797f72ef1a9deae3e42fc1447648feaf1d7cd8dc1a4e20c7c64350ed"),
 	},
+
+	// optional-list (canonical List[T, 1] for pointer types). Works without
+	// WithExtendedTypes() since the encoding has no custom shape.
+	{
+		"optional_list_uint32",
+		struct {
+			Opt *uint32 `ssz-type:"optional-list"`
+		}{Opt: func() *uint32 { v := uint32(1337); return &v }()},
+		fromHex("0x0400000039050000"),
+		fromHex("0x8246bdf6ebefc9975ce67afa054fa9b3a2df54e41173684f1a66edd8523b0cb9"),
+	},
+	{
+		"optional_list_uint32_nil",
+		struct {
+			Opt *uint32 `ssz-type:"optional-list"`
+		}{Opt: nil},
+		fromHex("0x04000000"),
+		fromHex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b"),
+	},
+	{
+		"optional_list_dynamic_inner",
+		struct {
+			Opt *struct {
+				Data []byte `ssz-max:"32"`
+			} `ssz-type:"optional-list"`
+		}{Opt: &struct {
+			Data []byte `ssz-max:"32"`
+		}{Data: []byte{1, 2, 3, 4, 5}}},
+		fromHex("0x0400000004000000040000000102030405"),
+		fromHex("0x0be8baeb911a0caeb38eb37bb068e2162ebc3b6ba1bf37236304e597a279dc87"),
+	},
+	{
+		"optional_list_dynamic_inner_nil",
+		struct {
+			Opt *struct {
+				Data []byte `ssz-max:"32"`
+			} `ssz-type:"optional-list"`
+		}{Opt: nil},
+		fromHex("0x04000000"),
+		fromHex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b"),
+	},
 }
 
 var opt1 = int16(1337)

--- a/reflection/marshal.go
+++ b/reflection/marshal.go
@@ -40,7 +40,7 @@ import (
 //   - Primitive type encoding (bool, uint8, uint16, uint32, uint64)
 //   - Delegation to specialized functions for composite types (structs, arrays, slices)
 func (ctx *ReflectionCtx) marshalType(sourceType *ssztypes.TypeDescriptor, sourceValue reflect.Value, encoder sszutils.Encoder, idt int) error {
-	if sourceType.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 && sourceType.SszType != ssztypes.SszOptionalType {
+	if sourceType.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 && sourceType.SszType != ssztypes.SszOptionalType && sourceType.SszType != ssztypes.SszOptionalListType {
 		if sourceValue.IsNil() {
 			sourceValue = reflect.New(sourceType.Type.Elem()).Elem()
 		} else {
@@ -181,6 +181,11 @@ func (ctx *ReflectionCtx) marshalType(sourceType *ssztypes.TypeDescriptor, sourc
 		encoder.EncodeUint64(math.Float64bits(sourceValue.Float()))
 	case ssztypes.SszOptionalType:
 		err = ctx.marshalOptional(sourceType, sourceValue, encoder, idt)
+		if err != nil {
+			return err
+		}
+	case ssztypes.SszOptionalListType:
+		err = ctx.marshalOptionalList(sourceType, sourceValue, encoder, idt)
 		if err != nil {
 			return err
 		}
@@ -784,6 +789,38 @@ func (ctx *ReflectionCtx) marshalOptional(sourceType *ssztypes.TypeDescriptor, s
 	encoder.EncodeBool(true)
 
 	// Marshal the wrapped value using its type descriptor
+	return ctx.marshalType(sourceType.ElemDesc, sourceValue.Elem(), encoder, idt+2)
+}
+
+// marshalOptionalList encodes a pointer as a canonical SSZ List[T, 1].
+//
+// Nil pointers encode as an empty list (no bytes).
+// Non-nil pointers encode as a single-element list:
+//   - Fixed-size element: just the element bytes
+//   - Dynamic-size element: a single 4-byte offset (=4) followed by the element bytes
+//
+// Parameters:
+//   - sourceType: The TypeDescriptor containing optional-list metadata
+//   - sourceValue: The reflect.Value of the pointer to encode
+//   - encoder: The encoder instance used to write SSZ-encoded data
+//   - idt: Indentation level for verbose logging
+//
+// Returns:
+//   - error: An error if encoding fails
+func (ctx *ReflectionCtx) marshalOptionalList(sourceType *ssztypes.TypeDescriptor, sourceValue reflect.Value, encoder sszutils.Encoder, idt int) error {
+	if ctx.verbose {
+		ctx.logCb("%smarshalOptionalList: %s\n", strings.Repeat(" ", idt), sourceType.Type.Name())
+	}
+
+	if sourceValue.IsNil() {
+		return nil
+	}
+
+	if sourceType.ElemDesc.SszTypeFlags&ssztypes.SszTypeFlagIsDynamic != 0 {
+		// dynamic element: write a single offset pointing past the offset header
+		encoder.EncodeOffset(4)
+	}
+
 	return ctx.marshalType(sourceType.ElemDesc, sourceValue.Elem(), encoder, idt+2)
 }
 

--- a/reflection/marshal.go
+++ b/reflection/marshal.go
@@ -821,7 +821,10 @@ func (ctx *ReflectionCtx) marshalOptionalList(sourceType *ssztypes.TypeDescripto
 		encoder.EncodeOffset(4)
 	}
 
-	return ctx.marshalType(sourceType.ElemDesc, sourceValue.Elem(), encoder, idt+2)
+	if err := ctx.marshalType(sourceType.ElemDesc, sourceValue.Elem(), encoder, idt+2); err != nil {
+		return sszutils.ErrorWithPathf(err, "[0]")
+	}
+	return nil
 }
 
 // marshalBigInt marshals a BigInt by marshaling its data field as the wrapped type.

--- a/reflection/marshal_test.go
+++ b/reflection/marshal_test.go
@@ -1333,6 +1333,121 @@ func TestMarshalOptionalError(t *testing.T) {
 	}
 }
 
+// TestOptionalListEquivalentToListMax verifies that the optional-list SSZ
+// type produces the same encoding, size, and hash tree root as a canonical
+// List[T, 1] (i.e. []T with ssz-max:"1"). It also exercises round-trip
+// marshal/unmarshal for both nil and non-nil pointer states and ensures the
+// type works without WithExtendedTypes().
+func TestOptionalListEquivalentToListMax(t *testing.T) {
+	type optStatic struct {
+		Opt *uint32 `ssz-type:"optional-list"`
+	}
+	type listStatic struct {
+		Opt []uint32 `ssz-max:"1"`
+	}
+	type dynInner struct {
+		Data []byte `ssz-max:"32"`
+	}
+	type optDynamic struct {
+		Opt *dynInner `ssz-type:"optional-list"`
+	}
+	type listDynamic struct {
+		Opt []dynInner `ssz-max:"1"`
+	}
+
+	u32 := uint32(1337)
+	staticVal := &optStatic{Opt: &u32}
+	staticEquiv := &listStatic{Opt: []uint32{u32}}
+	staticNil := &optStatic{Opt: nil}
+	staticEmpty := &listStatic{Opt: nil}
+
+	dynVal := &optDynamic{Opt: &dynInner{Data: []byte{1, 2, 3, 4, 5}}}
+	dynEquiv := &listDynamic{Opt: []dynInner{{Data: []byte{1, 2, 3, 4, 5}}}}
+	dynNil := &optDynamic{Opt: nil}
+	dynEmpty := &listDynamic{Opt: nil}
+
+	cases := []struct {
+		name      string
+		optVal    any
+		listVal   any
+		decodeOpt func() any
+		expectNil bool
+	}{
+		{"static_value", staticVal, staticEquiv, func() any { return new(optStatic) }, false},
+		{"static_nil", staticNil, staticEmpty, func() any { return new(optStatic) }, true},
+		{"dynamic_value", dynVal, dynEquiv, func() any { return new(optDynamic) }, false},
+		{"dynamic_nil", dynNil, dynEmpty, func() any { return new(optDynamic) }, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Optional-list must work without extended types — it's canonical SSZ.
+			ds := NewDynSsz(nil)
+
+			optBuf, err := ds.MarshalSSZ(tc.optVal)
+			if err != nil {
+				t.Fatalf("MarshalSSZ(optional-list): %v", err)
+			}
+			listBuf, err := ds.MarshalSSZ(tc.listVal)
+			if err != nil {
+				t.Fatalf("MarshalSSZ(list ssz-max:1): %v", err)
+			}
+			if !bytes.Equal(optBuf, listBuf) {
+				t.Errorf("encoding mismatch:\n  optional-list: 0x%x\n  list[T,1]:     0x%x", optBuf, listBuf)
+			}
+
+			optSize, err := ds.SizeSSZ(tc.optVal)
+			if err != nil {
+				t.Fatalf("SizeSSZ(optional-list): %v", err)
+			}
+			if optSize != len(optBuf) {
+				t.Errorf("SizeSSZ %d != marshal length %d", optSize, len(optBuf))
+			}
+
+			optRoot, err := ds.HashTreeRoot(tc.optVal)
+			if err != nil {
+				t.Fatalf("HashTreeRoot(optional-list): %v", err)
+			}
+			listRoot, err := ds.HashTreeRoot(tc.listVal)
+			if err != nil {
+				t.Fatalf("HashTreeRoot(list ssz-max:1): %v", err)
+			}
+			if optRoot != listRoot {
+				t.Errorf("hash tree root mismatch:\n  optional-list: 0x%x\n  list[T,1]:     0x%x", optRoot, listRoot)
+			}
+
+			decoded := tc.decodeOpt()
+			if err := ds.UnmarshalSSZ(decoded, optBuf); err != nil {
+				t.Fatalf("UnmarshalSSZ: %v", err)
+			}
+			decodedField := reflect.ValueOf(decoded).Elem().Field(0)
+			if tc.expectNil {
+				if !decodedField.IsNil() {
+					t.Errorf("expected nil pointer after unmarshal of empty payload, got %#v", decodedField.Interface())
+				}
+			} else if !reflect.DeepEqual(reflect.ValueOf(tc.optVal).Elem().Interface(), reflect.ValueOf(decoded).Elem().Interface()) {
+				t.Errorf("round-trip mismatch:\n  original: %#v\n  decoded:  %#v", tc.optVal, decoded)
+			}
+		})
+	}
+}
+
+// TestOptionalListPointerRequired verifies that ssz-type:"optional-list"
+// on a non-pointer field is rejected by the type cache.
+func TestOptionalListPointerRequired(t *testing.T) {
+	type bad struct {
+		Opt uint32 `ssz-type:"optional-list"`
+	}
+	ds := NewDynSsz(nil)
+	_, err := ds.MarshalSSZ(bad{Opt: 1})
+	if err == nil {
+		t.Fatal("expected error for non-pointer optional-list, got nil")
+	}
+	if !contains(err.Error(), "pointer types") {
+		t.Errorf("expected pointer-type error, got: %v", err)
+	}
+}
+
 func TestMarshalBigIntTypeAssertionFailure(t *testing.T) {
 	dynssz := NewDynSsz(nil, WithExtendedTypes(), WithNoFastSsz())
 

--- a/reflection/marshal_test.go
+++ b/reflection/marshal_test.go
@@ -1452,7 +1452,8 @@ func TestOptionalListMarshalVerbose(t *testing.T) {
 }
 
 // TestOptionalListInnerMarshalError verifies marshalOptionalList propagates
-// errors from marshaling the inner element.
+// errors from marshaling the inner element and tags them with the "[0]" path
+// to match how list[T,1] reports element errors.
 func TestOptionalListInnerMarshalError(t *testing.T) {
 	type Inner struct {
 		Value uint32
@@ -1466,13 +1467,16 @@ func TestOptionalListInnerMarshalError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Force the inner descriptor to an unsupported SSZ type so marshalType returns an error.
 	optDesc := typeDesc.ContainerDesc.Fields[0].Type
 	optDesc.ElemDesc.SszType = ssztypes.SszType(255)
 	optDesc.ElemDesc.SszCompatFlags = 0
 
-	if _, err = ds.MarshalSSZ(Container{Opt: &Inner{Value: 42}}); err == nil {
-		t.Error("expected error for optional-list with unsupported inner type")
+	_, err = ds.MarshalSSZ(Container{Opt: &Inner{Value: 42}})
+	if err == nil {
+		t.Fatal("expected error for optional-list with unsupported inner type")
+	}
+	if !contains(err.Error(), "[0]") {
+		t.Errorf("expected error path to contain '[0]', got: %v", err)
 	}
 }
 

--- a/reflection/marshal_test.go
+++ b/reflection/marshal_test.go
@@ -1454,26 +1454,19 @@ func TestOptionalListMarshalVerbose(t *testing.T) {
 // TestOptionalListInnerMarshalError verifies marshalOptionalList propagates
 // errors from marshaling the inner element and tags them with the "[0]" path
 // to match how list[T,1] reports element errors.
+//
+// The inner type's SizeSSZ succeeds (returning 8) so the precomputed-size
+// step in MarshalSSZ doesn't trip; MarshalSSZTo then fails, exercising both
+// the error-wrap inside marshalOptionalList and the dispatcher's case.
 func TestOptionalListInnerMarshalError(t *testing.T) {
-	type Inner struct {
-		Value uint32
-	}
 	type Container struct {
-		Opt *Inner `ssz-type:"optional-list"`
+		Opt *TestContainerWithMarshalError `ssz-type:"optional-list"`
 	}
 
-	ds := NewDynSsz(nil, WithNoFastSsz())
-	typeDesc, err := ds.GetTypeCache().GetTypeDescriptor(reflect.TypeOf(Container{}), nil, nil, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	optDesc := typeDesc.ContainerDesc.Fields[0].Type
-	optDesc.ElemDesc.SszType = ssztypes.SszType(255)
-	optDesc.ElemDesc.SszCompatFlags = 0
-
-	_, err = ds.MarshalSSZ(Container{Opt: &Inner{Value: 42}})
+	ds := NewDynSsz(nil)
+	_, err := ds.MarshalSSZ(Container{Opt: &TestContainerWithMarshalError{Field0: 42}})
 	if err == nil {
-		t.Fatal("expected error for optional-list with unsupported inner type")
+		t.Fatal("expected error from inner marshal failure")
 	}
 	if !contains(err.Error(), "[0]") {
 		t.Errorf("expected error path to contain '[0]', got: %v", err)

--- a/reflection/marshal_test.go
+++ b/reflection/marshal_test.go
@@ -1432,6 +1432,50 @@ func TestOptionalListEquivalentToListMax(t *testing.T) {
 	}
 }
 
+// TestOptionalListMarshalVerbose exercises the verbose-logging branch in
+// marshalOptionalList.
+func TestOptionalListMarshalVerbose(t *testing.T) {
+	type Inner struct {
+		Data []byte `ssz-max:"32"`
+	}
+	type Container struct {
+		Opt *Inner `ssz-type:"optional-list"`
+	}
+
+	ds := NewDynSsz(nil, WithVerbose(), WithLogCb(func(string, ...any) {}), WithNoFastSsz())
+	if _, err := ds.MarshalSSZ(Container{Opt: &Inner{Data: []byte{1, 2, 3}}}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := ds.MarshalSSZ(Container{Opt: nil}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestOptionalListInnerMarshalError verifies marshalOptionalList propagates
+// errors from marshaling the inner element.
+func TestOptionalListInnerMarshalError(t *testing.T) {
+	type Inner struct {
+		Value uint32
+	}
+	type Container struct {
+		Opt *Inner `ssz-type:"optional-list"`
+	}
+
+	ds := NewDynSsz(nil, WithNoFastSsz())
+	typeDesc, err := ds.GetTypeCache().GetTypeDescriptor(reflect.TypeOf(Container{}), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Force the inner descriptor to an unsupported SSZ type so marshalType returns an error.
+	optDesc := typeDesc.ContainerDesc.Fields[0].Type
+	optDesc.ElemDesc.SszType = ssztypes.SszType(255)
+	optDesc.ElemDesc.SszCompatFlags = 0
+
+	if _, err = ds.MarshalSSZ(Container{Opt: &Inner{Value: 42}}); err == nil {
+		t.Error("expected error for optional-list with unsupported inner type")
+	}
+}
+
 // TestOptionalListPointerRequired verifies that ssz-type:"optional-list"
 // on a non-pointer field is rejected by the type cache.
 func TestOptionalListPointerRequired(t *testing.T) {

--- a/reflection/sszsize.go
+++ b/reflection/sszsize.go
@@ -40,7 +40,7 @@ import (
 func (ctx *ReflectionCtx) getSszValueSize(targetType *ssztypes.TypeDescriptor, targetValue reflect.Value) (uint32, error) {
 	staticSize := uint32(0)
 
-	if targetType.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 && targetType.SszType != ssztypes.SszOptionalType {
+	if targetType.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 && targetType.SszType != ssztypes.SszOptionalType && targetType.SszType != ssztypes.SszOptionalListType {
 		if targetValue.IsNil() {
 			targetValue = reflect.New(targetType.Type.Elem()).Elem()
 		} else {
@@ -240,6 +240,19 @@ func (ctx *ReflectionCtx) getSszValueSize(targetType *ssztypes.TypeDescriptor, t
 			}
 
 			staticSize = dataSize + 1 // data size + 1 byte availability
+		}
+	case ssztypes.SszOptionalListType:
+		// canonical List[T, 1]: empty for nil, one element otherwise
+		if !targetValue.IsNil() {
+			dataSize, err := ctx.getSszValueSize(targetType.ElemDesc, targetValue.Elem())
+			if err != nil {
+				return 0, err
+			}
+
+			staticSize = dataSize
+			if targetType.ElemDesc.SszTypeFlags&ssztypes.SszTypeFlagIsDynamic != 0 {
+				staticSize += 4 // single offset header for dynamic element
+			}
 		}
 	case ssztypes.SszBigIntType:
 		bigInt, isBigInt := targetValue.Interface().(big.Int)

--- a/reflection/sszsize.go
+++ b/reflection/sszsize.go
@@ -246,7 +246,7 @@ func (ctx *ReflectionCtx) getSszValueSize(targetType *ssztypes.TypeDescriptor, t
 		if !targetValue.IsNil() {
 			dataSize, err := ctx.getSszValueSize(targetType.ElemDesc, targetValue.Elem())
 			if err != nil {
-				return 0, err
+				return 0, sszutils.ErrorWithPathf(err, "[0]")
 			}
 
 			staticSize = dataSize

--- a/reflection/sszsize.go
+++ b/reflection/sszsize.go
@@ -37,7 +37,7 @@ import (
 //   - Nil pointers are sized as zero-valued instances
 //   - Dynamic slices include padding for size hint compliance
 //   - Struct fields are sized based on their static/dynamic nature
-func (ctx *ReflectionCtx) getSszValueSize(targetType *ssztypes.TypeDescriptor, targetValue reflect.Value) (uint32, error) {
+func (ctx *ReflectionCtx) getSszValueSize(targetType *ssztypes.TypeDescriptor, targetValue reflect.Value) (uint32, error) { //nolint:gocyclo // SSZ size computation handles many type cases
 	staticSize := uint32(0)
 
 	if targetType.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 && targetType.SszType != ssztypes.SszOptionalType && targetType.SszType != ssztypes.SszOptionalListType {

--- a/reflection/sszsize_test.go
+++ b/reflection/sszsize_test.go
@@ -469,6 +469,35 @@ func TestSizeSSZOptionalError(t *testing.T) {
 	}
 }
 
+// TestSizeSSZOptionalListError verifies getSszValueSize tags inner sizing
+// errors with the "[0]" path for optional-list fields.
+func TestSizeSSZOptionalListError(t *testing.T) {
+	dynssz := NewDynSsz(nil, WithNoFastSsz())
+
+	type Inner struct {
+		Value uint32
+	}
+	type Container struct {
+		Opt *Inner `ssz-type:"optional-list"`
+	}
+
+	typeDesc, err := dynssz.GetTypeCache().GetTypeDescriptor(reflect.TypeOf(Container{}), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("Failed to get type descriptor: %v", err)
+	}
+	optDesc := typeDesc.ContainerDesc.Fields[0].Type
+	optDesc.ElemDesc.SszType = ssztypes.SszType(255)
+	optDesc.ElemDesc.SszCompatFlags = 0
+
+	_, err = dynssz.SizeSSZ(Container{Opt: &Inner{Value: 42}})
+	if err == nil {
+		t.Fatal("expected error for optional-list with unsupported inner type")
+	}
+	if !contains(err.Error(), "[0]") {
+		t.Errorf("expected error path to contain '[0]', got: %v", err)
+	}
+}
+
 func TestSizeSSZBigIntTypeAssertionFailure(t *testing.T) {
 	dynssz := NewDynSsz(nil, WithExtendedTypes(), WithNoFastSsz())
 

--- a/reflection/treeroot.go
+++ b/reflection/treeroot.go
@@ -40,7 +40,7 @@ import (
 //   - Primitive type hashing (bool, uint8, uint16, uint32, uint64)
 //   - Delegation to specialized functions for composite types (structs, arrays, slices)
 func (ctx *ReflectionCtx) buildRootFromType(sourceType *ssztypes.TypeDescriptor, sourceValue reflect.Value, hh sszutils.HashWalker, pack bool, idt int) error { //nolint:gocyclo // SSZ hash tree root builder handles many type cases
-	if sourceType.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 && sourceType.SszType != ssztypes.SszOptionalType {
+	if sourceType.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 && sourceType.SszType != ssztypes.SszOptionalType && sourceType.SszType != ssztypes.SszOptionalListType {
 		if sourceValue.IsNil() {
 			sourceValue = reflect.New(sourceType.Type.Elem()).Elem()
 		} else {
@@ -247,6 +247,11 @@ func (ctx *ReflectionCtx) buildRootFromType(sourceType *ssztypes.TypeDescriptor,
 		}
 	case ssztypes.SszOptionalType:
 		err := ctx.buildRootFromOptional(sourceType, sourceValue, hh, idt)
+		if err != nil {
+			return err
+		}
+	case ssztypes.SszOptionalListType:
+		err := ctx.buildRootFromOptionalList(sourceType, sourceValue, hh, idt)
 		if err != nil {
 			return err
 		}
@@ -823,6 +828,40 @@ func (ctx *ReflectionCtx) buildRootFromOptional(sourceType *ssztypes.TypeDescrip
 	if err != nil {
 		return err
 	}
+
+	return nil
+}
+
+// buildRootFromOptionalList computes the hash tree root for a pointer encoded as List[T, 1].
+//
+// The hash matches the canonical SSZ list hashing:
+//   - Merkleize the (zero or one) element chunks
+//   - Mix in the length (0 for nil, 1 for non-nil)
+//   - Limit is always 1 chunk/element for List[T, 1]
+//
+// Parameters:
+//   - sourceType: The TypeDescriptor containing optional-list metadata
+//   - sourceValue: The reflect.Value of the pointer to hash
+//   - hh: The Hasher instance for hash computation
+//   - idt: Indentation level for verbose logging
+//
+// Returns:
+//   - error: An error if hashing fails
+func (ctx *ReflectionCtx) buildRootFromOptionalList(sourceType *ssztypes.TypeDescriptor, sourceValue reflect.Value, hh sszutils.HashWalker, idt int) error {
+	hashIndex := hh.StartTree(sszutils.TreeTypeBinary)
+
+	var sliceLen uint64
+	if !sourceValue.IsNil() {
+		err := ctx.buildRootFromType(sourceType.ElemDesc, sourceValue.Elem(), hh, true, idt+2)
+		if err != nil {
+			return sszutils.ErrorWithPathf(err, "[0]")
+		}
+		sliceLen = 1
+	}
+
+	hh.FillUpTo32()
+	// List[T, 1] always has limit 1 (either 1 element or 1 packed chunk for basic types ≤32 bytes)
+	hh.MerkleizeWithMixin(hashIndex, sliceLen, 1)
 
 	return nil
 }

--- a/reflection/treeroot_test.go
+++ b/reflection/treeroot_test.go
@@ -1914,6 +1914,32 @@ func TestOptionalInnerBuildRootError(t *testing.T) {
 	}
 }
 
+// TestOptionalListInnerBuildRootError verifies buildRootFromOptionalList
+// propagates errors from the inner element's buildRootFromType call.
+func TestOptionalListInnerBuildRootError(t *testing.T) {
+	dynssz := NewDynSsz(nil, WithNoFastSsz())
+
+	type Inner struct {
+		Value uint32
+	}
+	type Container struct {
+		Opt *Inner `ssz-type:"optional-list"`
+	}
+
+	typeDesc, err := dynssz.GetTypeCache().GetTypeDescriptor(reflect.TypeOf(Container{}), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("Failed to get type descriptor: %v", err)
+	}
+
+	optDesc := typeDesc.ContainerDesc.Fields[0].Type
+	optDesc.ElemDesc.SszType = ssztypes.SszType(255)
+	optDesc.ElemDesc.SszCompatFlags = 0
+
+	if _, err = dynssz.HashTreeRoot(Container{Opt: &Inner{Value: 42}}); err == nil {
+		t.Error("expected error for optional-list inner build root error")
+	}
+}
+
 func TestBuildRootFromTypeWrapperError(t *testing.T) {
 	dynssz := NewDynSsz(nil, WithNoFastSsz())
 

--- a/reflection/treeroot_test.go
+++ b/reflection/treeroot_test.go
@@ -1915,7 +1915,8 @@ func TestOptionalInnerBuildRootError(t *testing.T) {
 }
 
 // TestOptionalListInnerBuildRootError verifies buildRootFromOptionalList
-// propagates errors from the inner element's buildRootFromType call.
+// propagates errors from the inner element's buildRootFromType call and tags
+// them with the "[0]" path to match list[T,1] error reporting.
 func TestOptionalListInnerBuildRootError(t *testing.T) {
 	dynssz := NewDynSsz(nil, WithNoFastSsz())
 
@@ -1935,8 +1936,12 @@ func TestOptionalListInnerBuildRootError(t *testing.T) {
 	optDesc.ElemDesc.SszType = ssztypes.SszType(255)
 	optDesc.ElemDesc.SszCompatFlags = 0
 
-	if _, err = dynssz.HashTreeRoot(Container{Opt: &Inner{Value: 42}}); err == nil {
-		t.Error("expected error for optional-list inner build root error")
+	_, err = dynssz.HashTreeRoot(Container{Opt: &Inner{Value: 42}})
+	if err == nil {
+		t.Fatal("expected error for optional-list inner build root error")
+	}
+	if !contains(err.Error(), "[0]") {
+		t.Errorf("expected error path to contain '[0]', got: %v", err)
 	}
 }
 

--- a/reflection/unmarshal.go
+++ b/reflection/unmarshal.go
@@ -42,7 +42,7 @@ import (
 //   - Delegation to specialized functions for composite types (structs, arrays, slices)
 //   - Validation that consumed bytes match expected sizes
 func (ctx *ReflectionCtx) unmarshalType(targetType *ssztypes.TypeDescriptor, targetValue reflect.Value, decoder sszutils.Decoder, idt int) error { //nolint:gocyclo // SSZ unmarshaling handles many type cases
-	if targetType.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 && targetType.SszType != ssztypes.SszOptionalType {
+	if targetType.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 && targetType.SszType != ssztypes.SszOptionalType && targetType.SszType != ssztypes.SszOptionalListType {
 		// target is a pointer type, resolve type & value to actual value type
 		if targetValue.IsNil() {
 			// create new instance of target type for null pointers
@@ -273,6 +273,11 @@ func (ctx *ReflectionCtx) unmarshalType(targetType *ssztypes.TypeDescriptor, tar
 			return err
 		}
 		targetValue.SetFloat(math.Float64frombits(f64Val))
+	case ssztypes.SszOptionalListType:
+		err = ctx.unmarshalOptionalList(targetType, targetValue, decoder, idt)
+		if err != nil {
+			return err
+		}
 	case ssztypes.SszOptionalType:
 		err = ctx.unmarshalOptional(targetType, targetValue, decoder, idt)
 		if err != nil {
@@ -1121,6 +1126,53 @@ func (ctx *ReflectionCtx) unmarshalOptional(targetType *ssztypes.TypeDescriptor,
 	}
 
 	return nil
+}
+
+// unmarshalOptionalList decodes a canonical SSZ List[T, 1] into a pointer.
+//
+// An empty buffer decodes to a nil pointer.
+// Otherwise the buffer contains a single element:
+//   - Fixed-size element: just the element bytes
+//   - Dynamic-size element: a 4-byte offset (=4) followed by the element bytes
+//
+// Parameters:
+//   - targetType: The TypeDescriptor containing optional-list metadata
+//   - targetValue: The reflect.Value of the pointer to populate
+//   - decoder: The decoder instance used to read SSZ-encoded data
+//   - idt: Indentation level for verbose logging
+//
+// Returns:
+//   - error: An error if decoding fails
+func (ctx *ReflectionCtx) unmarshalOptionalList(targetType *ssztypes.TypeDescriptor, targetValue reflect.Value, decoder sszutils.Decoder, idt int) error {
+	sszLen := decoder.GetLength()
+	if sszLen == 0 {
+		targetValue.Set(reflect.Zero(targetType.Type))
+		return nil
+	}
+
+	elemDesc := targetType.ElemDesc
+	dynamicElem := elemDesc.SszTypeFlags&ssztypes.SszTypeFlagIsDynamic != 0
+
+	if dynamicElem {
+		if sszLen < 4 {
+			return sszutils.ErrListOffsetsEOFFn(sszLen, 4)
+		}
+
+		offset, err := decoder.DecodeOffset()
+		if err != nil {
+			return err
+		}
+		if offset != 4 || uint32(sszLen) < offset {
+			return sszutils.ErrElementOffsetOutOfRangeFn(offset, uint32(4), sszLen)
+		}
+	}
+
+	if targetValue.IsNil() {
+		newValue := reflect.New(targetType.Type.Elem())
+		targetValue.Set(newValue)
+	}
+
+	return ctx.unmarshalType(elemDesc, targetValue.Elem(), decoder, idt+2)
 }
 
 // unmarshalBigInt decodes a BigInt by unmarshalling its data field.

--- a/reflection/unmarshal.go
+++ b/reflection/unmarshal.go
@@ -1162,8 +1162,8 @@ func (ctx *ReflectionCtx) unmarshalOptionalList(targetType *ssztypes.TypeDescrip
 		if err != nil {
 			return err
 		}
-		if offset != 4 || uint32(sszLen) < offset {
-			return sszutils.ErrElementOffsetOutOfRangeFn(offset, uint32(4), sszLen)
+		if offset != 4 {
+			return sszutils.ErrFirstOffsetMismatchFn(offset, uint32(4))
 		}
 	}
 
@@ -1172,7 +1172,10 @@ func (ctx *ReflectionCtx) unmarshalOptionalList(targetType *ssztypes.TypeDescrip
 		targetValue.Set(newValue)
 	}
 
-	return ctx.unmarshalType(elemDesc, targetValue.Elem(), decoder, idt+2)
+	if err := ctx.unmarshalType(elemDesc, targetValue.Elem(), decoder, idt+2); err != nil {
+		return sszutils.ErrorWithPathf(err, "[0]")
+	}
+	return nil
 }
 
 // unmarshalBigInt decodes a BigInt by unmarshalling its data field.

--- a/reflection/unmarshal_test.go
+++ b/reflection/unmarshal_test.go
@@ -1343,6 +1343,46 @@ func TestUnmarshalEmptyDynamicList(t *testing.T) {
 	}
 }
 
+// TestUnmarshalOptionalListInvalidOffset verifies that an out-of-range first
+// offset in the dynamic-element form of an optional-list is rejected.
+func TestUnmarshalOptionalListInvalidOffset(t *testing.T) {
+	dynssz := NewDynSsz(nil, WithNoFastSsz())
+
+	type Inner struct {
+		Data []byte `ssz-max:"32"`
+	}
+	type Container struct {
+		Opt *Inner `ssz-type:"optional-list"`
+	}
+
+	// container offset(=4) + payload offset(=99, out of range relative to payload size of 4)
+	bad := []byte{0x04, 0x00, 0x00, 0x00, 0x63, 0x00, 0x00, 0x00}
+	var out Container
+	if err := dynssz.UnmarshalSSZ(&out, bad); err == nil {
+		t.Fatal("expected error for invalid offset, got nil")
+	}
+}
+
+// TestUnmarshalOptionalListTruncatedOffset verifies that a payload shorter
+// than the 4-byte offset header (with a dynamic element) is rejected.
+func TestUnmarshalOptionalListTruncatedOffset(t *testing.T) {
+	dynssz := NewDynSsz(nil, WithNoFastSsz())
+
+	type Inner struct {
+		Data []byte `ssz-max:"32"`
+	}
+	type Container struct {
+		Opt *Inner `ssz-type:"optional-list"`
+	}
+
+	// container offset(=4) + 2-byte payload (less than required 4-byte offset header)
+	bad := []byte{0x04, 0x00, 0x00, 0x00, 0xaa, 0xbb}
+	var out Container
+	if err := dynssz.UnmarshalSSZ(&out, bad); err == nil {
+		t.Fatal("expected error for truncated offset header, got nil")
+	}
+}
+
 func TestUnmarshalDynamicDecoderWithUnmarshal(t *testing.T) {
 	dynssz := NewDynSsz(nil, WithNoFastSsz())
 

--- a/reflection/unmarshal_test.go
+++ b/reflection/unmarshal_test.go
@@ -1709,6 +1709,12 @@ func TestUnmarshalTruncatedReaderErrors(t *testing.T) {
 	type BigIntContainer struct {
 		Value big.Int `ssz-max:"256"`
 	}
+	type OptionalListInner struct {
+		Data []byte `ssz-max:"32"`
+	}
+	type OptionalListContainer struct {
+		Opt *OptionalListInner `ssz-type:"optional-list"`
+	}
 
 	marshalValid := func(t *testing.T, d *DynSsz, v any) []byte {
 		t.Helper()
@@ -1889,6 +1895,18 @@ func TestUnmarshalTruncatedReaderErrors(t *testing.T) {
 				return marshalValid(t, dynssz_ext, &BigIntContainer{Value: *big.NewInt(42)})
 			},
 			truncateAt:  4,
+			expectedErr: "unexpected end of SSZ",
+		},
+		{
+			name:   "optional_list_decode_offset_error",
+			dynssz: dynssz,
+			target: func() any { return new(OptionalListContainer) },
+			fullData: func(t *testing.T) []byte {
+				t.Helper()
+				return marshalValid(t, dynssz, &OptionalListContainer{Opt: &OptionalListInner{Data: []byte{}}})
+			},
+			// Truncate mid-offset-header so unmarshalOptionalList's DecodeOffset call fails.
+			truncateAt:  6,
 			expectedErr: "unexpected end of SSZ",
 		},
 	}

--- a/reflection/unmarshal_test.go
+++ b/reflection/unmarshal_test.go
@@ -1343,8 +1343,9 @@ func TestUnmarshalEmptyDynamicList(t *testing.T) {
 	}
 }
 
-// TestUnmarshalOptionalListInvalidOffset verifies that an out-of-range first
-// offset in the dynamic-element form of an optional-list is rejected.
+// TestUnmarshalOptionalListInvalidOffset verifies that a wrong first offset
+// in the dynamic-element form of an optional-list is rejected with the first
+// offset mismatch error (consistent with how list[T,1] reports the same).
 func TestUnmarshalOptionalListInvalidOffset(t *testing.T) {
 	dynssz := NewDynSsz(nil, WithNoFastSsz())
 
@@ -1355,11 +1356,47 @@ func TestUnmarshalOptionalListInvalidOffset(t *testing.T) {
 		Opt *Inner `ssz-type:"optional-list"`
 	}
 
-	// container offset(=4) + payload offset(=99, out of range relative to payload size of 4)
+	// container offset(=4) + payload offset(=99, not 4)
 	bad := []byte{0x04, 0x00, 0x00, 0x00, 0x63, 0x00, 0x00, 0x00}
 	var out Container
-	if err := dynssz.UnmarshalSSZ(&out, bad); err == nil {
+	err := dynssz.UnmarshalSSZ(&out, bad)
+	if err == nil {
 		t.Fatal("expected error for invalid offset, got nil")
+	}
+	if !contains(err.Error(), "first offset") {
+		t.Errorf("expected first-offset-mismatch error, got: %v", err)
+	}
+}
+
+// TestUnmarshalOptionalListInnerError verifies unmarshalOptionalList tags
+// inner unmarshal errors with the "[0]" path.
+func TestUnmarshalOptionalListInnerError(t *testing.T) {
+	dynssz := NewDynSsz(nil, WithNoFastSsz())
+
+	type Inner struct {
+		Value uint32
+	}
+	type Container struct {
+		Opt *Inner `ssz-type:"optional-list"`
+	}
+
+	typeDesc, err := dynssz.GetTypeCache().GetTypeDescriptor(reflect.TypeOf(Container{}), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	optDesc := typeDesc.ContainerDesc.Fields[0].Type
+	optDesc.ElemDesc.SszType = ssztypes.SszType(255)
+	optDesc.ElemDesc.SszCompatFlags = 0
+
+	// container offset(=4) + 4 bytes of element data
+	data := []byte{0x04, 0x00, 0x00, 0x00, 0x2a, 0x00, 0x00, 0x00}
+	var out Container
+	err = dynssz.UnmarshalSSZ(&out, data)
+	if err == nil {
+		t.Fatal("expected error for unsupported inner type")
+	}
+	if !contains(err.Error(), "[0]") {
+		t.Errorf("expected error path to contain '[0]', got: %v", err)
 	}
 }
 

--- a/ssztypes/ssztags.go
+++ b/ssztypes/ssztags.go
@@ -53,6 +53,9 @@ const (
 	SszFloat32Type
 	SszFloat64Type
 	SszOptionalType
+
+	// canonical SSZ encodings expressed via Go conveniences
+	SszOptionalListType // pointer encoded as canonical List[T, 1]
 )
 
 // SszTypeHint holds a parsed SSZ type hint from an ssz-type struct tag.
@@ -126,6 +129,10 @@ func ParseSszType(typeStr string) (SszType, error) {
 		return SszFloat64Type, nil
 	case "optional":
 		return SszOptionalType, nil
+
+	// canonical SSZ encodings expressed via Go conveniences
+	case "optional-list":
+		return SszOptionalListType, nil
 
 	default:
 		return SszUnspecifiedType, sszutils.NewSszErrorf(sszutils.ErrInvalidTag, "invalid ssz-type tag '%v'", typeStr)

--- a/ssztypes/typecache.go
+++ b/ssztypes/typecache.go
@@ -569,13 +569,13 @@ func (tc *TypeCache) buildTypeDescriptor(runtimeType, schemaType reflect.Type, s
 		if !tc.ExtendedTypes {
 			return nil, sszutils.NewSszError(sszutils.ErrExtendedTypeDisabled, "optional types are not supported in SSZ (use extended types option to enable it)")
 		}
-		err := tc.buildOptionalDescriptor(desc, t, sizeHints, maxSizeHints, typeHints)
+		err := tc.buildOptionalDescriptor(desc, runtimeType, schemaType, sizeHints, maxSizeHints, typeHints)
 		if err != nil {
 			return nil, err
 		}
 	case SszOptionalListType:
 		// optional-list expresses a pointer as a canonical List[T, 1]; allowed without ExtendedTypes
-		err := tc.buildOptionalListDescriptor(desc, t, sizeHints, maxSizeHints, typeHints)
+		err := tc.buildOptionalListDescriptor(desc, runtimeType, schemaType, sizeHints, maxSizeHints, typeHints)
 		if err != nil {
 			return nil, err
 		}
@@ -1060,7 +1060,7 @@ func (tc *TypeCache) buildCompatibleUnionDescriptor(desc *TypeDescriptor, runtim
 }
 
 // buildOptionalDescriptor builds a descriptor for optional types
-func (tc *TypeCache) buildOptionalDescriptor(desc *TypeDescriptor, t reflect.Type, sizeHints []SszSizeHint, maxSizeHints []SszMaxSizeHint, typeHints []SszTypeHint) error {
+func (tc *TypeCache) buildOptionalDescriptor(desc *TypeDescriptor, runtimeType, schemaType reflect.Type, sizeHints []SszSizeHint, maxSizeHints []SszMaxSizeHint, typeHints []SszTypeHint) error {
 	// Optional is always dynamic size (1 byte for presence + variable data)
 	desc.Size = 0
 	desc.SszTypeFlags |= SszTypeFlagIsDynamic
@@ -1084,7 +1084,7 @@ func (tc *TypeCache) buildOptionalDescriptor(desc *TypeDescriptor, t reflect.Typ
 		childTypeHints = typeHints[1:]
 	}
 
-	elemDesc, err := tc.getTypeDescriptor(t, t, childSizeHints, childMaxSizeHints, childTypeHints)
+	elemDesc, err := tc.getTypeDescriptor(runtimeType, schemaType, childSizeHints, childMaxSizeHints, childTypeHints)
 	if err != nil {
 		return err
 	}
@@ -1105,7 +1105,7 @@ func (tc *TypeCache) buildOptionalDescriptor(desc *TypeDescriptor, t reflect.Typ
 //
 // Unlike SszOptionalType, this is a canonical SSZ encoding with no custom
 // presence flag and is allowed regardless of the ExtendedTypes setting.
-func (tc *TypeCache) buildOptionalListDescriptor(desc *TypeDescriptor, t reflect.Type, sizeHints []SszSizeHint, maxSizeHints []SszMaxSizeHint, typeHints []SszTypeHint) error {
+func (tc *TypeCache) buildOptionalListDescriptor(desc *TypeDescriptor, runtimeType, schemaType reflect.Type, sizeHints []SszSizeHint, maxSizeHints []SszMaxSizeHint, typeHints []SszTypeHint) error {
 	if desc.GoTypeFlags&GoTypeFlagIsPointer == 0 {
 		return sszutils.NewSszErrorf(sszutils.ErrTypeMismatch, "optional-list ssz type can only be represented by pointer types, got %v", desc.Kind)
 	}
@@ -1125,7 +1125,7 @@ func (tc *TypeCache) buildOptionalListDescriptor(desc *TypeDescriptor, t reflect
 		childTypeHints = typeHints[1:]
 	}
 
-	elemDesc, err := tc.getTypeDescriptor(t, t, childSizeHints, childMaxSizeHints, childTypeHints)
+	elemDesc, err := tc.getTypeDescriptor(runtimeType, schemaType, childSizeHints, childMaxSizeHints, childTypeHints)
 	if err != nil {
 		return err
 	}

--- a/ssztypes/typecache.go
+++ b/ssztypes/typecache.go
@@ -573,6 +573,12 @@ func (tc *TypeCache) buildTypeDescriptor(runtimeType, schemaType reflect.Type, s
 		if err != nil {
 			return nil, err
 		}
+	case SszOptionalListType:
+		// optional-list expresses a pointer as a canonical List[T, 1]; allowed without ExtendedTypes
+		err := tc.buildOptionalListDescriptor(desc, t, sizeHints, maxSizeHints, typeHints)
+		if err != nil {
+			return nil, err
+		}
 	case SszBigIntType:
 		if !tc.ExtendedTypes {
 			return nil, sszutils.NewSszError(sszutils.ErrExtendedTypeDisabled, "big integers are not supported in SSZ (use extended types option to enable it)")
@@ -1071,6 +1077,49 @@ func (tc *TypeCache) buildOptionalDescriptor(desc *TypeDescriptor, t reflect.Typ
 
 	// The Optional inherits properties from the child type
 	desc.SszTypeFlags |= elemDesc.SszTypeFlags & (SszTypeFlagIsDynamic | SszTypeFlagHasDynamicSize | SszTypeFlagHasDynamicMax | SszTypeFlagHasSizeExpr | SszTypeFlagHasMaxExpr)
+
+	return nil
+}
+
+// buildOptionalListDescriptor builds a descriptor for optional-list types.
+//
+// An optional-list expresses a Go pointer as a canonical SSZ List[T, 1]:
+//   - nil pointer encodes as an empty list (no bytes)
+//   - non-nil pointer encodes as a list with a single element
+//
+// Unlike SszOptionalType, this is a canonical SSZ encoding with no custom
+// presence flag and is allowed regardless of the ExtendedTypes setting.
+func (tc *TypeCache) buildOptionalListDescriptor(desc *TypeDescriptor, t reflect.Type, sizeHints []SszSizeHint, maxSizeHints []SszMaxSizeHint, typeHints []SszTypeHint) error {
+	if desc.GoTypeFlags&GoTypeFlagIsPointer == 0 {
+		return sszutils.NewSszErrorf(sszutils.ErrTypeMismatch, "optional-list ssz type can only be represented by pointer types, got %v", desc.Kind)
+	}
+
+	childSizeHints := []SszSizeHint{}
+	if len(sizeHints) > 1 {
+		childSizeHints = sizeHints[1:]
+	}
+
+	childMaxSizeHints := []SszMaxSizeHint{}
+	if len(maxSizeHints) > 1 {
+		childMaxSizeHints = maxSizeHints[1:]
+	}
+
+	childTypeHints := []SszTypeHint{}
+	if len(typeHints) > 1 {
+		childTypeHints = typeHints[1:]
+	}
+
+	elemDesc, err := tc.getTypeDescriptor(t, t, childSizeHints, childMaxSizeHints, childTypeHints)
+	if err != nil {
+		return err
+	}
+
+	desc.ElemDesc = elemDesc
+	// canonical List[T, 1]: always dynamic, limit fixed at 1 element
+	desc.Size = 0
+	desc.Limit = 1
+	desc.SszTypeFlags |= SszTypeFlagIsDynamic | SszTypeFlagHasLimit
+	desc.SszTypeFlags |= elemDesc.SszTypeFlags & (SszTypeFlagHasDynamicSize | SszTypeFlagHasDynamicMax | SszTypeFlagHasSizeExpr | SszTypeFlagHasMaxExpr)
 
 	return nil
 }

--- a/ssztypes/typecache.go
+++ b/ssztypes/typecache.go
@@ -665,6 +665,22 @@ func (tc *TypeCache) buildTypeDescriptor(runtimeType, schemaType reflect.Type, s
 			SszCompatFlagHashTreeRootWith
 	}
 
+	// Optional and optional-list reshape the encoding around the inner type
+	// (presence byte / List[T,1] framing). The inner type's own SSZ methods
+	// must not be invoked at this level — they would skip the framing and
+	// emit the inner value as if it were the canonical encoding.
+	if desc.SszType == SszOptionalType || desc.SszType == SszOptionalListType {
+		desc.SszCompatFlags &^= SszCompatFlagDynamicMarshaler |
+			SszCompatFlagDynamicUnmarshaler |
+			SszCompatFlagDynamicSizer |
+			SszCompatFlagDynamicHashRoot |
+			SszCompatFlagDynamicEncoder |
+			SszCompatFlagDynamicDecoder |
+			SszCompatFlagFastSSZMarshaler |
+			SszCompatFlagFastSSZHasher |
+			SszCompatFlagHashTreeRootWith
+	}
+
 	if desc.SszType == SszCustomType {
 		isCompatible := desc.SszCompatFlags&SszCompatFlagFastSSZMarshaler != 0 && desc.SszCompatFlags&SszCompatFlagFastSSZHasher != 0
 		// isCompatible = isCompatible || (desc.SszCompatFlags&SszCompatFlagDynamicMarshaler != 0 && desc.SszCompatFlags&SszCompatFlagDynamicUnmarshaler != 0 && desc.SszCompatFlags&SszCompatFlagDynamicSizer != 0 && desc.SszCompatFlags&SszCompatFlagDynamicHashRoot != 0)

--- a/ssztypes/typecache_test.go
+++ b/ssztypes/typecache_test.go
@@ -1226,6 +1226,94 @@ func TestTypeCache_ExtendedTypes(t *testing.T) {
 			t.Error("expected bigint to be dynamic")
 		}
 	})
+
+	// Optional-list (canonical List[T, 1]) works without ExtendedTypes since
+	// it has no custom shape.
+	t.Run("OptionalListDescriptor", func(t *testing.T) {
+		cache := NewTypeCache(ds)
+
+		desc, err := cache.GetTypeDescriptor(
+			reflect.TypeOf((*uint32)(nil)),
+			nil, nil,
+			[]SszTypeHint{{Type: SszOptionalListType}},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if desc.SszType != SszOptionalListType {
+			t.Errorf("expected SszOptionalListType, got %v", desc.SszType)
+		}
+		if desc.Limit != 1 {
+			t.Errorf("expected Limit=1, got %d", desc.Limit)
+		}
+		if desc.SszTypeFlags&SszTypeFlagHasLimit == 0 {
+			t.Error("expected SszTypeFlagHasLimit to be set")
+		}
+		if desc.SszTypeFlags&SszTypeFlagIsDynamic == 0 {
+			t.Error("expected optional-list to be dynamic")
+		}
+		if desc.ElemDesc == nil {
+			t.Fatal("expected ElemDesc to be set")
+		}
+		if desc.ElemDesc.SszType != SszUint32Type {
+			t.Errorf("expected child SszUint32Type, got %v", desc.ElemDesc.SszType)
+		}
+	})
+
+	t.Run("OptionalListDescriptorWithChildHints", func(t *testing.T) {
+		cache := NewTypeCache(ds)
+
+		// Child size and max hints get forwarded to the element descriptor.
+		desc, err := cache.GetTypeDescriptor(
+			reflect.TypeOf((*[]byte)(nil)),
+			[]SszSizeHint{{}, {Size: 0, Dynamic: true}},
+			[]SszMaxSizeHint{{}, {Size: 32}},
+			[]SszTypeHint{{Type: SszOptionalListType}, {Type: SszListType}},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if desc.SszType != SszOptionalListType {
+			t.Errorf("expected SszOptionalListType, got %v", desc.SszType)
+		}
+		if desc.ElemDesc == nil || desc.ElemDesc.SszType != SszListType {
+			t.Fatalf("expected child SszListType, got %v", desc.ElemDesc)
+		}
+		if desc.ElemDesc.Limit != 32 {
+			t.Errorf("expected child Limit=32, got %d", desc.ElemDesc.Limit)
+		}
+	})
+
+	t.Run("OptionalListNonPointer", func(t *testing.T) {
+		cache := NewTypeCache(ds)
+
+		_, err := cache.GetTypeDescriptor(
+			reflect.TypeOf(uint32(0)),
+			nil, nil,
+			[]SszTypeHint{{Type: SszOptionalListType}},
+		)
+		if err == nil {
+			t.Fatal("expected error for optional-list with non-pointer type")
+		}
+		if !strings.Contains(err.Error(), "optional-list ssz type can only be represented by pointer") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	// Inner descriptor build error propagates from the child getTypeDescriptor call.
+	t.Run("OptionalListInnerBuildError", func(t *testing.T) {
+		cache := NewTypeCache(ds)
+
+		// chan is unsupported in SSZ; building the child descriptor fails.
+		_, err := cache.GetTypeDescriptor(
+			reflect.TypeOf((*chan int)(nil)),
+			nil, nil,
+			[]SszTypeHint{{Type: SszOptionalListType}},
+		)
+		if err == nil {
+			t.Fatal("expected error for optional-list with unsupported inner type")
+		}
+	})
 }
 
 // Test ParseSszType for all types
@@ -1271,6 +1359,9 @@ func TestParseSszType(t *testing.T) {
 		{"float64", SszFloat64Type},
 		{"bigint", SszBigIntType},
 		{"optional", SszOptionalType},
+
+		// canonical SSZ encodings expressed via Go conveniences
+		{"optional-list", SszOptionalListType},
 	}
 
 	for _, tt := range tests {

--- a/ssztypes/typecache_test.go
+++ b/ssztypes/typecache_test.go
@@ -1314,6 +1314,69 @@ func TestTypeCache_ExtendedTypes(t *testing.T) {
 			t.Fatal("expected error for optional-list with unsupported inner type")
 		}
 	})
+
+	// Optional/optional-list must preserve the (runtime, schema) pairing for
+	// the inner element when used with a view descriptor.
+	t.Run("OptionalListViewPairing", func(t *testing.T) {
+		type runtimeInner struct {
+			A uint32
+			B uint64
+		}
+		type schemaInner struct {
+			A uint32
+			B uint64
+		}
+
+		cache := NewTypeCache(ds)
+		desc, err := cache.GetTypeDescriptorWithSchema(
+			reflect.TypeOf((*runtimeInner)(nil)),
+			reflect.TypeOf((*schemaInner)(nil)),
+			nil, nil,
+			[]SszTypeHint{{Type: SszOptionalListType}},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if desc.ElemDesc == nil {
+			t.Fatal("expected ElemDesc to be set")
+		}
+		if desc.ElemDesc.Type != reflect.TypeOf(runtimeInner{}) {
+			t.Errorf("expected ElemDesc.Type to be runtimeInner, got %v", desc.ElemDesc.Type)
+		}
+		if desc.ElemDesc.SchemaType != reflect.TypeOf(schemaInner{}) {
+			t.Errorf("expected ElemDesc.SchemaType to be schemaInner, got %v", desc.ElemDesc.SchemaType)
+		}
+	})
+
+	t.Run("OptionalViewPairing", func(t *testing.T) {
+		type runtimeInner struct {
+			A uint32
+		}
+		type schemaInner struct {
+			A uint32
+		}
+
+		cache := NewTypeCache(ds)
+		cache.ExtendedTypes = true
+		desc, err := cache.GetTypeDescriptorWithSchema(
+			reflect.TypeOf((*runtimeInner)(nil)),
+			reflect.TypeOf((*schemaInner)(nil)),
+			nil, nil,
+			[]SszTypeHint{{Type: SszOptionalType}},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if desc.ElemDesc == nil {
+			t.Fatal("expected ElemDesc to be set")
+		}
+		if desc.ElemDesc.Type != reflect.TypeOf(runtimeInner{}) {
+			t.Errorf("expected ElemDesc.Type to be runtimeInner, got %v", desc.ElemDesc.Type)
+		}
+		if desc.ElemDesc.SchemaType != reflect.TypeOf(schemaInner{}) {
+			t.Errorf("expected ElemDesc.SchemaType to be schemaInner, got %v", desc.ElemDesc.SchemaType)
+		}
+	})
 }
 
 // Test ParseSszType for all types


### PR DESCRIPTION
# Add `optional-list` SSZ type — canonical `List[T, 1]` encoding for pointers

## Summary

Introduces `ssz-type:"optional-list"` to encode Go pointer fields as the canonical SSZ `List[T, 1]`:

- `nil` pointer → empty list (no bytes)
- non-`nil` pointer → single-element list (one element, with a 4-byte offset header when the element is dynamic)

This matches what the Ethereum spec uses for canonical "optional" fields, in contrast to the existing extended `ssz-type:"optional"` which uses a custom non-canonical presence-byte format. Unlike `optional`, `optional-list` is **not gated by `WithExtendedTypes()`** — it has no custom shape.

## Why

The canonical SSZ spec does not define optionals. Ethereum spec PRs and downstream implementations express optional fields as `List[T, 1]`, which is fully canonical. Adding it as a first-class type lets users opt into the canonical encoding without re-modeling pointer fields as slices.

## Encoding

| Case                      | Bytes                                                 |
|---------------------------|-------------------------------------------------------|
| `nil`, fixed element      | (empty)                                               |
| `nil`, dynamic element    | (empty)                                               |
| non-nil, fixed element    | `<element bytes>`                                     |
| non-nil, dynamic element  | `0x04 0x00 0x00 0x00 <element bytes>` (offset = 4) |

Hash tree root: standard `List[T, 1]` merkleization — pack/merkleize zero or one element chunks, mix in length (0 or 1), limit = 1.

## Usage

```go
type Container struct {
    Maybe *uint32 `ssz-type:"optional-list"`
}
```

Works without `WithExtendedTypes()`. The annotation is required on pointer fields — `*T` without this tag still follows the existing default (nil expanded to zero value).
