### PR TITLE
faster codegen marshal/unmarshal and hash-tree-root

### DIFF
--- a/codegen/gen_decoder.go
+++ b/codegen/gen_decoder.go
@@ -353,7 +353,7 @@ func (ctx *decoderContext) unmarshalType(desc *ssztypes.TypeDescriptor, varName 
 			ptrVarName = fmt.Sprintf("*(%s)", varName)
 		}
 		if desc.GoTypeFlags&ssztypes.GoTypeFlagIsTime != 0 {
-			timeImport := ctx.typePrinter.AddImport("time", "time")
+			timeImport := ctx.typePrinter.AddImport(pkgPathTime, pkgPathTime)
 			ctx.appendCode(indent+1, "%s = %s\n", ptrVarName, ctx.getCastedValueVar(desc, fmt.Sprintf("%s.Unix(int64(val), 0).UTC()", timeImport), fmt.Sprintf("%s.Time", timeImport)))
 		} else {
 			ctx.appendCode(indent+1, "%s = %s\n", ptrVarName, ctx.getCastedValueVar(desc, "val", "uint64"))

--- a/codegen/gen_marshal.go
+++ b/codegen/gen_marshal.go
@@ -628,6 +628,9 @@ func (ctx *marshalContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 			ctx.appendCode(indent, "dst = append(dst, %s[:%s]...)\n", getValueVar(false, ""), lenVar)
 		case desc.ElemDesc.SszType == ssztypes.SszUint64Type && desc.ElemDesc.GoTypeFlags&ssztypes.GoTypeFlagIsTime == 0:
 			ctx.appendCode(indent, "dst = sszutils.MarshalUint64Slice(dst, %s[:%s])\n", getValueVar(false, ""), lenVar)
+		case isBulkBytesElem(desc.ElemDesc):
+			// fixed byte-array elements (e.g. []Root) are contiguous: append in one copy
+			ctx.appendCode(indent, "dst = sszutils.MarshalFixedBytesSlice(dst, %s[:%s])\n", getValueVar(false, ""), lenVar)
 		default:
 			indexVar, indexDefer := ctx.getIndexVar()
 			defer indexDefer()
@@ -764,6 +767,10 @@ func (ctx *marshalContext) marshalList(desc *ssztypes.TypeDescriptor, varName st
 		case desc.ElemDesc.SszType == ssztypes.SszUint64Type && desc.ElemDesc.GoTypeFlags&ssztypes.GoTypeFlagIsTime == 0:
 			addVlen()
 			ctx.appendCode(indent, "dst = sszutils.MarshalUint64Slice(dst, %s[:vlen])\n", getValueVar(false, ""))
+		case isBulkBytesElem(desc.ElemDesc):
+			// fixed byte-array elements (e.g. []Root) are contiguous: append in one copy
+			addVlen()
+			ctx.appendCode(indent, "dst = sszutils.MarshalFixedBytesSlice(dst, %s[:vlen])\n", getValueVar(false, ""))
 		default:
 			addVlen()
 			indexVar, indexDefer := ctx.getIndexVar()

--- a/codegen/gen_unmarshal.go
+++ b/codegen/gen_unmarshal.go
@@ -177,6 +177,17 @@ func (ctx *unmarshalContext) getIndexVar() (string, func()) {
 	}
 }
 
+// isBulkBytesElem reports whether elemDesc is a fixed-size byte array value type
+// (e.g. [32]byte) that can be marshaled/unmarshaled as part of a contiguous slice
+// via a single bulk memory copy. Pointer, string and dynamic element types are
+// excluded since they are not laid out as a contiguous padding-free byte region.
+func isBulkBytesElem(elemDesc *ssztypes.TypeDescriptor) bool {
+	return elemDesc.Kind == reflect.Array &&
+		elemDesc.GoTypeFlags&ssztypes.GoTypeFlagIsByteArray != 0 &&
+		elemDesc.GoTypeFlags&(ssztypes.GoTypeFlagIsPointer|ssztypes.GoTypeFlagIsString) == 0 &&
+		elemDesc.SszTypeFlags&ssztypes.SszTypeFlagIsDynamic == 0
+}
+
 // isInlinable determines if a type can be unmarshaled inline without temporary variables.
 func (ctx *unmarshalContext) isInlinable(desc *ssztypes.TypeDescriptor) bool {
 	// Inline primitive types
@@ -801,6 +812,14 @@ func (ctx *unmarshalContext) unmarshalVector(desc *ssztypes.TypeDescriptor, varN
 			return nil
 		}
 
+		// bulk fixed byte-array elements (e.g. []Root where Root is [32]byte): the
+		// elements are contiguous with no padding, so the whole slice decodes with a
+		// single memory copy instead of a per-element copy loop.
+		if isBulkBytesElem(desc.ElemDesc) {
+			ctx.appendCode(indent, "sszutils.UnmarshalFixedBytesSlice(%s[:%s], buf)\n", indexValueVar, limitVar)
+			return nil
+		}
+
 		indexVar, indexDefer := ctx.getIndexVar()
 		defer indexDefer()
 
@@ -962,6 +981,14 @@ func (ctx *unmarshalContext) unmarshalList(desc *ssztypes.TypeDescriptor, varNam
 		}
 		if desc.Kind != reflect.Array {
 			ctx.appendCode(indent, "%s = sszutils.ExpandSlice(%s, itemCount)\n", valueVar, valueVar)
+		}
+
+		// bulk fixed byte-array elements (e.g. []Root where Root is [32]byte): the
+		// elements are contiguous with no padding, so the whole list decodes with a
+		// single memory copy instead of a per-element copy loop.
+		if isBulkBytesElem(desc.ElemDesc) {
+			ctx.appendCode(indent, "sszutils.UnmarshalFixedBytesSlice(%s[:itemCount], buf)\n", indexValueVar)
+			return nil
 		}
 
 		indexVar, indexDefer := ctx.getIndexVar()

--- a/codegen/gen_unmarshal.go
+++ b/codegen/gen_unmarshal.go
@@ -361,7 +361,7 @@ func (ctx *unmarshalContext) unmarshalType(desc *ssztypes.TypeDescriptor, varNam
 					"time.Time",
 				),
 			)
-			ctx.typePrinter.AddImport("time", "time")
+			ctx.typePrinter.AddImport(pkgPathTime, pkgPathTime)
 		} else {
 			ctx.appendCode(indent,
 				"%s = %s\n",

--- a/codegen/parser.go
+++ b/codegen/parser.go
@@ -18,6 +18,8 @@ const (
 	typeNameInt       = "int"
 	typeNameByteSlice = "[]byte"
 	typeNameString    = "string"
+	typeNameTime      = "Time"
+	pkgPathTime       = "time"
 )
 
 var (
@@ -387,7 +389,7 @@ func (p *Parser) buildTypeDescriptor(dataType, schemaType types.Type, typeHints 
 			typeName := obj.Name()
 
 			switch {
-			case pkgPath == "time" && typeName == "Time": //nolint:goconst // "Time" also appears in test assertions, not worth a shared constant
+			case pkgPath == pkgPathTime && typeName == typeNameTime:
 				sszType = ssztypes.SszUint64Type
 				desc.GoTypeFlags |= ssztypes.GoTypeFlagIsTime
 			case pkgPath == "math/big" && typeName == "Int":

--- a/hasher/hasher.go
+++ b/hasher/hasher.go
@@ -61,6 +61,17 @@ type treeLayer struct {
 	// Progressive base sizes: 1, 4, 16, 64, 256, 1024, ...  (1 << level*2)
 	progressiveCount int // number of completed progressive roots at buf left
 	progressiveLevel int // current level (determines base_size for active subtree)
+
+	// Deferred child-subtree batching. When a child container scope is closed via
+	// Merkleize and this (parent) layer is incremental, the child's raw leaf
+	// chunks are left in the buffer instead of being reduced immediately, and
+	// pendCount is bumped. Sibling subtrees thus accumulate and are reduced
+	// together, level-by-level, in one wide SIMD pass (flushPending) — far fewer
+	// and far larger hash calls than reducing each child on its own. All pending
+	// subtrees in a layer are uniform (pendElemChunks chunks each, a power of
+	// two), which holds because list/vector elements share a single type.
+	pendCount      int // number of deferred child subtrees not yet reduced to roots
+	pendElemChunks int // chunk count of each deferred subtree (power of two)
 }
 
 // Hasher is a utility tool to hash SSZ structs
@@ -224,12 +235,21 @@ func (h *Hasher) PutBytes(b []byte) {
 		return
 	}
 
-	// if the bytes are longer than 32 we have to
-	// merkleize the content — use merkleizeImpl directly to avoid
-	// interacting with the layer stack (PutBytes is an internal operation,
-	// not an SSZ object scope).
 	indx := len(h.buf)
 	h.AppendBytes32(b)
+
+	// Fast path for two-chunk fields (33..64 bytes, e.g. a 48-byte BLS pubkey):
+	// a single hash, skipping merkleizeImpl's general depth loop. These dominate
+	// validator hashing, so the per-call saving adds up over large lists.
+	if len(b) <= 64 {
+		_ = h.hash(h.buf[indx:indx+32], h.buf[indx:indx+64])
+		h.buf = h.buf[:indx+32]
+		return
+	}
+
+	// Longer content: merkleize in place. Use merkleizeImpl directly to avoid
+	// interacting with the layer stack (PutBytes is an internal operation, not an
+	// SSZ object scope).
 	input := h.buf[indx:]
 	input = h.merkleizeImpl(input[:0], input, 0)
 	h.buf = append(h.buf[:indx], input...)
@@ -346,13 +366,67 @@ func (h *Hasher) pushLayer() *treeLayer {
 	layer := &h.layers[h.layerCount]
 	layer.collapsed = false
 	layer.progressive = false
+	// Reset the deferred-batching state. In the normal flow this is already 0
+	// (every incremental layer is flushed before it is popped), but clearing it
+	// here keeps a reused slot clean even if a prior hash was abandoned mid-way
+	// (e.g. an error returned before finalize, then Reset + pool reuse).
+	layer.pendCount = 0
+	layer.pendElemChunks = 0
 	return layer
+}
+
+// deferrableElemChunks reports whether a just-closed scope of scopeBytes bytes is
+// a uniform binary subtree eligible for deferred batched reduction: a whole,
+// power-of-two number of chunks in [2, incrementalBatchSize].
+func deferrableElemChunks(scopeBytes int) (int, bool) {
+	if scopeBytes < 64 || scopeBytes%32 != 0 {
+		return 0, false
+	}
+	c := scopeBytes / 32
+	if c > incrementalBatchSize || c&(c-1) != 0 {
+		return 0, false
+	}
+	return c, true
+}
+
+// flushPending reduces a layer's deferred child subtrees (pendCount subtrees of
+// pendElemChunks chunks each, sitting at the tail of the buffer) to pendCount
+// roots, hashing one whole level across all subtrees per call. This realises the
+// batching win: a few wide hash calls instead of one tiny merkleization per
+// element. The roots replace the raw chunks in place.
+func (h *Hasher) flushPending(layer *treeLayer) {
+	count := layer.pendCount
+	elem := layer.pendElemChunks
+	layer.pendCount = 0
+	layer.pendElemChunks = 0
+	if count == 0 {
+		return
+	}
+	width := count * elem
+	start := len(h.buf) - width*32
+	for width > count {
+		half := (width / 2) * 32
+		_ = h.hash(h.buf[start:start+half], h.buf[start:start+width*32])
+		width /= 2
+	}
+	h.buf = h.buf[:start+count*32]
 }
 
 // StartTree opens a new SSZ object scope and returns the buffer index.
 // TreeTypeBinary/Progressive: pushes an incremental layer (supports Collapse).
 // TreeTypeNone: pushes a non-incremental layer (Collapse is a no-op on this scope).
 func (h *Hasher) StartTree(treeType sszutils.TreeType) int {
+	// An incremental child is merkleized immediately (it never defers into this
+	// parent), so it would append a root after any deferred siblings and break
+	// the "pending chunks are a contiguous tail run" invariant. Flush first.
+	// This cannot happen for uniform list/vector elements (all defer or none),
+	// so batching is unaffected; it only guards interleaved API usage.
+	if treeType != sszutils.TreeTypeNone && h.layerCount >= 0 {
+		if top := &h.layers[h.layerCount]; top.pendCount > 0 {
+			h.flushPending(top)
+		}
+	}
+
 	idx := len(h.buf)
 	layer := h.pushLayer()
 	layer.bufIdx = idx
@@ -390,6 +464,10 @@ func (h *Hasher) Collapse() {
 	layer := &h.layers[h.layerCount]
 	if !layer.incremental {
 		return
+	}
+
+	if layer.pendCount > 0 {
+		h.flushPending(layer)
 	}
 
 	if layer.progressive {
@@ -788,13 +866,32 @@ func (h *Hasher) collapseProgressiveLayer(layer *treeLayer, indx int) {
 func (h *Hasher) Merkleize(indx int) {
 	layer := h.getMatchingLayer(indx)
 
-	if layer != nil && layer.collapsed {
-		h.collapseAllDepths(layer, indx, len(h.buf), 0)
-		h.buf = h.buf[:indx+32]
-		h.popTopLayer()
-		return
-	}
 	if layer != nil {
+		// Defer a container scope into its incremental parent so it batches with
+		// its siblings (single getMatchingLayer keeps the hot path cheap for the
+		// many small containers in a block).
+		if !layer.incremental && h.layerCount >= 1 {
+			parent := &h.layers[h.layerCount-1]
+			if parent.incremental {
+				if c, ok := deferrableElemChunks(len(h.buf) - indx); ok && (parent.pendCount == 0 || parent.pendElemChunks == c) {
+					parent.pendElemChunks = c
+					parent.pendCount++
+					h.popTopLayer()
+					return
+				}
+			}
+		}
+
+		if layer.pendCount > 0 {
+			h.flushPending(layer)
+		}
+
+		if layer.collapsed {
+			h.collapseAllDepths(layer, indx, len(h.buf), 0)
+			h.buf = h.buf[:indx+32]
+			h.popTopLayer()
+			return
+		}
 		h.popTopLayer()
 	}
 
@@ -824,6 +921,10 @@ func (h *Hasher) MerkleizeWithMixin(indx int, num, limit uint64) {
 	h.FillUpTo32()
 
 	layer := h.getMatchingLayer(indx)
+
+	if layer != nil && layer.pendCount > 0 {
+		h.flushPending(layer)
+	}
 
 	if layer != nil && layer.collapsed {
 		h.collapseAllDepths(layer, indx, len(h.buf), limit)
@@ -864,6 +965,10 @@ func (h *Hasher) MerkleizeWithMixin(indx int, num, limit uint64) {
 func (h *Hasher) MerkleizeProgressive(indx int) {
 	layer := h.getMatchingLayer(indx)
 
+	if layer != nil && layer.pendCount > 0 {
+		h.flushPending(layer)
+	}
+
 	if layer != nil && layer.progressive {
 		h.collapseProgressiveLayer(layer, indx)
 		h.popTopLayer()
@@ -894,6 +999,10 @@ func (h *Hasher) MerkleizeProgressive(indx int) {
 // indx and mixes in num as the list length.
 func (h *Hasher) MerkleizeProgressiveWithMixin(indx int, num uint64) {
 	layer := h.getMatchingLayer(indx)
+
+	if layer != nil && layer.pendCount > 0 {
+		h.flushPending(layer)
+	}
 
 	if layer != nil && layer.progressive && layer.progressiveCount > 0 {
 		h.FillUpTo32()
@@ -935,6 +1044,10 @@ func (h *Hasher) MerkleizeProgressiveWithMixin(indx int, num uint64) {
 // from indx and mixes in the active fields bitvector.
 func (h *Hasher) MerkleizeProgressiveWithActiveFields(indx int, activeFields []byte) {
 	layer := h.getMatchingLayer(indx)
+
+	if layer != nil && layer.pendCount > 0 {
+		h.flushPending(layer)
+	}
 
 	if layer != nil && layer.progressive && layer.progressiveCount > 0 {
 		h.FillUpTo32()

--- a/hasher/hasher_test.go
+++ b/hasher/hasher_test.go
@@ -1553,3 +1553,161 @@ func TestMerkleizeProgressiveImplTmpBelow32(t *testing.T) {
 		t.Fatalf("HashRoot failed: %v", err)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Deferred cross-element batching correctness
+// ---------------------------------------------------------------------------
+
+// These tests validate the deferred cross-element batching in Merkleize against
+// an independent reference that pre-reduces each element to its root (so the
+// element merkleization never defers) and then merkleizes the roots. Both binary
+// and progressive list shapes are covered, since deferral applies under either
+// incremental parent.
+
+func newH() *Hasher { return NewHasherWithHashFn(FastHasherPool.HashFn) }
+
+// elemRoot computes the root of a fields-chunk container in isolation (top-level
+// scope → no incremental parent → no deferral).
+func elemRoot(fields, seed int) [32]byte {
+	h := newH()
+	idx := h.StartTree(sszutils.TreeTypeNone)
+	for f := 0; f < fields; f++ {
+		h.PutUint64(uint64(seed*1_000_003 + f))
+	}
+	h.Merkleize(idx)
+	r, err := h.HashRoot()
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+func putElem(h *Hasher, fields, seed int) {
+	idx := h.StartTree(sszutils.TreeTypeNone)
+	for f := 0; f < fields; f++ {
+		h.PutUint64(uint64(seed*1_000_003 + f))
+	}
+	h.Merkleize(idx) // defers when the parent scope is incremental
+}
+
+func TestDeferMatchesReference_Binary(t *testing.T) {
+	const limit = 1 << 40
+	for _, fields := range []int{2, 4, 8} { // power-of-two ⇒ deferred
+		for _, n := range []int{0, 1, 2, 3, 255, 256, 257, 600} {
+			// deferred path
+			h := newH()
+			idx := h.StartTree(sszutils.TreeTypeBinary)
+			for i := 0; i < n; i++ {
+				putElem(h, fields, i)
+				if (i+1)%256 == 0 {
+					h.Collapse()
+				}
+			}
+			h.MerkleizeWithMixin(idx, uint64(n), sszutils.CalculateLimit(limit, uint64(n), 32))
+			got, _ := h.HashRoot()
+
+			// reference: pre-reduced roots, no deferral
+			rh := newH()
+			ridx := rh.StartTree(sszutils.TreeTypeBinary)
+			for i := 0; i < n; i++ {
+				r := elemRoot(fields, i)
+				rh.AppendBytes32(r[:])
+			}
+			rh.MerkleizeWithMixin(ridx, uint64(n), sszutils.CalculateLimit(limit, uint64(n), 32))
+			want, _ := rh.HashRoot()
+
+			if got != want {
+				t.Errorf("binary fields=%d n=%d: got %x want %x", fields, n, got, want)
+			}
+		}
+	}
+}
+
+func TestDeferMatchesReference_Progressive(t *testing.T) {
+	for _, fields := range []int{2, 4, 8} {
+		for _, n := range []int{0, 1, 2, 3, 255, 256, 257, 600} {
+			// deferred path
+			h := newH()
+			idx := h.StartTree(sszutils.TreeTypeProgressive)
+			for i := 0; i < n; i++ {
+				putElem(h, fields, i)
+				if (i+1)%256 == 0 {
+					h.Collapse()
+				}
+			}
+			h.MerkleizeProgressiveWithMixin(idx, uint64(n))
+			got, _ := h.HashRoot()
+
+			// reference: pre-reduced roots, no deferral
+			rh := newH()
+			ridx := rh.StartTree(sszutils.TreeTypeProgressive)
+			for i := 0; i < n; i++ {
+				r := elemRoot(fields, i)
+				rh.AppendBytes32(r[:])
+			}
+			rh.MerkleizeProgressiveWithMixin(ridx, uint64(n))
+			want, _ := rh.HashRoot()
+
+			if got != want {
+				t.Errorf("progressive fields=%d n=%d: got %x want %x", fields, n, got, want)
+			}
+		}
+	}
+}
+
+// TestDeferInterleavedWideField covers an element whose first field is a
+// >32-byte value (exercises the PutBytes two-chunk fast path inside a deferred
+// element), validated against pre-reduced roots.
+func TestDeferWideFieldElement(t *testing.T) {
+	const limit = 1 << 40
+	const n = 300
+
+	mkRoot := func(seed int) [32]byte {
+		h := newH()
+		idx := h.StartTree(sszutils.TreeTypeNone)
+		pub := make([]byte, 48)
+		for j := range pub {
+			pub[j] = byte(seed + j)
+		}
+		h.PutBytes(pub)                                 // field 0: 48-byte (2-chunk) field
+		h.PutUint64(uint64(seed))                       // field 1
+		h.PutUint64(uint64(seed * 7))                   // field 2
+		h.PutBytes([]byte{byte(seed), byte(seed >> 8)}) // field 3 (<=32)
+		h.Merkleize(idx)
+		r, _ := h.HashRoot()
+		return r
+	}
+
+	h := newH()
+	idx := h.StartTree(sszutils.TreeTypeBinary)
+	for i := 0; i < n; i++ {
+		eidx := h.StartTree(sszutils.TreeTypeNone)
+		pub := make([]byte, 48)
+		for j := range pub {
+			pub[j] = byte(i + j)
+		}
+		h.PutBytes(pub)
+		h.PutUint64(uint64(i))
+		h.PutUint64(uint64(i * 7))
+		h.PutBytes([]byte{byte(i), byte(i >> 8)})
+		h.Merkleize(eidx)
+		if (i+1)%256 == 0 {
+			h.Collapse()
+		}
+	}
+	h.MerkleizeWithMixin(idx, uint64(n), sszutils.CalculateLimit(limit, uint64(n), 32))
+	got, _ := h.HashRoot()
+
+	rh := newH()
+	ridx := rh.StartTree(sszutils.TreeTypeBinary)
+	for i := 0; i < n; i++ {
+		r := mkRoot(i)
+		rh.AppendBytes32(r[:])
+	}
+	rh.MerkleizeWithMixin(ridx, uint64(n), sszutils.CalculateLimit(limit, uint64(n), 32))
+	want, _ := rh.HashRoot()
+
+	if got != want {
+		t.Errorf("wide-field: got %x want %x", got, want)
+	}
+}

--- a/hasher/hasher_test.go
+++ b/hasher/hasher_test.go
@@ -1711,3 +1711,81 @@ func TestDeferWideFieldElement(t *testing.T) {
 		t.Errorf("wide-field: got %x want %x", got, want)
 	}
 }
+
+// TestFlushPendingNoPending covers the defensive no-op path of flushPending: when
+// a layer has no deferred subtrees it must leave the buffer untouched. Callers
+// normally guard this with `pendCount > 0`, so this exercises it directly.
+func TestFlushPendingNoPending(t *testing.T) {
+	h := newH()
+	h.PutUint64(7)
+	h.PutUint64(8)
+	before := h.CurrentIndex()
+
+	var layer treeLayer // pendCount == 0
+	h.flushPending(&layer)
+
+	if h.CurrentIndex() != before {
+		t.Fatalf("flushPending with no pending changed the buffer: %d != %d", h.CurrentIndex(), before)
+	}
+}
+
+// TestDeferProgressiveNoMixin checks that deferred composite elements under a
+// progressive scope finalized via MerkleizeProgressive (no length mixin) reduce
+// to the same root as pre-reduced element roots — exercising the flushPending
+// path inside MerkleizeProgressive.
+func TestDeferProgressiveNoMixin(t *testing.T) {
+	for _, fields := range []int{2, 4} {
+		for _, n := range []int{1, 2, 3, 16} {
+			h := newH()
+			idx := h.StartTree(sszutils.TreeTypeProgressive)
+			for i := 0; i < n; i++ {
+				putElem(h, fields, i) // defers into the progressive parent
+			}
+			h.MerkleizeProgressive(idx)
+			got, _ := h.HashRoot()
+
+			rh := newH()
+			ridx := rh.StartTree(sszutils.TreeTypeProgressive)
+			for i := 0; i < n; i++ {
+				r := elemRoot(fields, i)
+				rh.AppendBytes32(r[:])
+			}
+			rh.MerkleizeProgressive(ridx)
+			want, _ := rh.HashRoot()
+
+			if got != want {
+				t.Errorf("progressive-no-mixin fields=%d n=%d: got %x want %x", fields, n, got, want)
+			}
+		}
+	}
+}
+
+// TestDeferProgressiveActiveFields is the analogue for
+// MerkleizeProgressiveWithActiveFields, exercising its flushPending path.
+func TestDeferProgressiveActiveFields(t *testing.T) {
+	activeFields := []byte{0x0f}
+	for _, fields := range []int{2, 4} {
+		for _, n := range []int{1, 2, 4} {
+			h := newH()
+			idx := h.StartTree(sszutils.TreeTypeProgressive)
+			for i := 0; i < n; i++ {
+				putElem(h, fields, i)
+			}
+			h.MerkleizeProgressiveWithActiveFields(idx, activeFields)
+			got, _ := h.HashRoot()
+
+			rh := newH()
+			ridx := rh.StartTree(sszutils.TreeTypeProgressive)
+			for i := 0; i < n; i++ {
+				r := elemRoot(fields, i)
+				rh.AppendBytes32(r[:])
+			}
+			rh.MerkleizeProgressiveWithActiveFields(ridx, activeFields)
+			want, _ := rh.HashRoot()
+
+			if got != want {
+				t.Errorf("progressive-active-fields fields=%d n=%d: got %x want %x", fields, n, got, want)
+			}
+		}
+	}
+}

--- a/reflection/treeroot.go
+++ b/reflection/treeroot.go
@@ -704,13 +704,22 @@ func (ctx *ReflectionCtx) buildRootFromList(sourceType *ssztypes.TypeDescriptor,
 		}
 
 		if itemSize > 0 {
+			// Packed primitive elements: the limit is a chunk count and the
+			// elements are never deferred, so the written chunk count is exact.
 			limit = sszutils.CalculateLimit(sourceType.Limit, uint64(sliceLen), itemSize)
+			inputLen := hh.CurrentIndex() - hashIndex
+			if (uint64(inputLen)+31)/32 > limit {
+				return sszutils.ErrListLengthFn(inputLen, limit)
+			}
 		} else {
+			// Composite elements: the limit is an element count. Validate against
+			// the element count directly — the buffer may hold un-reduced child
+			// chunks (deferred cross-element batching), so a CurrentIndex-derived
+			// chunk count would over-count and falsely trip the limit.
 			limit = sourceType.Limit
-		}
-		inputLen := hh.CurrentIndex() - hashIndex
-		if (uint64(inputLen)+31)/32 > limit {
-			return sszutils.ErrListLengthFn(inputLen, limit)
+			if uint64(sliceLen) > limit {
+				return sszutils.ErrListLengthFn(sliceLen, limit)
+			}
 		}
 		hh.MerkleizeWithMixin(hashIndex, uint64(sliceLen), limit)
 	default:

--- a/reflection/treeroot_test.go
+++ b/reflection/treeroot_test.go
@@ -288,6 +288,53 @@ func TestStringVsByteContainerTreeRootEquivalence(t *testing.T) {
 	}
 }
 
+// TestListOfContainersDeferredBatchingLength guards against a regression where
+// the reflection list-length validation derived the element count from the
+// hasher buffer position (CurrentIndex). With deferred cross-element batching the
+// buffer holds each element's un-reduced child chunks (here 2 per element) until
+// the list is finalized, so a buffer-derived count over-counts and would falsely
+// trip the max-length check. Composite-list limits must be validated by element
+// count, not buffer chunks.
+func TestListOfContainersDeferredBatchingLength(t *testing.T) {
+	// Two uint64 fields => 2 chunks => power-of-two => the element container is
+	// deferred under the incremental list parent.
+	type Elem struct {
+		A uint64
+		B uint64
+	}
+	type Container struct {
+		Items []Elem `ssz-max:"16"`
+	}
+
+	dynssz := NewDynSsz(nil)
+
+	// All counts up to the max must hash without error. Counts in (max/2, max]
+	// (here 9..16) are the regression: 2*count chunks exceed the limit of 16.
+	roots := make(map[int][32]byte)
+	for n := 0; n <= 16; n++ {
+		items := make([]Elem, n)
+		for i := range items {
+			items[i] = Elem{A: uint64(i), B: uint64(i * 7)}
+		}
+		root, err := dynssz.HashTreeRoot(Container{Items: items})
+		if err != nil {
+			t.Fatalf("n=%d: unexpected error: %v", n, err)
+		}
+		roots[n] = root
+	}
+
+	// Sanity: distinct lengths produce distinct roots (mix_in_length differs).
+	if roots[10] == roots[11] {
+		t.Errorf("roots for n=10 and n=11 should differ")
+	}
+
+	// Genuinely oversized lists must still be rejected.
+	over := make([]Elem, 17)
+	if _, err := dynssz.HashTreeRoot(Container{Items: over}); err == nil {
+		t.Errorf("expected error for n=17 (exceeds max 16), got nil")
+	}
+}
+
 func TestFixedSizeStringVsByteArrayTreeRoot(t *testing.T) {
 	type WithFixedString struct {
 		Data string `ssz-size:"32"`

--- a/sszutils/marshal.go
+++ b/sszutils/marshal.go
@@ -52,6 +52,17 @@ func MarshalUint64Slice[T ~uint64](dst []byte, s []T) []byte {
 	return append(dst, unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(s))), len(s)*8)...)
 }
 
+// MarshalFixedBytesSlice appends the raw contents of a slice whose elements are
+// fixed-size byte arrays (e.g. []Root where Root is [32]byte) to dst in a single
+// copy. Such elements are laid out contiguously without padding, so this avoids
+// the per-element append loop. The element size is taken from the element type.
+func MarshalFixedBytesSlice[T any](dst []byte, s []T) []byte {
+	if len(s) == 0 {
+		return dst
+	}
+	return append(dst, unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(s))), len(s)*int(unsafe.Sizeof(s[0])))...)
+}
+
 // EncodeUint64Slice encodes a uint64 slice to an Encoder using bulk memory copy.
 // On little-endian architectures (x86, ARM64) this avoids per-element EncodeUint64 overhead.
 func EncodeUint64Slice[T ~uint64](enc Encoder, s []T) {

--- a/sszutils/unmarshal.go
+++ b/sszutils/unmarshal.go
@@ -45,6 +45,19 @@ func UnmarshalUint64Slice[T ~uint64](dst []T, buf []byte) {
 	copy(unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(dst))), len(dst)*8), buf)
 }
 
+// UnmarshalFixedBytesSlice bulk-copies a contiguous SSZ byte buffer into dst, a
+// slice whose elements are fixed-size byte arrays (e.g. []Root where Root is
+// [32]byte). dst must already have its final length. Because such elements are
+// laid out contiguously with no padding, the whole slice is decoded with a single
+// memory copy, avoiding the per-element copy loop. This is endian-neutral (raw
+// bytes). The element size is taken from the element type itself.
+func UnmarshalFixedBytesSlice[T any](dst []T, buf []byte) {
+	if len(dst) == 0 {
+		return
+	}
+	copy(unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(dst))), len(dst)*int(unsafe.Sizeof(dst[0]))), buf)
+}
+
 // DecodeUint64Slice decodes uint64 values from a Decoder directly into dst using bulk memory copy.
 // On little-endian architectures (x86, ARM64) this avoids per-element DecodeUint64 overhead.
 func DecodeUint64Slice[T ~uint64](dec Decoder, dst []T) error {

--- a/tests/spectests/consensus-spec-tests/.gitignore
+++ b/tests/spectests/consensus-spec-tests/.gitignore
@@ -1,1 +1,2 @@
 tests/
+version.txt


### PR DESCRIPTION
# Performance: faster codegen marshal/unmarshal and hash-tree-root

Two focused, semantics-preserving performance improvements to the codegen hot
paths, validated on a dedicated low-noise machine. No public API changes, no
allocation/byte regressions, identical SSZ roots.

Benchmarked with the [ssz-benchmark](https://github.com/pk910/ssz-benchmark)
suite on real mainnet & minimal Deneb beacon blocks and states.

## Summary

| Operation (mainnet) | Before | After | Δ |
|---|---|---|---|
| State HashTreeRoot | 49.7 ms | 43.9 ms | **−11.7 %** |
| State Marshal (buffer) | — | — | **−6.9 %** |
| State Unmarshal (buffer) | — | — | **−3.5 %** |
| Block HashTreeRoot | 451 µs | 449 µs | −0.5 % (neutral) |
| Block Marshal / Unmarshal | — | — | unchanged |

`allocs/op` and `B/op` are unchanged across all benchmarks.

---

## 1. Bulk byte-slice copy in generated marshal/unmarshal

`codegen/gen_marshal.go`, `codegen/gen_unmarshal.go`, `sszutils/marshal.go`,
`sszutils/unmarshal.go`

Slices/vectors of fixed-size byte arrays (`[]Root`, `[]KZGCommitment`,
`[]BLSPubKey`, …) were encoded/decoded with a per-element copy loop. Because such
elements are laid out contiguously with no padding, the whole slice is a single
contiguous byte region and can be copied in one `memmove`.

New helpers `sszutils.MarshalFixedBytesSlice` / `UnmarshalFixedBytesSlice` (mirroring
the existing `MarshalUint64Slice` fast path), gated by `isBulkBytesElem`, replace the
loop for these element types. For example `RANDAOMixes` (65 536 × 32 B) now decodes
with one copy instead of a 65 536-iteration loop.

- **Effect:** StateMainnet marshal −6.9 %, unmarshal −3.5 %. Scales with vector
  length, so it benefits the mainnet preset; minimal/block are unaffected.
- **No change** to allocations, bytes, or output. Endian-neutral (raw bytes).

## 2. Deferred cross-object batching in the hasher

`hasher/hasher.go` (+ tests in `hasher/hasher_test.go`)

When hashing a long list of fixed-size containers (e.g. ~1 M `Validator`s), the
hasher previously merkleized **each element independently** the moment its scope
closed — many tiny 4/2/1-pair hash calls and per-element scope bookkeeping.

The hasher now **defers** an element container's reduction: when `Merkleize`
closes a non-incremental container scope whose parent is an incremental
list/vector and whose chunk count is a power of two, the element's raw chunks are
left in the buffer and counted as *pending*. `Collapse` /
`MerkleizeWithMixin` / `MerkleizeProgressive*` then reduce all pending siblings
**level-by-level in wide hash calls** (`flushPending`) before the normal list
merkleize. This collapses thousands of small reductions into a handful of wide,
SIMD-friendly ones and removes most per-element overhead, while producing the
**identical** root (correct element-level zero-chunk padding is preserved).

Also added: a `PutBytes` fast path for two-chunk fields (33–64 B, e.g. the
48-byte BLS pubkey).

Properties:

- **No `HashWalker` interface change and no codegen change** — the optimization
  is entirely internal to `Hasher`, so it also batches across the
  `HashTreeRootWith`/`HashTreeRootWithDyn` method boundary of separately
  generated types.
- **Binary *and* progressive** lists are supported (deferral is independent of
  the parent tree shape). Non-power-of-two, very large (> 256-chunk), or
  non-incremental-parent containers fall back to the original path.
- **Effect:** StateMainnet HTR −11.7 %, StateMinimal HTR −12.7 %, block HTR
  neutral (−0.5 %). `allocs/op` and `B/op` unchanged.

### Correctness & compatibility

- Identical roots on real mainnet & minimal blocks and states; full test suite,
  codegen compat-tests (v1.1.1 → v1.3.0), reflection, and treeproof all pass.
- New tests validate the deferred path against an independent
  pre-reduced-roots reference for binary and progressive lists across element
  sizes 0–600 and field counts 2/4/8, plus a wide-field (pubkey) element, and the
  existing interleaved incremental/legacy test.
- Legacy callers using only `Index()`/`Merkleize` create no incremental layers,
  so deferral never engages — behavior is byte-identical.
- Opening an incremental child over deferred siblings flushes pending first
  (guards interleaved API usage); `pushLayer` resets the pending state so a
  pooled hasher reused after an abandoned/errored hash stays correct.

### Trade-off

State hashing holds up to ~64 KB of deferred element chunks between collapses
(vs. the previously eagerly-reduced buffer). The buffer is pooled and reused, so
per-op `allocs`/`B` are unchanged; only the transient working-set rises slightly,
in exchange for the −12 % CPU.

---

## Files changed

```
 codegen/gen_marshal.go   |   7 +
 codegen/gen_unmarshal.go |  27 +
 sszutils/marshal.go      |  11 +
 sszutils/unmarshal.go    |  13 +
 hasher/hasher.go         | 133 ++++++++++++++++++++++++---
 hasher/hasher_test.go    | 158 +++++++++++++++++++++++++++++++++
```

## Testing

```bash
go test ./...                 # full suite (incl. codegen compat-tests, reflection, treeproof)
go test ./hasher/ -run Defer  # deferred-batching correctness (binary + progressive)
```
