### PR TITLE
Fix marshal/HTR/stream inconsistencies found by differential fuzzing

### DIFF
--- a/codegen/gen_decoder.go
+++ b/codegen/gen_decoder.go
@@ -1128,15 +1128,25 @@ func (ctx *decoderContext) unmarshalOptionalList(desc *ssztypes.TypeDescriptor, 
 
 // unmarshalBigInt generates unmarshal code for SSZ big int types.
 func (ctx *decoderContext) unmarshalBigInt(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int) error {
-	ctx.appendCode(indent, "if buf, err := dec.DecodeBytesBuf(dec.GetLength()); err != nil {\n")
-	ctx.appendCode(indent+1, "return %s\n", typePath.getErrorWith("err"))
-	ctx.appendCode(indent, "} else {\n")
+	bigImport := ctx.typePrinter.AddImport("math/big", "big")
 	ptrVarName := varName
 	if desc.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 {
 		ptrVarName = fmt.Sprintf("*(%s)", varName)
 	}
-	mathImport := ctx.typePrinter.AddImport("math/big", "big")
-	ctx.appendCode(indent+1, "%s = %s\n", ptrVarName, ctx.getCastedValueVar(desc, fmt.Sprintf("*(%s.NewInt(0).SetBytes(buf))", mathImport), "big.Int"))
+	valVar := ctx.getValVar()
+	signErr := "sszutils.NewSszErrorf(sszutils.ErrInvalidValueRange, \"invalid big.Int sign byte\")"
+	// sign byte (0 = non-negative, 1 = negative) followed by the big-endian magnitude
+	ctx.appendCode(indent, "if buf, err := dec.DecodeBytesBuf(dec.GetLength()); err != nil {\n")
+	ctx.appendCode(indent+1, "return %s\n", typePath.getErrorWith("err"))
+	ctx.appendCode(indent, "} else if len(buf) > 0 && buf[0] > 1 {\n")
+	ctx.appendCode(indent+1, "return %s\n", typePath.getErrorWith(signErr))
+	ctx.appendCode(indent, "} else {\n")
+	ctx.appendCode(indent+1, "%s := %s.NewInt(0)\n", valVar, bigImport)
+	ctx.appendCode(indent+1, "if len(buf) > 0 {\n")
+	ctx.appendCode(indent+2, "%s.SetBytes(buf[1:])\n", valVar)
+	ctx.appendCode(indent+2, "if buf[0] == 1 {\n\t\t\t%s.Neg(%s)\n\t\t}\n", valVar, valVar)
+	ctx.appendCode(indent+1, "}\n")
+	ctx.appendCode(indent+1, "%s = %s\n", ptrVarName, ctx.getCastedValueVar(desc, fmt.Sprintf("*%s", valVar), "big.Int"))
 	ctx.appendCode(indent, "}\n")
 	return nil
 }

--- a/codegen/gen_encoder.go
+++ b/codegen/gen_encoder.go
@@ -440,6 +440,8 @@ func (ctx *encoderContext) marshalOptionalList(desc *ssztypes.TypeDescriptor, va
 
 // marshalBigInt generates marshal code for SSZ big int types.
 func (ctx *encoderContext) marshalBigInt(_ *ssztypes.TypeDescriptor, varName string, indent int) error {
+	// sign byte (0 = non-negative, 1 = negative) followed by the big-endian magnitude
+	ctx.appendCode(indent, "if %s.Sign() < 0 {\n\tenc.EncodeUint8(1)\n} else {\n\tenc.EncodeUint8(0)\n}\n", varName)
 	ctx.appendCode(indent, "enc.EncodeBytes(%s.Bytes())\n", varName)
 	return nil
 }

--- a/codegen/gen_hashtreeroot.go
+++ b/codegen/gen_hashtreeroot.go
@@ -443,11 +443,11 @@ func (ctx *hashTreeRootContext) hashOptionalList(desc *ssztypes.TypeDescriptor, 
 
 // hashBigInt generates hash tree root code for SSZ big int types.
 func (ctx *hashTreeRootContext) hashBigInt(_ *ssztypes.TypeDescriptor, varName string, indent int) error {
+	// hash the sign byte followed by the big-endian magnitude so values of equal
+	// magnitude but opposite sign do not collide
 	ctx.appendCode(indent, "{\n")
-	ctx.appendCode(indent+1, "bigIntBytes := %s.Bytes()\n", varName)
-	ctx.appendCode(indent+1, "if len(bigIntBytes) == 0 {\n")
-	ctx.appendCode(indent+2, "bigIntBytes = make([]byte, 1)\n")
-	ctx.appendCode(indent+1, "}\n")
+	ctx.appendCode(indent+1, "bigIntBytes := append([]byte{0}, %s.Bytes()...)\n", varName)
+	ctx.appendCode(indent+1, "if %s.Sign() < 0 {\n\t\tbigIntBytes[0] = 1\n\t}\n", varName)
 	ctx.appendCode(indent+1, "hh.PutBytes(bigIntBytes)\n")
 	ctx.appendCode(indent, "}\n")
 	return nil

--- a/codegen/gen_hashtreeroot.go
+++ b/codegen/gen_hashtreeroot.go
@@ -873,6 +873,12 @@ func (ctx *hashTreeRootContext) hashBitlist(desc *ssztypes.TypeDescriptor, varNa
 		maxVar = fmt.Sprintf("%d", desc.Limit)
 	}
 
+	// reject bitlists that are missing their termination bit, consistent with
+	// the marshal path and the reflection hash tree root implementation.
+	ctx.appendCode(indent, "if l := len(%s); l > 0 && %s[l-1] == 0x00 {\n", varName, varName)
+	ctx.appendCode(indent, "\treturn %s\n", typePath.getErrorWith("sszutils.ErrBitlistNotTerminatedFn()"))
+	ctx.appendCode(indent, "}\n")
+
 	ctx.appendCode(indent, "idx := hh.StartTree(sszutils.TreeTypeNone)\n")
 	hasherAlias := ctx.typePrinter.AddImport("github.com/pk910/dynamic-ssz/hasher", "hasher")
 	sizeVar := "_"

--- a/codegen/gen_hashtreeroot_test.go
+++ b/codegen/gen_hashtreeroot_test.go
@@ -634,3 +634,42 @@ func TestHashTreeRootContainerStaticPlusDynamicError(t *testing.T) {
 		t.Error("expected error for container with static + dynamic unsupported field")
 	}
 }
+
+// TestGenerateHashTreeRootBitlistTerminatorCheck verifies that the generated
+// hash tree root code for bitlists emits a guard rejecting bitlists that are
+// missing their termination bit (regression guard for the codegen half of the
+// HTR-vs-marshal bitlist inconsistency).
+func TestGenerateHashTreeRootBitlistTerminatorCheck(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		sszType ssztypes.SszType
+	}{
+		{"bitlist", ssztypes.SszBitlistType},
+		{"progressive-bitlist", ssztypes.SszProgressiveBitlistType},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			desc := &ssztypes.TypeDescriptor{
+				Type:    reflect.TypeOf([]byte(nil)),
+				SszType: tt.sszType,
+				Kind:    reflect.Slice,
+				Limit:   32,
+			}
+
+			codeBuilder := &strings.Builder{}
+			typePrinter := NewTypePrinter("test/package")
+			options := &CodeGeneratorOptions{}
+
+			if err := generateHashTreeRoot(desc, codeBuilder, typePrinter, "", options); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			out := codeBuilder.String()
+			if !strings.Contains(out, "[l-1] == 0x00") {
+				t.Errorf("generated bitlist HTR is missing the terminator-bit check:\n%s", out)
+			}
+			if !strings.Contains(out, "ErrBitlistNotTerminatedFn") {
+				t.Errorf("generated bitlist HTR is missing the ErrBitlistNotTerminatedFn return:\n%s", out)
+			}
+		})
+	}
+}

--- a/codegen/gen_marshal.go
+++ b/codegen/gen_marshal.go
@@ -417,6 +417,8 @@ func (ctx *marshalContext) marshalOptionalList(desc *ssztypes.TypeDescriptor, va
 
 // marshalBigInt generates marshal code for SSZ big int types.
 func (ctx *marshalContext) marshalBigInt(_ *ssztypes.TypeDescriptor, varName string, indent int) error {
+	// sign byte (0 = non-negative, 1 = negative) followed by the big-endian magnitude
+	ctx.appendCode(indent, "if %s.Sign() < 0 {\n\tdst = append(dst, 1)\n} else {\n\tdst = append(dst, 0)\n}\n", varName)
 	ctx.appendCode(indent, "dst = append(dst, %s.Bytes()...)\n", varName)
 	return nil
 }

--- a/codegen/gen_size.go
+++ b/codegen/gen_size.go
@@ -311,7 +311,7 @@ func (ctx *sizeContext) sizeType(desc *ssztypes.TypeDescriptor, varName, sizeVar
 	case ssztypes.SszOptionalListType:
 		return ctx.sizeOptionalList(desc, varName, sizeVar, indent)
 	case ssztypes.SszBigIntType:
-		ctx.appendCode(indent, "%s += len(%s.Bytes())\n", sizeVar, varName)
+		ctx.appendCode(indent, "%s += 1 + len(%s.Bytes())\n", sizeVar, varName)
 
 	default:
 		return fmt.Errorf("unsupported SSZ type: %v", desc.SszType)

--- a/codegen/gen_unmarshal.go
+++ b/codegen/gen_unmarshal.go
@@ -491,7 +491,7 @@ func (ctx *unmarshalContext) unmarshalType(desc *ssztypes.TypeDescriptor, varNam
 	case ssztypes.SszOptionalListType:
 		return ctx.unmarshalOptionalList(desc, varName, typePath, indent)
 	case ssztypes.SszBigIntType:
-		return ctx.unmarshalBigInt(desc, varName, indent)
+		return ctx.unmarshalBigInt(desc, varName, typePath, indent)
 
 	default:
 		return fmt.Errorf("unsupported SSZ type: %v", desc.SszType)
@@ -503,7 +503,10 @@ func (ctx *unmarshalContext) unmarshalType(desc *ssztypes.TypeDescriptor, varNam
 // unmarshalOptional generates unmarshal code for SSZ optional types.
 func (ctx *unmarshalContext) unmarshalOptional(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int) error {
 	ctx.appendCode(indent, "if len(buf) < 1 {\n\treturn %s\n}\n", typePath.getErrorWith("sszutils.ErrOptionalFlagEOFFn()"))
-	ctx.appendCode(indent, "if buf[0] == 1 {\n")
+	ctx.appendCode(indent, "switch buf[0] {\n")
+	ctx.appendCode(indent, "case 0:\n")
+	ctx.appendCode(indent+1, "%s = nil\n", varName)
+	ctx.appendCode(indent, "case 1:\n")
 
 	// Check that buf has enough bytes for the presence flag plus the value
 	elemSize := desc.ElemDesc.Size
@@ -518,8 +521,9 @@ func (ctx *unmarshalContext) unmarshalOptional(desc *ssztypes.TypeDescriptor, va
 		return err
 	}
 	ctx.appendCode(indent+1, "%s = &%s\n", varName, valVar)
-	ctx.appendCode(indent, "} else {\n")
-	ctx.appendCode(indent+1, "%s = nil\n", varName)
+	ctx.appendCode(indent, "default:\n")
+	signErr := "sszutils.NewSszErrorf(sszutils.ErrInvalidValueRange, \"invalid optional availability byte\")"
+	ctx.appendCode(indent+1, "return %s\n", typePath.getErrorWith(signErr))
 	ctx.appendCode(indent, "}\n")
 	return nil
 }
@@ -554,17 +558,22 @@ func (ctx *unmarshalContext) unmarshalOptionalList(desc *ssztypes.TypeDescriptor
 }
 
 // unmarshalBigInt generates unmarshal code for SSZ big int types.
-func (ctx *unmarshalContext) unmarshalBigInt(desc *ssztypes.TypeDescriptor, varName string, indent int) error {
+func (ctx *unmarshalContext) unmarshalBigInt(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int) error {
 	bigImport := ctx.typePrinter.AddImport("math/big", "big")
 	ptrVarName := varName
 	if desc.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 {
 		ptrVarName = fmt.Sprintf("*(%s)", varName)
 	}
-	ctx.appendCode(indent,
-		"%s = %s\n",
-		ptrVarName,
-		ctx.getCastedValueVar(desc, fmt.Sprintf("*(%s.NewInt(0).SetBytes(buf))", bigImport), "big.Int"),
-	)
+	valVar := ctx.getValVar()
+	signErr := "sszutils.NewSszErrorf(sszutils.ErrInvalidValueRange, \"invalid big.Int sign byte\")"
+	// sign byte (0 = non-negative, 1 = negative) followed by the big-endian magnitude
+	ctx.appendCode(indent, "%s := %s.NewInt(0)\n", valVar, bigImport)
+	ctx.appendCode(indent, "if len(buf) > 0 {\n")
+	ctx.appendCode(indent+1, "if buf[0] > 1 {\n\t\treturn %s\n\t}\n", typePath.getErrorWith(signErr))
+	ctx.appendCode(indent+1, "%s.SetBytes(buf[1:])\n", valVar)
+	ctx.appendCode(indent+1, "if buf[0] == 1 {\n\t\t%s.Neg(%s)\n\t}\n", valVar, valVar)
+	ctx.appendCode(indent, "}\n")
+	ctx.appendCode(indent, "%s = %s\n", ptrVarName, ctx.getCastedValueVar(desc, fmt.Sprintf("*%s", valVar), "big.Int"))
 	return nil
 }
 

--- a/codegen/parser.go
+++ b/codegen/parser.go
@@ -901,6 +901,11 @@ func (p *Parser) buildContainerDescriptor(desc *ssztypes.TypeDescriptor, dataStr
 	size := uint32(0)
 	isDynamic := false
 
+	// Progressive-container detection: tracks whether any field carries an
+	// ssz-index tag, and (parallel to fields) which ones do.
+	hasAnyIndexTag := false
+	fieldHasIndex := []bool{}
+
 	// Check if we're using a view descriptor (data and schema types differ)
 	isViewDescriptor := dataStruct != schemaStruct
 
@@ -968,12 +973,15 @@ func (p *Parser) buildContainerDescriptor(desc *ssztypes.TypeDescriptor, dataStr
 		}
 
 		// Handle ssz-index for progressive containers - extract from original tag parsing
+		hasIndex := false
 		if indexStr := p.extractSszIndex(schemaStruct.Tag(i)); indexStr != "" {
 			idx, err := strconv.ParseUint(indexStr, 10, 16)
 			if err != nil {
 				return fmt.Errorf("invalid ssz-index: %v", indexStr)
 			}
 			fieldDesc.SszIndex = uint16(idx)
+			hasIndex = true
+			hasAnyIndexTag = true
 		}
 
 		if typeDesc.SszTypeFlags&ssztypes.SszTypeFlagIsDynamic != 0 {
@@ -992,6 +1000,7 @@ func (p *Parser) buildContainerDescriptor(desc *ssztypes.TypeDescriptor, dataStr
 
 		desc.SszTypeFlags |= fieldDesc.Type.SszTypeFlags & (ssztypes.SszTypeFlagHasDynamicSize | ssztypes.SszTypeFlagHasDynamicMax | ssztypes.SszTypeFlagHasSizeExpr | ssztypes.SszTypeFlagHasMaxExpr)
 		fields = append(fields, fieldDesc)
+		fieldHasIndex = append(fieldHasIndex, hasIndex)
 	}
 
 	containerDesc := &ssztypes.ContainerDescriptor{
@@ -999,6 +1008,23 @@ func (p *Parser) buildContainerDescriptor(desc *ssztypes.TypeDescriptor, dataStr
 		DynFields: dynFields,
 	}
 	desc.ContainerDesc = containerDesc
+
+	// A container with ssz-index tags is a progressive container. All fields must
+	// carry the tag and the indices must strictly increase.
+	if hasAnyIndexTag {
+		for i, has := range fieldHasIndex {
+			if !has {
+				return fmt.Errorf("progressive container field %s missing ssz-index tag", fields[i].Name)
+			}
+		}
+		for i := 1; i < len(fields); i++ {
+			if fields[i].SszIndex <= fields[i-1].SszIndex {
+				return fmt.Errorf("progressive container requires increasing ssz-index values (field %s has index %d, previous field has %d)",
+					fields[i].Name, fields[i].SszIndex, fields[i-1].SszIndex)
+			}
+		}
+		desc.SszType = ssztypes.SszProgressiveContainerType
+	}
 
 	desc.Len = size
 	if isDynamic {

--- a/codegen/tests/codegen_test.go
+++ b/codegen/tests/codegen_test.go
@@ -502,3 +502,53 @@ func testCodegenPayload(t *testing.T, payload TestPayload) {
 		t.Fatalf("Hash root mismatch 2: expected %s, got %s", payload.Hash, hashRootHex)
 	}
 }
+
+// TestCodegenProgressiveIndexOnly verifies that codegen auto-detects a
+// progressive container from ssz-index tags alone (no explicit
+// ssz-type:"progressive-container"), matching the reflection engine. The
+// generated method is invoked directly so the codegen path is actually exercised
+// (passing a value to ds.HashTreeRoot would fall back to reflection on both
+// sides and never compare codegen output).
+func TestCodegenProgressiveIndexOnly(t *testing.T) {
+	genRoot, err := ProgIndexOnly_Payload.HashTreeRoot()
+	if err != nil {
+		t.Fatalf("generated HashTreeRoot: %v", err)
+	}
+
+	// Identical struct without generated methods -> pure reflection.
+	type reflProg struct {
+		A uint8 `ssz-index:"0"`
+		B uint8 `ssz-index:"5"`
+		C uint8 `ssz-index:"7"`
+	}
+	ds := dynssz.NewDynSsz(nil)
+	reflRoot, err := ds.HashTreeRoot(reflProg{A: 1, B: 2, C: 3})
+	if err != nil {
+		t.Fatalf("reflection HashTreeRoot: %v", err)
+	}
+	if genRoot != reflRoot {
+		t.Fatalf("progressive container HTR mismatch: codegen=%x reflection=%x", genRoot, reflRoot)
+	}
+}
+
+// TestCodegenZeroMaxList verifies that ssz-max:"0" is treated as a "no limit"
+// placeholder: the generated method (which always allowed it) and the reflection
+// engine (fixed to stop rejecting it) produce the same root.
+func TestCodegenZeroMaxList(t *testing.T) {
+	genRoot, err := ZeroMaxList_Payload.HashTreeRoot()
+	if err != nil {
+		t.Fatalf("generated HashTreeRoot: %v", err)
+	}
+
+	type reflZeroMax struct {
+		X []uint64 `ssz-max:"0"`
+	}
+	ds := dynssz.NewDynSsz(nil)
+	reflRoot, err := ds.HashTreeRoot(reflZeroMax{X: []uint64{1, 2, 3}})
+	if err != nil {
+		t.Fatalf("reflection HashTreeRoot (ssz-max:0 should be no-limit): %v", err)
+	}
+	if genRoot != reflRoot {
+		t.Fatalf("ssz-max:0 HTR mismatch: codegen=%x reflection=%x", genRoot, reflRoot)
+	}
+}

--- a/codegen/tests/codegen_test.go
+++ b/codegen/tests/codegen_test.go
@@ -56,6 +56,20 @@ var testMatrix = []TestPayload{
 		Hash:    "317f412cd2d042f367c4f2fb6447828ef9524396428eb2ed0837524bcc70433c",
 	},
 	{
+		// progressive container auto-detected from ssz-index tags alone
+		Name:    "ProgIndexOnly",
+		Payload: ProgIndexOnly_Payload,
+		Specs:   map[string]any{},
+		Hash:    "0c3b77007ca813db8a3d0ced4634530d9db15785e4b7a2b6c21db45c9ccd6409",
+	},
+	{
+		// ssz-max:"0" is a no-limit placeholder, not a zero limit
+		Name:    "ZeroMaxList",
+		Payload: ZeroMaxList_Payload,
+		Specs:   map[string]any{},
+		Hash:    "0100000000000000020000000000000003000000000000000000000000000000",
+	},
+	{
 		Name:    "ViewTypes_View1",
 		Payload: ViewTypes1_Payload,
 		View:    (*ViewTypes1_View1)(nil),
@@ -500,55 +514,5 @@ func testCodegenPayload(t *testing.T, payload TestPayload) {
 	hashRootHex = hex.EncodeToString(hashRoot[:])
 	if hashRootHex != payload.Hash {
 		t.Fatalf("Hash root mismatch 2: expected %s, got %s", payload.Hash, hashRootHex)
-	}
-}
-
-// TestCodegenProgressiveIndexOnly verifies that codegen auto-detects a
-// progressive container from ssz-index tags alone (no explicit
-// ssz-type:"progressive-container"), matching the reflection engine. The
-// generated method is invoked directly so the codegen path is actually exercised
-// (passing a value to ds.HashTreeRoot would fall back to reflection on both
-// sides and never compare codegen output).
-func TestCodegenProgressiveIndexOnly(t *testing.T) {
-	genRoot, err := ProgIndexOnly_Payload.HashTreeRoot()
-	if err != nil {
-		t.Fatalf("generated HashTreeRoot: %v", err)
-	}
-
-	// Identical struct without generated methods -> pure reflection.
-	type reflProg struct {
-		A uint8 `ssz-index:"0"`
-		B uint8 `ssz-index:"5"`
-		C uint8 `ssz-index:"7"`
-	}
-	ds := dynssz.NewDynSsz(nil)
-	reflRoot, err := ds.HashTreeRoot(reflProg{A: 1, B: 2, C: 3})
-	if err != nil {
-		t.Fatalf("reflection HashTreeRoot: %v", err)
-	}
-	if genRoot != reflRoot {
-		t.Fatalf("progressive container HTR mismatch: codegen=%x reflection=%x", genRoot, reflRoot)
-	}
-}
-
-// TestCodegenZeroMaxList verifies that ssz-max:"0" is treated as a "no limit"
-// placeholder: the generated method (which always allowed it) and the reflection
-// engine (fixed to stop rejecting it) produce the same root.
-func TestCodegenZeroMaxList(t *testing.T) {
-	genRoot, err := ZeroMaxList_Payload.HashTreeRoot()
-	if err != nil {
-		t.Fatalf("generated HashTreeRoot: %v", err)
-	}
-
-	type reflZeroMax struct {
-		X []uint64 `ssz-max:"0"`
-	}
-	ds := dynssz.NewDynSsz(nil)
-	reflRoot, err := ds.HashTreeRoot(reflZeroMax{X: []uint64{1, 2, 3}})
-	if err != nil {
-		t.Fatalf("reflection HashTreeRoot (ssz-max:0 should be no-limit): %v", err)
-	}
-	if genRoot != reflRoot {
-		t.Fatalf("ssz-max:0 HTR mismatch: codegen=%x reflection=%x", genRoot, reflRoot)
 	}
 }

--- a/codegen/tests/codegen_test.go
+++ b/codegen/tests/codegen_test.go
@@ -126,6 +126,35 @@ func TestCodegenExtendedTypes(t *testing.T) {
 	}
 }
 
+// TestCodegenBigIntGolden pins the generated big.Int hash tree root against
+// hardcoded golden values. The other codegen tests for extended types are purely
+// differential (codegen vs reflection), so a simultaneous change to both engines
+// would otherwise go unnoticed; these golden roots catch it. ExtendedTypes1 has a
+// value big.Int field, CoverageTypes2 a pointer *big.Int.
+func TestCodegenBigIntGolden(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload any
+		golden  string
+	}{
+		{"valueBigInt", ExtendedTypes1_Payload1, "5235f836b4e001a3984250744d2749e4ba9e79158c8fb36e6cde7acf1d62920c"},
+		{"pointerBigInt", CoverageTypes2_Payload1, "86b9299d76a4d3550dc10899d5508e1c4e1a0467a5c1b7dca4774c1f717b62ea"},
+	}
+
+	ds := dynssz.NewDynSsz(nil, dynssz.WithExtendedTypes())
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root, err := ds.HashTreeRoot(tc.payload)
+			if err != nil {
+				t.Fatalf("HashTreeRoot: %v", err)
+			}
+			if got := hex.EncodeToString(root[:]); got != tc.golden {
+				t.Fatalf("codegen big.Int root changed: got %s want %s", got, tc.golden)
+			}
+		})
+	}
+}
+
 func TestCodegenCoverageTypes1(t *testing.T) {
 	testCodegenPayloadByReflection(t, CoverageTypes1_Payload, SimpleTypesWithSpecs_Specs)
 }

--- a/codegen/tests/gen_ssz.yaml
+++ b/codegen/tests/gen_ssz.yaml
@@ -41,6 +41,10 @@ types:
 
   - name: ProgressiveTypes
     output: gen_progressive.go
+  - name: ProgIndexOnly
+    output: gen_progressive.go
+  - name: ZeroMaxList
+    output: gen_progressive.go
   - name: CustomTypes1
     output: gen_custom.go
   - name: CoverageTypes1

--- a/codegen/tests/types.go
+++ b/codegen/tests/types.go
@@ -318,6 +318,24 @@ var SimpleTypesWithSpecs_Specs = map[string]any{
 	"F2_MAX":       8,
 }
 
+// ProgIndexOnly is a progressive container detected purely from ssz-index tags
+// (no explicit ssz-type:"progressive-container"), exercising codegen auto-detection.
+type ProgIndexOnly struct {
+	A uint8 `ssz-index:"0"`
+	B uint8 `ssz-index:"5"`
+	C uint8 `ssz-index:"7"`
+}
+
+var ProgIndexOnly_Payload = ProgIndexOnly{A: 1, B: 2, C: 3}
+
+// ZeroMaxList exercises ssz-max:"0": the limit check must fire (codegen used to
+// treat a zero limit as "no limit").
+type ZeroMaxList struct {
+	X []uint64 `ssz-max:"0"`
+}
+
+var ZeroMaxList_Payload = ZeroMaxList{X: []uint64{1, 2, 3}}
+
 type ProgressiveTypes struct {
 	C1 struct {
 		F1 uint64      `ssz-index:"0"`

--- a/dynssz-gen/main_test.go
+++ b/dynssz-gen/main_test.go
@@ -1159,3 +1159,20 @@ func TestFindAnnotateCallInDecl_OtherDeclKind(t *testing.T) {
 		t.Errorf("expected empty from BadDecl, got %q", got)
 	}
 }
+
+// TestRun_ExternalViewLoading exercises external view-type package loading in
+// run(): the first view ref (canonical path to a package the base does not
+// import) triggers a fresh load + verbose log; the second ref to the same
+// package by a relative spelling hits the canonical-path cache.
+func TestRun_ExternalViewLoading(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "out.go")
+	cfg := Config{
+		PackagePath: "github.com/pk910/dynamic-ssz/dynssz-gen/testpkg/viewfix",
+		TypeNames:   "Base:views=github.com/pk910/dynamic-ssz/dynssz-gen/testpkg/viewfix/sub.View1;./testpkg/viewfix/sub.View2",
+		OutputFile:  out,
+		Verbose:     true,
+	}
+	if err := run(&cfg); err != nil {
+		t.Fatalf("run with external view types failed: %v", err)
+	}
+}

--- a/dynssz-gen/testpkg/viewfix/sub/sub.go
+++ b/dynssz-gen/testpkg/viewfix/sub/sub.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the dynamic-ssz library.
+
+// Package sub holds view types for the viewfix.Base fixture.
+package sub
+
+// View1 exposes a subset of viewfix.Base.
+type View1 struct {
+	F1 uint64
+}
+
+// View2 exposes all of viewfix.Base.
+type View2 struct {
+	F1 uint64
+	F2 uint64
+}

--- a/dynssz-gen/testpkg/viewfix/viewfix.go
+++ b/dynssz-gen/testpkg/viewfix/viewfix.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the dynamic-ssz library.
+
+// Package viewfix is a dynssz-gen coverage fixture for external view-type
+// loading. It deliberately does NOT import its sub package, so a view type
+// referenced from sub triggers a fresh external package load.
+package viewfix
+
+// Base is a simple container with view types defined in the sub package.
+type Base struct {
+	F1 uint64
+	F2 uint64
+}

--- a/dynssz.go
+++ b/dynssz.go
@@ -209,6 +209,9 @@ func (d *DynSsz) resolveSchemaType(runtimeType reflect.Type, cfg *callConfig) re
 //	}
 //	fmt.Printf("Encoded %d bytes\n", len(data))
 func (d *DynSsz) MarshalSSZ(source any, opts ...CallOption) ([]byte, error) {
+	if source == nil {
+		return nil, sszutils.NewSszError(sszutils.ErrInvalidValueRange, "source must not be nil")
+	}
 	cfg := applyCallOptions(opts)
 
 	// Skip view descriptor logic for types implementing DynamicMarshaler (they handle their own serialization)
@@ -306,6 +309,9 @@ func (d *DynSsz) MarshalSSZ(source any, opts ...CallOption) ([]byte, error) {
 //	}
 //	fmt.Printf("Serialized %d blocks into %d bytes\n", len(blocks), len(buf))
 func (d *DynSsz) MarshalSSZTo(source any, buf []byte, opts ...CallOption) ([]byte, error) {
+	if source == nil {
+		return nil, sszutils.NewSszError(sszutils.ErrInvalidValueRange, "source must not be nil")
+	}
 	cfg := applyCallOptions(opts)
 
 	// Skip view descriptor logic for types implementing DynamicMarshaler
@@ -331,6 +337,22 @@ func (d *DynSsz) MarshalSSZTo(source any, buf []byte, opts ...CallOption) ([]byt
 	}
 
 	ctx := reflection.NewReflectionCtx(d, d.options.LogCb, d.options.Verbose, d.options.NoFastSsz)
+
+	// Grow buf so the serialized data can be appended without overrunning its
+	// capacity (BufferEncoder writes at len(buf) using cap(buf) directly).
+	size, err := ctx.SizeSSZ(sourceTypeDesc, sourceValue)
+	if err != nil {
+		return nil, err
+	}
+	if int64(size) > int64(math.MaxInt)-int64(len(buf)) {
+		return nil, fmt.Errorf("SSZ size %d exceeds platform int max", size)
+	}
+	needed := len(buf) + int(size)
+	if cap(buf) < needed {
+		grown := make([]byte, len(buf), needed)
+		copy(grown, buf)
+		buf = grown
+	}
 
 	encoder := sszutils.NewBufferEncoder(buf)
 	err = ctx.MarshalSSZ(sourceTypeDesc, sourceValue, encoder)
@@ -396,6 +418,9 @@ func (d *DynSsz) MarshalSSZTo(source any, buf []byte, opts ...CallOption) ([]byt
 //
 //	err = ds.MarshalSSZWriter(block, conn)
 func (d *DynSsz) MarshalSSZWriter(source any, w io.Writer, opts ...CallOption) error {
+	if source == nil {
+		return sszutils.NewSszError(sszutils.ErrInvalidValueRange, "source must not be nil")
+	}
 	cfg := applyCallOptions(opts)
 	encoder := sszutils.NewStreamEncoder(w, d.options.StreamWriterBufferSize)
 
@@ -477,6 +502,9 @@ func (d *DynSsz) MarshalSSZWriter(source any, w io.Writer, opts ...CallOption) e
 //	buf := make([]byte, 0, size)
 //	buf, err = ds.MarshalSSZTo(state, buf)
 func (d *DynSsz) SizeSSZ(source any, opts ...CallOption) (int, error) {
+	if source == nil {
+		return 0, sszutils.NewSszError(sszutils.ErrInvalidValueRange, "source must not be nil")
+	}
 	cfg := applyCallOptions(opts)
 
 	// Skip view descriptor logic for types implementing DynamicSizer
@@ -548,6 +576,9 @@ func (d *DynSsz) SizeSSZ(source any, opts ...CallOption) (int, error) {
 //	}
 //	fmt.Printf("Decoded header for slot %d\n", header.Slot)
 func (d *DynSsz) UnmarshalSSZ(target any, ssz []byte, opts ...CallOption) error {
+	if target == nil {
+		return sszutils.NewSszError(sszutils.ErrInvalidValueRange, "target must not be nil")
+	}
 	cfg := applyCallOptions(opts)
 
 	// Skip view descriptor logic for types implementing DynamicUnmarshaler
@@ -661,6 +692,9 @@ func (d *DynSsz) UnmarshalSSZ(target any, ssz []byte, opts ...CallOption) error 
 //	var block phase0.BeaconBlock
 //	err = ds.UnmarshalSSZReader(&block, conn, -1)
 func (d *DynSsz) UnmarshalSSZReader(target any, r io.Reader, size int, opts ...CallOption) error {
+	if target == nil {
+		return sszutils.NewSszError(sszutils.ErrInvalidValueRange, "target must not be nil")
+	}
 	cfg := applyCallOptions(opts)
 	decoder := sszutils.NewStreamDecoder(r, size, d.options.StreamReaderBufferSize)
 	decoder.PushLimit(size)
@@ -769,6 +803,9 @@ func (d *DynSsz) UnmarshalSSZReader(target any, r io.Reader, size int, opts ...C
 //	}
 //	fmt.Printf("Block root: %x\n", root)
 func (d *DynSsz) HashTreeRoot(source any, opts ...CallOption) ([32]byte, error) {
+	if source == nil {
+		return [32]byte{}, sszutils.NewSszError(sszutils.ErrInvalidValueRange, "source must not be nil")
+	}
 	var pool *hasher.HasherPool
 	if d.options.NoFastHash {
 		pool = &hasher.DefaultHasherPool
@@ -824,6 +861,9 @@ func (d *DynSsz) HashTreeRoot(source any, opts ...CallOption) ([32]byte, error) 
 //	}
 //	fmt.Printf("Block root: %x\n", hh.HashRoot())
 func (d *DynSsz) HashTreeRootWith(source any, hh sszutils.HashWalker, opts ...CallOption) error {
+	if source == nil {
+		return sszutils.NewSszError(sszutils.ErrInvalidValueRange, "source must not be nil")
+	}
 	cfg := applyCallOptions(opts)
 
 	// Skip view descriptor logic for types implementing DynamicHashRoot
@@ -916,6 +956,9 @@ func (d *DynSsz) HashTreeRootWith(source any, hh sszutils.HashWalker, opts ...Ca
 // Note: For progressive containers (with ssz-index tags), the tree structure will be
 // progressive rather than binary, which affects the generalized indices of fields.
 func (d *DynSsz) GetTree(source any, opts ...CallOption) (*treeproof.Node, error) {
+	if source == nil {
+		return nil, sszutils.NewSszError(sszutils.ErrInvalidValueRange, "source must not be nil")
+	}
 	w := treeproof.NewWrapper()
 
 	if err := d.HashTreeRootWith(source, w, opts...); err != nil {

--- a/dynssz_test.go
+++ b/dynssz_test.go
@@ -1322,3 +1322,291 @@ func TestHashTreeRootWithReflectionError(t *testing.T) {
 		t.Fatal("expected error for corrupted type descriptor")
 	}
 }
+
+// --- Bitlist marshal/HTR fixes (empty, nested, missing terminator) ---
+
+func TestEmptyBitlistMarshalDoesNotPanic(t *testing.T) {
+	type T struct {
+		X []byte `ssz-type:"bitlist" ssz-max:"16"`
+	}
+
+	ds := NewDynSsz(nil)
+
+	cases := map[string][]byte{
+		"nil":         nil,
+		"emptyNonNil": {},
+	}
+
+	want := []byte{0x04, 0x00, 0x00, 0x00, 0x01}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			enc, err := ds.MarshalSSZ(&T{X: in})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !bytes.Equal(enc, want) {
+				t.Fatalf("unexpected encoding: got %x want %x", enc, want)
+			}
+		})
+	}
+}
+
+func TestEmptyProgressiveBitlistMarshalDoesNotPanic(t *testing.T) {
+	type T struct {
+		X []byte `ssz-type:"progressive-bitlist" ssz-max:"16"`
+	}
+
+	ds := NewDynSsz(nil)
+	enc, err := ds.MarshalSSZ(&T{X: nil})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []byte{0x04, 0x00, 0x00, 0x00, 0x01}
+	if !bytes.Equal(enc, want) {
+		t.Fatalf("unexpected encoding: got %x want %x", enc, want)
+	}
+}
+
+func TestNilBitlistNestedInContainer(t *testing.T) {
+	type T struct {
+		Pre uint32
+		X   []byte `ssz-type:"bitlist" ssz-max:"16"`
+		Pst uint64
+	}
+
+	ds := NewDynSsz(nil)
+	enc, err := ds.MarshalSSZ(&T{Pre: 1, Pst: 2})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var dst T
+	if err := ds.UnmarshalSSZ(&dst, enc); err != nil {
+		t.Fatalf("roundtrip unmarshal failed: %v", err)
+	}
+	if dst.Pre != 1 || dst.Pst != 2 {
+		t.Fatalf("roundtrip mismatch: %+v", dst)
+	}
+}
+
+func TestNilBitlistInListOfStructs(t *testing.T) {
+	type Inner struct {
+		X []byte `ssz-type:"progressive-bitlist" ssz-max:"16"`
+	}
+	type Outer struct {
+		Inner []*Inner `ssz-max:"4"`
+	}
+
+	ds := NewDynSsz(nil)
+	enc, err := ds.MarshalSSZ(&Outer{Inner: []*Inner{{X: nil}, {X: nil}}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var dst Outer
+	if err := ds.UnmarshalSSZ(&dst, enc); err != nil {
+		t.Fatalf("roundtrip unmarshal failed: %v", err)
+	}
+	if len(dst.Inner) != 2 {
+		t.Fatalf("expected 2 inner items, got %d", len(dst.Inner))
+	}
+}
+
+func TestNilBitlistStreamMatchesBuffer(t *testing.T) {
+	type T struct {
+		X []byte `ssz-type:"bitlist" ssz-max:"16"`
+	}
+
+	ds := NewDynSsz(nil)
+	bufEnc, err := ds.MarshalSSZ(&T{X: nil})
+	if err != nil {
+		t.Fatalf("buffer marshal failed: %v", err)
+	}
+
+	var sb bytes.Buffer
+	if err := ds.MarshalSSZWriter(&T{X: nil}, &sb); err != nil {
+		t.Fatalf("stream marshal failed: %v", err)
+	}
+
+	if !bytes.Equal(bufEnc, sb.Bytes()) {
+		t.Fatalf("stream/buffer mismatch: buffer=%x stream=%x", bufEnc, sb.Bytes())
+	}
+}
+
+func TestNilBitlistHTRAndMarshalAgree(t *testing.T) {
+	type T struct {
+		X []byte `ssz-type:"bitlist" ssz-max:"16"`
+	}
+
+	ds := NewDynSsz(nil)
+
+	if _, err := ds.MarshalSSZ(&T{X: nil}); err != nil {
+		t.Fatalf("marshal of nil bitlist failed: %v", err)
+	}
+
+	r1, err := ds.HashTreeRoot(&T{X: nil})
+	if err != nil {
+		t.Fatalf("HTR of nil bitlist failed: %v", err)
+	}
+	r2, err := ds.HashTreeRoot(&T{X: []byte{0x01}})
+	if err != nil {
+		t.Fatalf("HTR of empty bitlist failed: %v", err)
+	}
+	if r1 != r2 {
+		t.Fatalf("nil and empty bitlist should hash equally: %x != %x", r1, r2)
+	}
+}
+
+func TestBitlistMissingTerminatorHTRRejected(t *testing.T) {
+	type T struct {
+		X []byte `ssz-type:"bitlist" ssz-max:"32"`
+	}
+
+	ds := NewDynSsz(nil)
+	src := &T{X: []byte{0xff, 0x00}} // last byte 0x00 => no terminator
+
+	if _, err := ds.MarshalSSZ(src); err == nil {
+		t.Fatalf("marshal should reject a non-terminated bitlist")
+	}
+
+	if _, err := ds.HashTreeRoot(src); err == nil {
+		t.Fatalf("HTR should reject a non-terminated bitlist")
+	} else if !errors.Is(err, sszutils.ErrInvalidValueRange) {
+		t.Fatalf("expected ErrInvalidValueRange, got %v", err)
+	}
+}
+
+// --- Byte-aligned bitvector followed by another field must round-trip ---
+
+func TestBitvectorByteAlignedRoundtrip(t *testing.T) {
+	ds := NewDynSsz(nil)
+
+	t.Run("bitsize8", func(t *testing.T) {
+		type T struct {
+			BV    []byte `ssz-type:"bitvector" ssz-bitsize:"8"`
+			After uint64
+		}
+		src := &T{BV: []byte{0xff}, After: 1}
+		enc, err := ds.MarshalSSZ(src)
+		if err != nil {
+			t.Fatalf("marshal failed: %v", err)
+		}
+		var dst T
+		if err := ds.UnmarshalSSZ(&dst, enc); err != nil {
+			t.Fatalf("unmarshal failed: %v", err)
+		}
+		if !bytes.Equal(dst.BV, src.BV) || dst.After != src.After {
+			t.Fatalf("roundtrip mismatch: %+v", dst)
+		}
+	})
+
+	t.Run("bitsize16", func(t *testing.T) {
+		type T struct {
+			BV    []byte `ssz-type:"bitvector" ssz-bitsize:"16"`
+			After uint64
+		}
+		src := &T{BV: []byte{0xff, 0xff}, After: 1}
+		enc, err := ds.MarshalSSZ(src)
+		if err != nil {
+			t.Fatalf("marshal failed: %v", err)
+		}
+		var dst T
+		if err := ds.UnmarshalSSZ(&dst, enc); err != nil {
+			t.Fatalf("unmarshal failed: %v", err)
+		}
+		if !bytes.Equal(dst.BV, src.BV) || dst.After != src.After {
+			t.Fatalf("roundtrip mismatch: %+v", dst)
+		}
+	})
+
+	t.Run("bitsize32", func(t *testing.T) {
+		type T struct {
+			BV    []byte `ssz-type:"bitvector" ssz-bitsize:"32"`
+			After uint64
+		}
+		src := &T{BV: []byte{0xff, 0xff, 0xff, 0xff}, After: 1}
+		enc, err := ds.MarshalSSZ(src)
+		if err != nil {
+			t.Fatalf("marshal failed: %v", err)
+		}
+		var dst T
+		if err := ds.UnmarshalSSZ(&dst, enc); err != nil {
+			t.Fatalf("unmarshal failed: %v", err)
+		}
+		if !bytes.Equal(dst.BV, src.BV) || dst.After != src.After {
+			t.Fatalf("roundtrip mismatch: %+v", dst)
+		}
+	})
+
+	t.Run("bitsize12_paddingStillChecked", func(t *testing.T) {
+		// 12 bits => 2 bytes; the top 4 bits of the 2nd byte are padding and must be 0.
+		type T struct {
+			BV    []byte `ssz-type:"bitvector" ssz-bitsize:"12"`
+			After uint64
+		}
+		good := []byte{0xff, 0x0f, 0, 0, 0, 0, 0, 0, 0, 0} // padding bits zero
+		var dst T
+		if err := ds.UnmarshalSSZ(&dst, good); err != nil {
+			t.Fatalf("valid 12-bit bitvector should decode: %v", err)
+		}
+		bad := []byte{0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0} // padding bits set
+		if err := ds.UnmarshalSSZ(&T{}, bad); err == nil {
+			t.Fatalf("expected padding error for non-zero padding bits")
+		}
+	})
+}
+
+// --- Recursive type definitions must error instead of stack overflowing ---
+
+type recursiveType struct {
+	Val      uint32
+	Children []*recursiveType `ssz-max:"4"`
+}
+
+func TestRecursiveTypeRejected(t *testing.T) {
+	ds := NewDynSsz(nil)
+
+	var err error
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("recursive type caused a panic: %v", r)
+			}
+		}()
+		_, err = ds.MarshalSSZ(&recursiveType{})
+	}()
+
+	if err == nil {
+		t.Fatalf("expected an error for recursive type, got nil")
+	}
+	if !errors.Is(err, sszutils.ErrUnsupportedType) {
+		t.Fatalf("expected ErrUnsupportedType, got %v", err)
+	}
+}
+
+// --- Stream writer with a too-small buffer must not panic ---
+
+func TestStreamWriterBufferTooSmall(t *testing.T) {
+	for _, sz := range []int{1, 3, 4, 7} {
+		ds := NewDynSsz(nil, WithStreamWriterBufferSize(sz))
+		var sb bytes.Buffer
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("buffer size %d caused a panic: %v", sz, r)
+				}
+			}()
+			if err := ds.MarshalSSZWriter(&struct{ A uint64 }{A: 1}, &sb); err != nil {
+				t.Fatalf("buffer size %d marshal failed: %v", sz, err)
+			}
+		}()
+
+		ref, err := ds.MarshalSSZ(&struct{ A uint64 }{A: 1})
+		if err != nil {
+			t.Fatalf("reference marshal failed: %v", err)
+		}
+		if !bytes.Equal(sb.Bytes(), ref) {
+			t.Fatalf("buffer size %d output mismatch: got %x want %x", sz, sb.Bytes(), ref)
+		}
+	}
+}

--- a/dynssz_test.go
+++ b/dynssz_test.go
@@ -1894,3 +1894,172 @@ func TestResolveSpecValuePrecisionAbove2p53(t *testing.T) {
 		t.Fatalf("precision loss: got %d want %d", val, v)
 	}
 }
+
+// --- coverage: spec value type handling (specvals.go) ---
+
+func TestResolveSpecValueTypes(t *testing.T) {
+	cases := []struct {
+		name string
+		val  any
+		want uint64
+		ok   bool
+	}{
+		{"uint", uint(7), 7, true},
+		{"uint32", uint32(8), 8, true},
+		{"uint16", uint16(9), 9, true},
+		{"uint8", uint8(10), 10, true},
+		{"uintptr", uintptr(11), 11, true},
+		{"int32", int32(12), 12, true},
+		{"int16", int16(13), 13, true},
+		{"int8", int8(14), 14, true},
+		{"float32", float32(15), 15, true},
+		{"unsupportedString", "nope", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ds := NewDynSsz(map[string]any{"X": tc.val})
+			ok, val, err := ds.ResolveSpecValue("X")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ok != tc.ok {
+				t.Fatalf("resolved=%v, want %v", ok, tc.ok)
+			}
+			if tc.ok && val != tc.want {
+				t.Fatalf("value=%d, want %d", val, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveSpecValueExpressionDegenerate(t *testing.T) {
+	// An expression (not a direct lookup) that evaluates to a negative value must
+	// be rejected by specFloatToUint64.
+	ds := NewDynSsz(map[string]any{"A": float64(1), "B": float64(2)})
+	if _, _, err := ds.ResolveSpecValue("A - B"); err == nil {
+		t.Fatal("expected error for negative expression result")
+	}
+}
+
+// --- coverage: nil guards for HashTreeRootWith and GetTree (dynssz.go) ---
+
+func TestNilArgumentRejectedHashWithAndTree(t *testing.T) {
+	ds := NewDynSsz(nil)
+	noPanic := func(name string, fn func()) {
+		t.Helper()
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("%s panicked on nil: %v", name, r)
+			}
+		}()
+		fn()
+	}
+	noPanic("HashTreeRootWith", func() { _ = ds.HashTreeRootWith(nil, nil) })
+	noPanic("GetTree", func() { _, _ = ds.GetTree(nil) })
+
+	if err := ds.HashTreeRootWith(nil, nil); err == nil {
+		t.Error("HashTreeRootWith(nil) should error")
+	}
+	if _, err := ds.GetTree(nil); err == nil {
+		t.Error("GetTree(nil) should error")
+	}
+}
+
+// --- coverage: marshal/HTR error propagation paths (reflection) ---
+
+// non-terminated bitlist: a leaf whose marshal and HTR both fail.
+type covBadBitlist struct {
+	X []byte `ssz-type:"bitlist" ssz-max:"16"`
+}
+
+func covBadBitlistValue() covBadBitlist { return covBadBitlist{X: []byte{0xff, 0x00}} }
+
+func TestMarshalErrorPropagation(t *testing.T) {
+	ds := NewDynSsz(nil, WithExtendedTypes())
+
+	t.Run("typeWrapper", func(t *testing.T) {
+		type desc struct {
+			Data []byte `ssz-type:"bitlist" ssz-max:"16"`
+		}
+		w := &TypeWrapper[desc, []byte]{Data: []byte{0xff, 0x00}}
+		if _, err := ds.MarshalSSZ(w); err == nil {
+			t.Fatal("expected error from wrapped bitlist")
+		}
+	})
+
+	t.Run("optional", func(t *testing.T) {
+		type T struct {
+			O *covBadBitlist `ssz-type:"optional"`
+		}
+		v := covBadBitlistValue()
+		if _, err := ds.MarshalSSZ(&T{O: &v}); err == nil {
+			t.Fatal("expected error from optional inner bitlist")
+		}
+	})
+
+	t.Run("dynamicVector", func(t *testing.T) {
+		type T struct {
+			V [1]covBadBitlist
+		}
+		if _, err := ds.MarshalSSZ(&T{V: [1]covBadBitlist{covBadBitlistValue()}}); err == nil {
+			t.Fatal("expected error from vector element bitlist")
+		}
+	})
+
+	t.Run("dynamicList", func(t *testing.T) {
+		type T struct {
+			L []covBadBitlist `ssz-max:"4"`
+		}
+		if _, err := ds.MarshalSSZ(&T{L: []covBadBitlist{covBadBitlistValue()}}); err == nil {
+			t.Fatal("expected error from list element bitlist")
+		}
+	})
+}
+
+// union marshal error paths require reaching marshalCompatibleUnion without a
+// prior size pass, which only happens for a top-level union via MarshalSSZWriter.
+func TestUnionMarshalErrorPaths(t *testing.T) {
+	ds := NewDynSsz(nil)
+
+	t.Run("invalidVariant", func(t *testing.T) {
+		u := &CompatibleUnion[struct {
+			V0 uint32
+			V1 [16]byte
+		}]{Variant: 99, Data: uint32(1)}
+		var sb bytes.Buffer
+		if err := ds.MarshalSSZWriter(u, &sb); err == nil {
+			t.Fatal("expected error for invalid variant")
+		}
+	})
+
+	t.Run("typeMismatch", func(t *testing.T) {
+		u := &CompatibleUnion[struct {
+			V0 uint32
+			V1 [16]byte
+		}]{Variant: 0, Data: "wrong type"}
+		var sb bytes.Buffer
+		if err := ds.MarshalSSZWriter(u, &sb); err == nil {
+			t.Fatal("expected error for wrong-typed data")
+		}
+	})
+
+	t.Run("variantMarshalError", func(t *testing.T) {
+		u := &CompatibleUnion[struct {
+			V0 []byte `ssz-type:"bitlist" ssz-max:"16"`
+		}]{Variant: 0, Data: []byte{0xff, 0x00}}
+		var sb bytes.Buffer
+		if err := ds.MarshalSSZWriter(u, &sb); err == nil {
+			t.Fatal("expected error from union variant bitlist")
+		}
+	})
+}
+
+func TestUnionHTRVariantError(t *testing.T) {
+	ds := NewDynSsz(nil)
+	u := &CompatibleUnion[struct {
+		V0 []byte `ssz-type:"bitlist" ssz-max:"16"`
+	}]{Variant: 0, Data: []byte{0xff, 0x00}}
+	if _, err := ds.HashTreeRoot(u); err == nil {
+		t.Fatal("expected HTR error from union variant bitlist")
+	}
+}

--- a/dynssz_test.go
+++ b/dynssz_test.go
@@ -1747,3 +1747,150 @@ func TestResolveSpecValueUint64Precision(t *testing.T) {
 		t.Fatalf("expected full-precision MaxUint64, got ok=%v val=%d", ok, val)
 	}
 }
+
+// --- #22: CalculateLimit overflow must not collide ---
+
+func TestCalculateLimitOverflowNoCollision(t *testing.T) {
+	type ListMax1 struct {
+		V []uint64 `ssz-max:"1"`
+	}
+	type ListMaxOverflow struct {
+		V []uint64 `ssz-max:"2305843009213693953"` // 2^61+1; *8 overflows uint64
+	}
+	ds := NewDynSsz(nil)
+	a, err := ds.HashTreeRoot(&ListMax1{V: []uint64{42}})
+	if err != nil {
+		t.Fatalf("ListMax1: %v", err)
+	}
+	b, err := ds.HashTreeRoot(&ListMaxOverflow{V: []uint64{42}})
+	if err != nil {
+		t.Fatalf("ListMaxOverflow: %v", err)
+	}
+	if a == b {
+		t.Fatal("distinct list capacities must not share a hash tree root")
+	}
+}
+
+// --- #24: nil argument must error, not panic ---
+
+func TestNilArgumentRejected(t *testing.T) {
+	ds := NewDynSsz(nil)
+	noPanic := func(name string, fn func()) {
+		t.Helper()
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("%s panicked on nil: %v", name, r)
+			}
+		}()
+		fn()
+	}
+	noPanic("MarshalSSZ", func() { _, _ = ds.MarshalSSZ(nil) })
+	noPanic("MarshalSSZTo", func() { _, _ = ds.MarshalSSZTo(nil, nil) })
+	noPanic("MarshalSSZWriter", func() { _ = ds.MarshalSSZWriter(nil, &bytes.Buffer{}) })
+	noPanic("SizeSSZ", func() { _, _ = ds.SizeSSZ(nil) })
+	noPanic("UnmarshalSSZ", func() { _ = ds.UnmarshalSSZ(nil, make([]byte, 8)) })
+	noPanic("UnmarshalSSZReader", func() { _ = ds.UnmarshalSSZReader(nil, bytes.NewReader(nil), 0) })
+	noPanic("HashTreeRoot", func() { _, _ = ds.HashTreeRoot(nil) })
+
+	if _, err := ds.MarshalSSZ(nil); err == nil {
+		t.Error("MarshalSSZ(nil) should return an error")
+	}
+	if _, err := ds.HashTreeRoot(nil); err == nil {
+		t.Error("HashTreeRoot(nil) should return an error")
+	}
+	if err := ds.UnmarshalSSZ(nil, make([]byte, 8)); err == nil {
+		t.Error("UnmarshalSSZ(nil) should return an error")
+	}
+}
+
+// --- #25: MarshalSSZTo must handle short-cap and non-empty (append) buffers ---
+
+func TestMarshalSSZToBuffer(t *testing.T) {
+	ds := NewDynSsz(nil)
+	type T struct{ A uint64 }
+
+	// capacity smaller than the output
+	enc, err := ds.MarshalSSZTo(&T{A: 1}, make([]byte, 0, 4))
+	if err != nil {
+		t.Fatalf("short-cap buffer: %v", err)
+	}
+	if len(enc) != 8 {
+		t.Fatalf("expected 8 bytes, got %d", len(enc))
+	}
+
+	// non-empty buffer -> append after existing content
+	prefix := []byte{0xfe, 0xed}
+	out, err := ds.MarshalSSZTo(&T{A: 1}, prefix)
+	if err != nil {
+		t.Fatalf("append buffer: %v", err)
+	}
+	if len(out) != 2+8 {
+		t.Fatalf("expected 10 bytes, got %d", len(out))
+	}
+	if out[0] != 0xfe || out[1] != 0xed {
+		t.Fatalf("prefix was clobbered: %x", out)
+	}
+}
+
+// --- #27: HTR must enforce the element-count limit for primitive lists ---
+
+func TestHTRListLimitEnforced(t *testing.T) {
+	ds := NewDynSsz(nil)
+
+	t.Run("bytes", func(t *testing.T) {
+		type T struct {
+			X []byte `ssz-max:"4"`
+		}
+		if _, err := ds.HashTreeRoot(&T{X: make([]byte, 5)}); err == nil {
+			t.Error("[]byte over max-4 should fail HTR")
+		}
+		if _, err := ds.HashTreeRoot(&T{X: make([]byte, 4)}); err != nil {
+			t.Errorf("[]byte at max-4 should pass HTR: %v", err)
+		}
+	})
+	t.Run("uint16", func(t *testing.T) {
+		type T struct {
+			X []uint16 `ssz-max:"4"`
+		}
+		if _, err := ds.HashTreeRoot(&T{X: make([]uint16, 5)}); err == nil {
+			t.Error("[]uint16 over max-4 should fail HTR")
+		}
+	})
+	t.Run("uint32", func(t *testing.T) {
+		type T struct {
+			X []uint32 `ssz-max:"4"`
+		}
+		if _, err := ds.HashTreeRoot(&T{X: make([]uint32, 5)}); err == nil {
+			t.Error("[]uint32 over max-4 should fail HTR")
+		}
+	})
+}
+
+// --- #28: ssz-max:"0" is a no-limit placeholder, not a zero limit ---
+
+func TestZeroMaxTreatedAsNoLimit(t *testing.T) {
+	ds := NewDynSsz(nil, WithNoFastSsz(), WithNoFastHash())
+	type T struct {
+		X []uint64 `ssz-max:"0"`
+	}
+	if _, err := ds.MarshalSSZ(&T{X: []uint64{1, 2, 3}}); err != nil {
+		t.Fatalf("ssz-max:0 marshal should succeed (no limit): %v", err)
+	}
+	if _, err := ds.HashTreeRoot(&T{X: []uint64{1, 2, 3}}); err != nil {
+		t.Fatalf("ssz-max:0 HTR should succeed (no limit): %v", err)
+	}
+}
+
+// --- #26: spec values above 2^53 keep full uint64 precision ---
+
+func TestResolveSpecValuePrecisionAbove2p53(t *testing.T) {
+	v := uint64(9007199254740993) // 2^53 + 1, not representable as float64
+	ds := NewDynSsz(map[string]any{"X": v})
+	ok, val, err := ds.ResolveSpecValue("X")
+	if err != nil || !ok {
+		t.Fatalf("expected resolved, got ok=%v err=%v", ok, err)
+	}
+	if val != v {
+		t.Fatalf("precision loss: got %d want %d", val, v)
+	}
+}

--- a/dynssz_test.go
+++ b/dynssz_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"math/big"
 	"reflect"
 	"runtime"
 	"strings"
@@ -1608,5 +1609,141 @@ func TestStreamWriterBufferTooSmall(t *testing.T) {
 		if !bytes.Equal(sb.Bytes(), ref) {
 			t.Fatalf("buffer size %d output mismatch: got %x want %x", sz, sb.Bytes(), ref)
 		}
+	}
+}
+
+// --- big.Int sign preservation (extended types) ---
+
+func TestBigIntSignRoundtrip(t *testing.T) {
+	type T struct{ N big.Int }
+	ds := NewDynSsz(nil, WithExtendedTypes())
+
+	for _, v := range []int64{-1000000, -100, -1, 0, 1, 100, 1 << 40} {
+		src := &T{N: *big.NewInt(v)}
+		enc, err := ds.MarshalSSZ(src)
+		if err != nil {
+			t.Fatalf("marshal %d: %v", v, err)
+		}
+		var dst T
+		if err := ds.UnmarshalSSZ(&dst, enc); err != nil {
+			t.Fatalf("unmarshal %d: %v", v, err)
+		}
+		if dst.N.Cmp(big.NewInt(v)) != 0 {
+			t.Fatalf("roundtrip %d -> %s", v, dst.N.String())
+		}
+	}
+}
+
+// TestBigIntSignEncodingGolden pins the sign-magnitude wire format so a change to
+// both engines at once is still caught (codegen tests are only differential).
+func TestBigIntSignEncodingGolden(t *testing.T) {
+	type T struct{ N big.Int }
+	ds := NewDynSsz(nil, WithExtendedTypes())
+
+	cases := map[int64][]byte{
+		0:    {0x04, 0, 0, 0, 0x00},       // offset, sign(+), no magnitude
+		100:  {0x04, 0, 0, 0, 0x00, 0x64}, // offset, sign(+), 0x64
+		-100: {0x04, 0, 0, 0, 0x01, 0x64}, // offset, sign(-), 0x64
+	}
+	for v, want := range cases {
+		enc, err := ds.MarshalSSZ(&T{N: *big.NewInt(v)})
+		if err != nil {
+			t.Fatalf("marshal %d: %v", v, err)
+		}
+		if !bytes.Equal(enc, want) {
+			t.Fatalf("marshal %d: got %x want %x", v, enc, want)
+		}
+	}
+}
+
+func TestBigIntSignHTRDistinct(t *testing.T) {
+	type T struct{ N big.Int }
+	ds := NewDynSsz(nil, WithExtendedTypes())
+
+	rPos, err := ds.HashTreeRoot(&T{N: *big.NewInt(100)})
+	if err != nil {
+		t.Fatalf("htr pos: %v", err)
+	}
+	rNeg, err := ds.HashTreeRoot(&T{N: *big.NewInt(-100)})
+	if err != nil {
+		t.Fatalf("htr neg: %v", err)
+	}
+	if rPos == rNeg {
+		t.Fatal("positive and negative big.Int must not hash equally")
+	}
+}
+
+func TestBigIntInvalidSignByteRejected(t *testing.T) {
+	type T struct{ N big.Int }
+	ds := NewDynSsz(nil, WithExtendedTypes())
+
+	// offset=4, sign byte 0x02 (invalid), magnitude 0x64
+	bad := []byte{0x04, 0, 0, 0, 0x02, 0x64}
+	var dst T
+	err := ds.UnmarshalSSZ(&dst, bad)
+	if err == nil {
+		t.Fatal("expected error for invalid big.Int sign byte")
+	}
+	if !errors.Is(err, sszutils.ErrInvalidValueRange) {
+		t.Fatalf("expected ErrInvalidValueRange, got %v", err)
+	}
+}
+
+// --- Optional availability byte must be canonical 0x00/0x01 ---
+
+func TestOptionalNonCanonicalAvailabilityRejected(t *testing.T) {
+	type T struct {
+		Pre uint32
+		Opt *uint32 `ssz-type:"optional"`
+	}
+	ds := NewDynSsz(nil, WithExtendedTypes())
+
+	// availability byte 0xff is non-canonical
+	malformed := []byte{0, 0, 0, 0, 8, 0, 0, 0, 0xff, 0x99, 0, 0, 0}
+	if err := ds.UnmarshalSSZ(&T{}, malformed); err == nil {
+		t.Fatal("expected error for non-canonical availability byte")
+	} else if !errors.Is(err, sszutils.ErrInvalidValueRange) {
+		t.Fatalf("expected ErrInvalidValueRange, got %v", err)
+	}
+
+	// canonical present (0x01) and absent (0x00) must decode
+	present := []byte{0, 0, 0, 0, 8, 0, 0, 0, 0x01, 0x99, 0, 0, 0}
+	var dst T
+	if err := ds.UnmarshalSSZ(&dst, present); err != nil {
+		t.Fatalf("availability=1 should decode: %v", err)
+	}
+	if dst.Opt == nil || *dst.Opt != 0x99 {
+		t.Fatalf("unexpected Opt: %v", dst.Opt)
+	}
+	absent := []byte{0, 0, 0, 0, 8, 0, 0, 0, 0x00}
+	var dst2 T
+	if err := ds.UnmarshalSSZ(&dst2, absent); err != nil {
+		t.Fatalf("availability=0 should decode: %v", err)
+	}
+	if dst2.Opt != nil {
+		t.Fatalf("expected nil Opt, got %v", *dst2.Opt)
+	}
+}
+
+// --- Spec value resolution validation ---
+
+func TestResolveSpecValueRejectsDegenerate(t *testing.T) {
+	for _, v := range []any{-1.0, math.NaN(), math.Inf(1), math.Inf(-1), float64(1e30), int(-5), int64(-1)} {
+		ds := NewDynSsz(map[string]any{"X": v})
+		ok, _, err := ds.ResolveSpecValue("X")
+		if err == nil && ok {
+			t.Errorf("spec value %v should be rejected, but resolved", v)
+		}
+	}
+}
+
+func TestResolveSpecValueUint64Precision(t *testing.T) {
+	ds := NewDynSsz(map[string]any{"X": uint64(math.MaxUint64)})
+	ok, val, err := ds.ResolveSpecValue("X")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok || val != math.MaxUint64 {
+		t.Fatalf("expected full-precision MaxUint64, got ok=%v val=%d", ok, val)
 	}
 }

--- a/reflection/common_test.go
+++ b/reflection/common_test.go
@@ -908,14 +908,14 @@ var commonExtendedTypesTestMatrix = []struct {
 	{
 		"bigint_min",
 		*big.NewInt(0),
-		fromHex("0x"),
+		fromHex("0x00"),
 		fromHex("0x0000000000000000000000000000000000000000000000000000000000000000"),
 	},
 	{
 		"bigint_val1",
 		*big.NewInt(123456789),
-		fromHex("0x075bcd15"),
-		fromHex("0x075bcd1500000000000000000000000000000000000000000000000000000000"),
+		fromHex("0x00075bcd15"),
+		fromHex("0x00075bcd15000000000000000000000000000000000000000000000000000000"),
 	},
 	{
 		"optional_int16",
@@ -954,8 +954,8 @@ var commonExtendedTypesTestMatrix = []struct {
 			F3  float64
 			Big big.Int
 		}{42, &opt1, 3.14, *big.NewInt(999999)},
-		fromHex("0x2a000000140000001f85eb51b81e0940170000000139050f423f"),
-		fromHex("0x6a2b0143a450c236cbfee0c6c7d94288a5968c1e033ee60e91fd6604d1b1be9c"),
+		fromHex("0x2a000000140000001f85eb51b81e094017000000013905000f423f"),
+		fromHex("0xa94c18b7784f8548193c27cac4a1dd8686f6cd3be5bd1356cc2ccc979dacca3a"),
 	},
 }
 

--- a/reflection/marshal.go
+++ b/reflection/marshal.go
@@ -758,6 +758,12 @@ func (ctx *ReflectionCtx) marshalCompatibleUnion(sourceType *ssztypes.TypeDescri
 		return sszutils.ErrInvalidUnionVariantFn()
 	}
 
+	// Reject data whose concrete type does not match the variant, instead of
+	// panicking inside the typed marshaler.
+	if dataField.Elem().Type() != variantDesc.Type {
+		return sszutils.ErrUnionTypeMismatchFn()
+	}
+
 	// Append variant byte
 	encoder.EncodeUint8(variant)
 
@@ -854,8 +860,13 @@ func (ctx *ReflectionCtx) marshalBigInt(sourceType *ssztypes.TypeDescriptor, sou
 	if !isBigInt {
 		return sszutils.ErrBigIntTypeExpectedFn(sourceType.Type.Name())
 	}
-	bigIntBytes := bigInt.Bytes()
-	encoder.EncodeBytes(bigIntBytes)
+	// sign byte (0 = non-negative, 1 = negative) followed by the big-endian magnitude
+	signByte := byte(0)
+	if bigInt.Sign() < 0 {
+		signByte = 1
+	}
+	encoder.EncodeUint8(signByte)
+	encoder.EncodeBytes(bigInt.Bytes())
 
 	return nil
 }

--- a/reflection/marshal.go
+++ b/reflection/marshal.go
@@ -746,14 +746,20 @@ func (ctx *ReflectionCtx) marshalCompatibleUnion(sourceType *ssztypes.TypeDescri
 	variant := uint8(sourceValue.Field(0).Uint())
 	dataField := sourceValue.Field(1)
 
-	// Append variant byte
-	encoder.EncodeUint8(variant)
-
 	// Get the variant descriptor
 	variantDesc, ok := sourceType.UnionVariants[variant]
 	if !ok {
 		return sszutils.ErrInvalidUnionVariantFn()
 	}
+
+	// A zero-value union has a nil data interface; reject it instead of
+	// panicking on the zero reflect.Value (consistent with the HTR path).
+	if dataField.IsNil() {
+		return sszutils.ErrInvalidUnionVariantFn()
+	}
+
+	// Append variant byte
+	encoder.EncodeUint8(variant)
 
 	// Marshal the data using the variant's type descriptor
 	err := ctx.marshalType(variantDesc, dataField.Elem(), encoder, idt+2)

--- a/reflection/sszsize.go
+++ b/reflection/sszsize.go
@@ -180,6 +180,10 @@ func (ctx *ReflectionCtx) getSszValueSize(targetType *ssztypes.TypeDescriptor, t
 			default:
 				staticSize = fieldType.Size * sliceLen
 			}
+		} else if targetType.SszType == ssztypes.SszBitlistType || targetType.SszType == ssztypes.SszProgressiveBitlistType {
+			// empty bitlists are marshaled as a single 0x01 termination byte
+			// (see marshalBitlist), so account for that extra byte here as well
+			staticSize = 1
 		}
 	case ssztypes.SszCompatibleUnionType:
 		// CompatibleUnion: 1 byte for selector + size of the data
@@ -189,6 +193,12 @@ func (ctx *ReflectionCtx) getSszValueSize(targetType *ssztypes.TypeDescriptor, t
 		// Get the variant descriptor
 		variantDesc, ok := targetType.UnionVariants[variant]
 		if !ok {
+			return 0, sszutils.ErrInvalidUnionVariantFn()
+		}
+
+		// A zero-value union has a nil data interface; reject it instead of
+		// panicking on the zero reflect.Value (consistent with marshal/HTR).
+		if dataField.IsNil() {
 			return 0, sszutils.ErrInvalidUnionVariantFn()
 		}
 

--- a/reflection/sszsize.go
+++ b/reflection/sszsize.go
@@ -201,6 +201,9 @@ func (ctx *ReflectionCtx) getSszValueSize(targetType *ssztypes.TypeDescriptor, t
 		if dataField.IsNil() {
 			return 0, sszutils.ErrInvalidUnionVariantFn()
 		}
+		if dataField.Elem().Type() != variantDesc.Type {
+			return 0, sszutils.ErrUnionTypeMismatchFn()
+		}
 
 		// Calculate size of the data
 		dataSize, err := ctx.getSszValueSize(variantDesc, dataField.Elem())
@@ -269,8 +272,7 @@ func (ctx *ReflectionCtx) getSszValueSize(targetType *ssztypes.TypeDescriptor, t
 		if !isBigInt {
 			return 0, sszutils.ErrBigIntTypeExpectedFn(targetType.Type.Name())
 		}
-		bigIntBytes := bigInt.Bytes()
-		staticSize = uint32(len(bigIntBytes))
+		staticSize = uint32(1 + len(bigInt.Bytes()))
 
 	default:
 		return 0, sszutils.ErrUnknownTypeFn(targetType.Kind)

--- a/reflection/treeroot.go
+++ b/reflection/treeroot.go
@@ -484,6 +484,9 @@ func (ctx *ReflectionCtx) buildRootFromCompatibleUnion(sourceType *ssztypes.Type
 	if dataField.IsNil() {
 		return sszutils.ErrInvalidUnionVariantFn()
 	}
+	if dataField.Elem().Type() != variantDesc.Type {
+		return sszutils.ErrUnionTypeMismatchFn()
+	}
 	dataField = dataField.Elem()
 
 	hashIndex := hh.StartTree(sszutils.TreeTypeNone)
@@ -899,9 +902,11 @@ func (ctx *ReflectionCtx) buildRootFromBigInt(sourceType *ssztypes.TypeDescripto
 	if !isBigInt {
 		return sszutils.ErrBigIntTypeExpectedFn(sourceType.Type.Name())
 	}
-	bigIntBytes := bigInt.Bytes()
-	if len(bigIntBytes) == 0 {
-		bigIntBytes = make([]byte, 1)
+	// hash the sign byte followed by the big-endian magnitude so values of equal
+	// magnitude but opposite sign do not collide
+	bigIntBytes := append([]byte{0}, bigInt.Bytes()...)
+	if bigInt.Sign() < 0 {
+		bigIntBytes[0] = 1
 	}
 	hh.PutBytes(bigIntBytes)
 	return nil

--- a/reflection/treeroot.go
+++ b/reflection/treeroot.go
@@ -564,8 +564,8 @@ func (ctx *ReflectionCtx) buildRootFromVector(sourceType *ssztypes.TypeDescripto
 		if appendZero > 0 {
 			zeroBytes := make([]byte, appendZero)
 			bytes = append(bytes, zeroBytes...)
-		} else if sourceType.BitSize > 0 && sourceType.BitSize < uint32(len(bytes))*8 {
-			// check padding bits
+		} else if sourceType.BitSize > 0 && sourceType.BitSize%8 != 0 {
+			// check padding bits (only bit-aligned bitvectors have padding bits)
 			paddingMask := uint8((uint16(0xff) << (sourceType.BitSize % 8)) & 0xff)
 			paddingBits := bytes[len(bytes)-1] & paddingMask
 			if paddingBits != 0 {
@@ -789,6 +789,12 @@ func (ctx *ReflectionCtx) getActiveFields(sourceType *ssztypes.TypeDescriptor) [
 func (ctx *ReflectionCtx) buildRootFromBitlist(sourceType *ssztypes.TypeDescriptor, sourceValue reflect.Value, hh sszutils.HashWalker, _ int) error {
 	maxSize := uint64(0)
 	bytes := sourceValue.Bytes()
+
+	// reject bitlists that are missing their termination bit, consistent with
+	// marshalBitlist. Empty/nil bitlists are treated as a 0-bit bitlist.
+	if len(bytes) > 0 && bytes[len(bytes)-1] == 0x00 {
+		return sszutils.ErrBitlistNotTerminatedFn()
+	}
 
 	if sourceType.SszTypeFlags&ssztypes.SszTypeFlagHasLimit != 0 {
 		maxSize = sourceType.Limit

--- a/reflection/treeroot.go
+++ b/reflection/treeroot.go
@@ -685,6 +685,13 @@ func (ctx *ReflectionCtx) buildRootFromList(sourceType *ssztypes.TypeDescriptor,
 	case sourceType.SszType == ssztypes.SszProgressiveListType:
 		hh.MerkleizeProgressiveWithMixin(hashIndex, uint64(sliceLen))
 	case sourceType.SszTypeFlags&ssztypes.SszTypeFlagHasLimit != 0:
+		// Enforce the element-count limit (matches marshal). The chunk count
+		// derived from the buffer is not a valid proxy for packed primitives —
+		// several items pack into one chunk, so an over-limit list would pass.
+		if uint64(sliceLen) > sourceType.Limit {
+			return sszutils.ErrListLengthFn(sliceLen, sourceType.Limit)
+		}
+
 		var limit, itemSize uint64
 
 		switch sourceType.ElemDesc.SszType {
@@ -707,22 +714,9 @@ func (ctx *ReflectionCtx) buildRootFromList(sourceType *ssztypes.TypeDescriptor,
 		}
 
 		if itemSize > 0 {
-			// Packed primitive elements: the limit is a chunk count and the
-			// elements are never deferred, so the written chunk count is exact.
 			limit = sszutils.CalculateLimit(sourceType.Limit, uint64(sliceLen), itemSize)
-			inputLen := hh.CurrentIndex() - hashIndex
-			if (uint64(inputLen)+31)/32 > limit {
-				return sszutils.ErrListLengthFn(inputLen, limit)
-			}
 		} else {
-			// Composite elements: the limit is an element count. Validate against
-			// the element count directly — the buffer may hold un-reduced child
-			// chunks (deferred cross-element batching), so a CurrentIndex-derived
-			// chunk count would over-count and falsely trip the limit.
 			limit = sourceType.Limit
-			if uint64(sliceLen) > limit {
-				return sszutils.ErrListLengthFn(sliceLen, limit)
-			}
 		}
 		hh.MerkleizeWithMixin(hashIndex, uint64(sliceLen), limit)
 	default:

--- a/reflection/unmarshal.go
+++ b/reflection/unmarshal.go
@@ -1104,15 +1104,20 @@ func (ctx *ReflectionCtx) unmarshalOptional(targetType *ssztypes.TypeDescriptor,
 		return sszutils.ErrOptionalFlagEOFFn()
 	}
 
-	// Read the availability byte
+	// Read the availability byte; only the canonical 0x00/0x01 values are valid
 	availability, err := decoder.DecodeUint8()
 	if err != nil {
 		return err
 	}
 
-	if availability == 0 {
+	switch availability {
+	case 0:
 		targetValue.Set(reflect.Zero(targetType.Type))
 		return nil
+	case 1:
+		// present, decoded below
+	default:
+		return sszutils.NewSszErrorf(sszutils.ErrInvalidValueRange, "invalid optional availability byte 0x%02x", availability)
 	}
 
 	if targetValue.IsNil() {
@@ -1199,7 +1204,14 @@ func (ctx *ReflectionCtx) unmarshalBigInt(_ *ssztypes.TypeDescriptor, targetValu
 			return err
 		}
 
-		bigInt.SetBytes(bigIntBytes)
+		// sign byte (0 = non-negative, 1 = negative) followed by the big-endian magnitude
+		if bigIntBytes[0] > 1 {
+			return sszutils.NewSszErrorf(sszutils.ErrInvalidValueRange, "invalid big.Int sign byte 0x%02x", bigIntBytes[0])
+		}
+		bigInt.SetBytes(bigIntBytes[1:])
+		if bigIntBytes[0] == 1 {
+			bigInt.Neg(bigInt)
+		}
 	}
 
 	targetValue.Set(reflect.ValueOf(*bigInt))

--- a/reflection/unmarshal.go
+++ b/reflection/unmarshal.go
@@ -565,14 +565,15 @@ func (ctx *ReflectionCtx) unmarshalVector(targetType *ssztypes.TypeDescriptor, t
 				buf = newValue.Bytes()
 			}
 
-			sszLen := decoder.GetLength()
 			_, err := decoder.DecodeBytes(buf)
 			if err != nil {
 				return err
 			}
 
-			if targetType.BitSize > 0 && targetType.BitSize < uint32(sszLen)*8 {
-				// check padding bits
+			// Only bit-aligned bitvectors (BitSize not a multiple of 8) have padding
+			// bits in the last byte that must be zero. Byte-aligned bitvectors have no
+			// padding bits, so the check is skipped to avoid misinterpreting data bits.
+			if targetType.BitSize > 0 && targetType.BitSize%8 != 0 {
 				paddingMask := uint8((uint16(0xff) << (targetType.BitSize % 8)) & 0xff)
 				paddingBits := buf[arrLen-1] & paddingMask
 				if paddingBits != 0 {

--- a/specvals.go
+++ b/specvals.go
@@ -90,6 +90,8 @@ func specValueToUint64(raw any) (value uint64, ok bool, err error) {
 		return uint64(v), true, nil
 	case uint8:
 		return uint64(v), true, nil
+	case uintptr:
+		return uint64(v), true, nil
 	case int:
 		return intSpecToUint64(int64(v))
 	case int64:

--- a/specvals.go
+++ b/specvals.go
@@ -6,6 +6,7 @@ package dynssz
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/casbin/govaluate"
 )
@@ -30,6 +31,26 @@ func (d *DynSsz) ResolveSpecValue(name string) (bool, uint64, error) {
 	}
 
 	cachedValue = &cachedSpecValue{}
+
+	// Fast path: a spec value provided directly under this name keeps its exact
+	// type and full uint64 precision. govaluate evaluates everything as float64,
+	// which silently loses precision near uint64 max, so it is only used for
+	// actual expressions below.
+	if raw, ok := d.specValues[name]; ok {
+		value, resolved, err := specValueToUint64(raw)
+		if err != nil {
+			return false, 0, fmt.Errorf("invalid dynamic spec value %q: %w", name, err)
+		}
+		if resolved {
+			cachedValue.resolved = true
+			cachedValue.value = value
+			d.specCacheMutex.Lock()
+			d.specValueCache[name] = cachedValue
+			d.specCacheMutex.Unlock()
+			return true, value, nil
+		}
+	}
+
 	expression, err := govaluate.NewEvaluableExpression(name)
 	if err != nil {
 		return false, 0, fmt.Errorf("error parsing dynamic spec expression: %w", err)
@@ -37,21 +58,82 @@ func (d *DynSsz) ResolveSpecValue(name string) (bool, uint64, error) {
 
 	result, err := expression.Evaluate(d.specValues)
 	if err == nil {
-		value, ok := result.(float64)
-		if ok {
-			cachedValue.resolved = true
-			cachedValue.value = uint64(value)
-			if float64(cachedValue.value) < value {
-				// rounding issue - always round up to full bytes as we can't serialize parial bytes
-				cachedValue.value++
+		if value, ok := result.(float64); ok {
+			resolved, rerr := specFloatToUint64(value)
+			if rerr != nil {
+				return false, 0, fmt.Errorf("invalid dynamic spec expression %q: %w", name, rerr)
 			}
+			cachedValue.resolved = true
+			cachedValue.value = resolved
 		}
 	}
 
-	// fmt.Printf("spec lookup %v,  ok: %v, value: %v\n", name, cachedValue.resolved, cachedValue.value)
 	d.specCacheMutex.Lock()
 	d.specValueCache[name] = cachedValue
 	d.specCacheMutex.Unlock()
 
 	return cachedValue.resolved, cachedValue.value, nil
+}
+
+// specValueToUint64 converts a directly-provided spec value to uint64, preserving
+// full precision for integer types. ok is false (without error) for unsupported
+// types so the caller can fall back to expression evaluation / static limits.
+func specValueToUint64(raw any) (value uint64, ok bool, err error) {
+	switch v := raw.(type) {
+	case uint64:
+		return v, true, nil
+	case uint:
+		return uint64(v), true, nil
+	case uint32:
+		return uint64(v), true, nil
+	case uint16:
+		return uint64(v), true, nil
+	case uint8:
+		return uint64(v), true, nil
+	case int:
+		return intSpecToUint64(int64(v))
+	case int64:
+		return intSpecToUint64(v)
+	case int32:
+		return intSpecToUint64(int64(v))
+	case int16:
+		return intSpecToUint64(int64(v))
+	case int8:
+		return intSpecToUint64(int64(v))
+	case float64:
+		u, ferr := specFloatToUint64(v)
+		return u, ferr == nil, ferr
+	case float32:
+		u, ferr := specFloatToUint64(float64(v))
+		return u, ferr == nil, ferr
+	default:
+		return 0, false, nil
+	}
+}
+
+func intSpecToUint64(v int64) (uint64, bool, error) {
+	if v < 0 {
+		return 0, false, fmt.Errorf("negative value %d", v)
+	}
+	return uint64(v), true, nil
+}
+
+// specFloatToUint64 validates a float spec value and rounds it up to the next
+// whole unit (partial bytes/bits cannot be serialized).
+func specFloatToUint64(v float64) (uint64, error) {
+	switch {
+	case math.IsNaN(v):
+		return 0, fmt.Errorf("value is NaN")
+	case math.IsInf(v, 0):
+		return 0, fmt.Errorf("value is infinite")
+	case v < 0:
+		return 0, fmt.Errorf("negative value %v", v)
+	case v >= math.Ldexp(1, 64): // >= 2^64 overflows uint64
+		return 0, fmt.Errorf("value %v overflows uint64", v)
+	}
+	u := uint64(v)
+	if float64(u) < v {
+		u++
+	}
+	return u, nil
 }

--- a/ssztypes/typecache.go
+++ b/ssztypes/typecache.go
@@ -29,6 +29,7 @@ type TypeCache struct {
 	specs         sszutils.DynamicSpecs
 	mutex         sync.RWMutex
 	descriptors   map[typeKey]*TypeDescriptor
+	building      map[typeKey]bool
 	CompatFlags   map[string]SszCompatFlag
 	ExtendedTypes bool
 }
@@ -38,6 +39,7 @@ func NewTypeCache(specs sszutils.DynamicSpecs) *TypeCache {
 	return &TypeCache{
 		specs:         specs,
 		descriptors:   make(map[typeKey]*TypeDescriptor),
+		building:      make(map[typeKey]bool),
 		CompatFlags:   map[string]SszCompatFlag{},
 		ExtendedTypes: false,
 	}
@@ -142,6 +144,16 @@ func (tc *TypeCache) getTypeDescriptor(runtimeType, schemaType reflect.Type, siz
 	if desc, exists := tc.descriptors[key]; exists && cacheable {
 		return desc, nil
 	}
+
+	// Detect self-referential (recursive) types. The whole descriptor tree is
+	// built under the cache write lock, so the build stack is tracked with a
+	// simple map. Recursive SSZ types have no finite serialization, so reject
+	// them with a clear error instead of overflowing the stack.
+	if tc.building[key] {
+		return nil, sszutils.NewSszErrorf(sszutils.ErrUnsupportedType, "recursive type %v is not supported", runtimeType)
+	}
+	tc.building[key] = true
+	defer delete(tc.building, key)
 
 	desc, err := tc.buildTypeDescriptor(runtimeType, schemaType, sizeHints, maxSizeHints, typeHints)
 	if err != nil {

--- a/ssztypes/typecache.go
+++ b/ssztypes/typecache.go
@@ -306,7 +306,10 @@ func (tc *TypeCache) buildTypeDescriptor(runtimeType, schemaType reflect.Type, s
 	}
 
 	if len(maxSizeHints) > 0 {
-		if !maxSizeHints[0].NoValue {
+		// A resolved limit of 0 is a "no limit" placeholder (ssz-max:"0" with the
+		// real limit supplied dynamically via dynssz-max). Spec values are already
+		// resolved at this point, so only treat a positive limit as a constraint.
+		if !maxSizeHints[0].NoValue && maxSizeHints[0].Size > 0 {
 			desc.SszTypeFlags |= SszTypeFlagHasLimit
 			desc.Limit = maxSizeHints[0].Size
 		}

--- a/sszutils/encoder_stream.go
+++ b/sszutils/encoder_stream.go
@@ -29,10 +29,14 @@ var _ Encoder = (*StreamEncoder)(nil)
 
 // NewStreamEncoder creates a new StreamEncoder that writes SSZ data to the
 // provided io.Writer. bufSize controls the internal write buffer size; if <= 0,
-// DefaultStreamEncoderBufSize is used.
+// DefaultStreamEncoderBufSize is used. Values smaller than 8 (the largest atomic
+// write) are raised to 8 so that primitive encodes never overflow the buffer.
 func NewStreamEncoder(writer io.Writer, bufSize int) *StreamEncoder {
+	const minBufSize = 8 // largest atomic write is a uint64 (8 bytes)
 	if bufSize <= 0 {
 		bufSize = DefaultStreamEncoderBufSize
+	} else if bufSize < minBufSize {
+		bufSize = minBufSize
 	}
 	return &StreamEncoder{
 		writer:   writer,

--- a/sszutils/stream_test.go
+++ b/sszutils/stream_test.go
@@ -117,6 +117,35 @@ func TestStreamEncoder_NewStreamEncoder(t *testing.T) {
 	}
 }
 
+// TestStreamEncoder_MinBufferSize verifies that a buffer size smaller than the
+// largest atomic write (uint64, 8 bytes) does not cause primitive encodes to
+// write past the internal buffer and panic.
+func TestStreamEncoder_MinBufferSize(t *testing.T) {
+	for _, sz := range []int{1, 3, 4, 7} {
+		var buf bytes.Buffer
+		enc := NewStreamEncoder(&buf, sz)
+
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("buffer size %d caused a panic: %v", sz, r)
+				}
+			}()
+			enc.EncodeUint64(0x0102030405060708)
+			enc.EncodeUint32(0x0a0b0c0d)
+			enc.EncodeOffset(0x11223344)
+			enc.Flush()
+		}()
+
+		if enc.GetWriteError() != nil {
+			t.Fatalf("buffer size %d unexpected write error: %v", sz, enc.GetWriteError())
+		}
+		if buf.Len() != 16 {
+			t.Errorf("buffer size %d: expected 16 bytes, got %d", sz, buf.Len())
+		}
+	}
+}
+
 func TestStreamEncoder_GetBuffer(t *testing.T) {
 	var buf bytes.Buffer
 	enc := NewStreamEncoder(&buf, 0)
@@ -1151,12 +1180,12 @@ func TestStreamEncoder_TinyBuffer_FlushOnEncodeOffset(t *testing.T) {
 
 func TestStreamEncoder_EncodeBytes_FlushError(t *testing.T) {
 	testErr := errors.New("write error")
-	// Buffer size 4: write 2 bytes, then write 4 bytes to trigger flush+early return
+	// Buffer size 8 (the minimum): write 6 bytes, then 4 bytes to trigger flush+early return
 	w := &errWriter{errAfter: 0, err: testErr}
-	enc := NewStreamEncoder(w, 4)
+	enc := NewStreamEncoder(w, 8)
 
-	enc.EncodeBytes([]byte{0x01, 0x02})       // fits in buffer
-	enc.EncodeBytes([]byte{0x03, 0x04, 0x05}) // triggers flush, flush fails
+	enc.EncodeBytes(make([]byte, 6)) // fits in buffer
+	enc.EncodeBytes(make([]byte, 4)) // triggers flush, flush fails
 
 	if !errors.Is(enc.GetWriteError(), testErr) {
 		t.Errorf("expected error %v, got %v", testErr, enc.GetWriteError())
@@ -1164,13 +1193,13 @@ func TestStreamEncoder_EncodeBytes_FlushError(t *testing.T) {
 }
 
 func TestStreamEncoder_EncodeBytes_LargeDirectWriteError(t *testing.T) {
-	// Buffer size 4: writing 8 bytes goes to direct write path after flush.
-	// errWriter succeeds on flush (errAfter > 4) but fails on direct write.
+	// Buffer size 8 (the minimum): writing 12 bytes goes to the direct write path.
+	// errWriter writes the first 4 bytes then fails on the direct write.
 	testErr := errors.New("disk full")
 	w := &errWriter{errAfter: 4, err: testErr}
-	enc := NewStreamEncoder(w, 4)
+	enc := NewStreamEncoder(w, 8)
 
-	enc.EncodeBytes(make([]byte, 8))
+	enc.EncodeBytes(make([]byte, 12))
 
 	if !errors.Is(enc.GetWriteError(), testErr) {
 		t.Errorf("expected error %v, got %v", testErr, enc.GetWriteError())
@@ -1178,12 +1207,12 @@ func TestStreamEncoder_EncodeBytes_LargeDirectWriteError(t *testing.T) {
 }
 
 func TestStreamEncoder_EncodeBytes_LargeDirectShortWrite(t *testing.T) {
-	// Buffer size 4: writing 8 bytes goes to direct write path.
+	// Buffer size 8 (the minimum): writing 12 bytes goes to the direct write path.
 	// shortWriter writes fewer bytes than requested.
 	w := &shortWriter{maxWrite: 3}
-	enc := NewStreamEncoder(w, 4)
+	enc := NewStreamEncoder(w, 8)
 
-	enc.EncodeBytes(make([]byte, 8))
+	enc.EncodeBytes(make([]byte, 12))
 
 	if enc.GetWriteError() == nil {
 		t.Fatal("expected error, got nil")

--- a/sszutils/stream_test.go
+++ b/sszutils/stream_test.go
@@ -1517,3 +1517,33 @@ func TestStreamDecoder_GetLength_WithLimits(t *testing.T) {
 		t.Errorf("expected length 100, got %d", dec.GetLength())
 	}
 }
+
+// TestStreamEncoderFlushOnSmallPrimitives covers the flush branch in EncodeUint8
+// and EncodeUint16 when the buffered data leaves too little room.
+func TestStreamEncoderFlushOnSmallPrimitives(t *testing.T) {
+	// EncodeUint8 flush: fill the 8-byte buffer exactly, then write one more byte.
+	var buf bytes.Buffer
+	enc := NewStreamEncoder(&buf, 8)
+	enc.EncodeBytes(make([]byte, 8)) // bufPos = 8
+	enc.EncodeUint8(0xaa)            // 8+1 > 8 -> flush
+	enc.Flush()
+	if enc.GetWriteError() != nil {
+		t.Fatalf("unexpected error: %v", enc.GetWriteError())
+	}
+	if buf.Len() != 9 {
+		t.Fatalf("expected 9 bytes, got %d", buf.Len())
+	}
+
+	// EncodeUint16 flush: leave 7 bytes buffered, then write 2 bytes.
+	var buf2 bytes.Buffer
+	enc2 := NewStreamEncoder(&buf2, 8)
+	enc2.EncodeBytes(make([]byte, 7)) // bufPos = 7
+	enc2.EncodeUint16(0xbbcc)         // 7+2 > 8 -> flush
+	enc2.Flush()
+	if enc2.GetWriteError() != nil {
+		t.Fatalf("unexpected error: %v", enc2.GetWriteError())
+	}
+	if buf2.Len() != 9 {
+		t.Fatalf("expected 9 bytes, got %d", buf2.Len())
+	}
+}

--- a/sszutils/treeroot.go
+++ b/sszutils/treeroot.go
@@ -4,12 +4,27 @@
 
 package sszutils
 
-import "unsafe"
+import (
+	"math"
+	"math/bits"
+	"unsafe"
+)
 
 // CalculateLimit computes the merkle tree chunk limit for a list or vector
 // given its maximum capacity, current number of items, and per-item byte size.
+//
+// ceil(maxCapacity*size/32) is computed in 128-bit so a large ssz-max cannot
+// overflow uint64 and collapse to a small limit (which would make unrelated list
+// types share a merkleization depth and collide).
 func CalculateLimit(maxCapacity, numItems, size uint64) uint64 {
-	limit := (maxCapacity*size + 31) / 32
+	hi, lo := bits.Mul64(maxCapacity, size)
+	lo, carry := bits.Add64(lo, 31, 0)
+	hi += carry
+	if hi>>5 != 0 {
+		// (product+31)/32 exceeds uint64; clamp to the max representable limit.
+		return math.MaxUint64
+	}
+	limit := hi<<59 | lo>>5
 	if limit != 0 {
 		return limit
 	}

--- a/sszutils/utils_test.go
+++ b/sszutils/utils_test.go
@@ -475,3 +475,33 @@ func TestAppendZeroPadding_Zero(t *testing.T) {
 		t.Errorf("expected 0, got %d", len(result))
 	}
 }
+
+// TestCalculateLimitOverflow verifies the 128-bit overflow-safe limit math so a
+// large ssz-max cannot wrap to a small limit (which would collide merkle depths).
+func TestCalculateLimitOverflow(t *testing.T) {
+	cases := []struct {
+		name                        string
+		maxCapacity, numItems, size uint64
+		want                        uint64
+	}{
+		{"small", 4, 1, 8, 1},
+		{"one", 1, 1, 8, 1},
+		{"zeroCapEmpty", 0, 0, 8, 1},
+		{"zeroCapItems", 0, 3, 8, 3},
+		{"noOverflow61", 1 << 61, 1, 8, 1 << 59}, // (2^61*8)/32 = 2^59, fits
+		{"overflowWraps", (1 << 61) + 1, 1, 8, (1 << 59) + 1},
+		{"hugeClamp", 1 << 62, 1, 64, 1 << 63}, // 2^62*64 = 2^68 -> /32 = 2^63
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := CalculateLimit(tc.maxCapacity, tc.numItems, tc.size); got != tc.want {
+				t.Fatalf("CalculateLimit(%d,%d,%d) = %d, want %d", tc.maxCapacity, tc.numItems, tc.size, got, tc.want)
+			}
+		})
+	}
+
+	// distinct large capacities must yield distinct limits (no overflow collision)
+	if CalculateLimit(1, 1, 8) == CalculateLimit((1<<61)+1, 1, 8) {
+		t.Fatal("overflow collision: small and huge capacities share a limit")
+	}
+}

--- a/sszutils/utils_test.go
+++ b/sszutils/utils_test.go
@@ -490,7 +490,8 @@ func TestCalculateLimitOverflow(t *testing.T) {
 		{"zeroCapItems", 0, 3, 8, 3},
 		{"noOverflow61", 1 << 61, 1, 8, 1 << 59}, // (2^61*8)/32 = 2^59, fits
 		{"overflowWraps", (1 << 61) + 1, 1, 8, (1 << 59) + 1},
-		{"hugeClamp", 1 << 62, 1, 64, 1 << 63}, // 2^62*64 = 2^68 -> /32 = 2^63
+		{"hugeClamp", 1 << 62, 1, 64, 1 << 63},            // 2^62*64 = 2^68 -> /32 = 2^63
+		{"overflowClamp", 1 << 60, 0, 1 << 10, 1<<64 - 1}, // 2^70 / 32 = 2^65 -> clamps to MaxUint64
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/union_test.go
+++ b/union_test.go
@@ -5,9 +5,13 @@
 package dynssz
 
 import (
+	"bytes"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/pk910/dynamic-ssz/sszutils"
 )
 
 func TestNewCompatibleUnion(t *testing.T) {
@@ -337,6 +341,122 @@ func TestCompatibleUnionEdgeCases(t *testing.T) {
 		// Both should return the same descriptor type
 		if type1 != type2 {
 			t.Error("GetDescriptorType should return same type for same union descriptor")
+		}
+	})
+}
+
+// TestZeroUnionMarshalDoesNotPanic verifies that a zero-value CompatibleUnion
+// (nil Data interface) returns a clean error across marshal, stream marshal and
+// HTR instead of panicking on the zero reflect.Value.
+func TestZeroUnionMarshalDoesNotPanic(t *testing.T) {
+	type T struct {
+		U CompatibleUnion[struct {
+			V0 uint32
+			V1 [16]byte
+		}]
+	}
+
+	ds := NewDynSsz(nil)
+
+	t.Run("buffer", func(t *testing.T) {
+		var err error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("zero union marshal panicked: %v", r)
+				}
+			}()
+			_, err = ds.MarshalSSZ(&T{})
+		}()
+		if err == nil {
+			t.Fatalf("expected error for zero-value union marshal")
+		}
+		if !errors.Is(err, sszutils.ErrInvalidValueRange) {
+			t.Fatalf("expected ErrInvalidValueRange, got %v", err)
+		}
+	})
+
+	t.Run("stream", func(t *testing.T) {
+		var sb bytes.Buffer
+		var err error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("zero union stream marshal panicked: %v", r)
+				}
+			}()
+			err = ds.MarshalSSZWriter(&T{}, &sb)
+		}()
+		if err == nil {
+			t.Fatalf("expected error for zero-value union stream marshal")
+		}
+		if !errors.Is(err, sszutils.ErrInvalidValueRange) {
+			t.Fatalf("expected ErrInvalidValueRange, got %v", err)
+		}
+	})
+
+	t.Run("htr", func(t *testing.T) {
+		_, err := ds.HashTreeRoot(&T{})
+		if err == nil {
+			t.Fatalf("expected error for zero-value union HTR")
+		}
+		if !errors.Is(err, sszutils.ErrInvalidValueRange) {
+			t.Fatalf("expected ErrInvalidValueRange, got %v", err)
+		}
+	})
+
+	// A zero-value union whose selected variant is a dynamic type would panic in
+	// the size path (getSszValueSize -> Len() on a zero reflect.Value) rather than
+	// the marshal path. This exercises the size-path nil guard independently.
+	t.Run("sizeDynamicVariant", func(t *testing.T) {
+		type D struct {
+			U CompatibleUnion[struct {
+				V0 []uint64 `ssz-max:"8"`
+				V1 uint32
+			}]
+		}
+
+		var err error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("zero union with dynamic variant panicked during sizing: %v", r)
+				}
+			}()
+			_, err = ds.MarshalSSZ(&D{}) // Variant 0 (dynamic []uint64), Data nil
+		}()
+		if err == nil {
+			t.Fatalf("expected error for zero-value union with dynamic variant")
+		}
+		if !errors.Is(err, sszutils.ErrInvalidValueRange) {
+			t.Fatalf("expected ErrInvalidValueRange, got %v", err)
+		}
+	})
+
+	// A top-level union streamed via MarshalSSZWriter reaches marshalCompatibleUnion
+	// directly (no prior size/offset computation), exercising the marshal-path nil
+	// guard rather than the size-path guard hit by the nested cases above.
+	t.Run("streamTopLevel", func(t *testing.T) {
+		u := &CompatibleUnion[struct {
+			V0 uint32
+			V1 [16]byte
+		}]{} // Variant 0, Data nil
+
+		var sb bytes.Buffer
+		var err error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("top-level zero union stream marshal panicked: %v", r)
+				}
+			}()
+			err = ds.MarshalSSZWriter(u, &sb)
+		}()
+		if err == nil {
+			t.Fatalf("expected error for top-level zero-value union stream marshal")
+		}
+		if !errors.Is(err, sszutils.ErrInvalidValueRange) {
+			t.Fatalf("expected ErrInvalidValueRange, got %v", err)
 		}
 	})
 }

--- a/union_test.go
+++ b/union_test.go
@@ -460,3 +460,62 @@ func TestZeroUnionMarshalDoesNotPanic(t *testing.T) {
 		}
 	})
 }
+
+// TestUnionDataTypeMismatch verifies that a CompatibleUnion whose Data holds a
+// value of the wrong concrete type returns a clean error across marshal/HTR/size
+// instead of panicking inside the typed marshaler.
+func TestUnionDataTypeMismatch(t *testing.T) {
+	type T struct {
+		U CompatibleUnion[struct {
+			Variant0 uint32
+			Variant1 [16]byte
+		}]
+	}
+	ds := NewDynSsz(nil)
+
+	check := func(name string, fn func() error) {
+		t.Helper()
+		var err error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("%s panicked: %v", name, r)
+				}
+			}()
+			err = fn()
+		}()
+		if err == nil {
+			t.Fatalf("%s: expected error", name)
+		}
+		if !errors.Is(err, sszutils.ErrInvalidValueRange) {
+			t.Fatalf("%s: expected ErrInvalidValueRange, got %v", name, err)
+		}
+	}
+
+	// variant 0 expects uint32, Data is a string
+	bad := &T{}
+	bad.U.Variant = 0
+	bad.U.Data = "not a uint32"
+	check("marshal", func() error { _, e := ds.MarshalSSZ(bad); return e })
+	check("htr", func() error { _, e := ds.HashTreeRoot(bad); return e })
+
+	// variant 1 expects [16]byte, Data is uint32
+	bad2 := &T{}
+	bad2.U.Variant = 1
+	bad2.U.Data = uint32(42)
+	check("marshal2", func() error { _, e := ds.MarshalSSZ(bad2); return e })
+	check("htr2", func() error { _, e := ds.HashTreeRoot(bad2); return e })
+
+	// A dynamic variant exercises the size-path guard: without it, sizing the
+	// wrong-typed value would call Len() on a non-slice and panic.
+	type D struct {
+		U CompatibleUnion[struct {
+			Variant0 []uint64 `ssz-max:"8"`
+			Variant1 uint32
+		}]
+	}
+	dynBad := &D{}
+	dynBad.U.Variant = 0 // expects []uint64
+	dynBad.U.Data = uint32(42)
+	check("size-dynvariant", func() error { _, e := ds.MarshalSSZ(dynBad); return e })
+}


### PR DESCRIPTION
# Fix marshal/HTR/stream inconsistencies found by differential fuzzing

## Summary

Three rounds of external differential fuzzing flagged a set of issues comparing
the reflection engine, the codegen engine, the streaming paths and the hasher
against each other. After verifying each against the code, most were genuine bugs;
a few were caller-contract (garbage-in/garbage-out) cases that are not library
bugs.

This PR fixes them, keeps the reflection and codegen paths consistent, and adds
regression tests for every fix (verified by mutation testing — re-introducing any
fixed bug fails a test).

## Round 1 — root causes & fixes

| Root cause | Fix |
|---|---|
| **Empty bitlist size under-counted** — `getSszValueSize` returned `0` while `marshalBitlist` writes a `0x01` terminator byte, so the pre-sized buffer overflowed and panicked | `reflection/sszsize.go`: an empty/nil bitlist is now sized as 1 byte |
| **Bitvector padding check used the decoder's remaining length** (`decoder.GetLength()`, which includes trailing fields) instead of the vector's own length, and fired even for byte-aligned vectors | `reflection/unmarshal.go`: only check padding when `BitSize%8 != 0` (matches codegen); same `%8` guard added to `reflection/treeroot.go` for symmetry |
| **Recursive type definitions → stack overflow** — no cycle detection in the type-descriptor builder | `ssztypes/typecache.go`: track the in-progress build set and return a clean `ErrUnsupportedType` for self-referential types |
| **Zero-value `CompatibleUnion` panicked** on the nil data interface (`reflect.Value.Uint on zero Value`) in both the size and marshal paths | `reflection/marshal.go` + `reflection/sszsize.go`: `IsNil()` guard returning `ErrInvalidUnionVariant`, consistent with the existing HTR path |
| **Stream encoder buffer < 8 bytes** overflowed on `EncodeUint32/64`/`EncodeOffset` | `sszutils/encoder_stream.go`: enforce a minimum buffer size of 8 (mirrors the stream decoder) |
| **HTR silently accepted non-terminated bitlists** that marshal rejects | `reflection/treeroot.go` + `codegen/gen_hashtreeroot.go` template: reject a bitlist whose last byte is `0x00` |

After these fixes, reflection and codegen agree on the same bitvector and bitlist
payloads — confirmed by regenerating the `codegen/tests` fixtures and running the
differential suite.

## Round 2 — root causes & fixes

| Root cause | Fix |
|---|---|
| **`big.Int` silently dropped its sign** — both engines encoded `big.Int.Bytes()` (magnitude only), so a negative value round-tripped to its positive counterpart and `-x`/`x` produced the same hash tree root | All `big.Int` paths now use a sign-magnitude encoding: a leading sign byte (`0x00` non-negative, `0x01` negative) followed by the big-endian magnitude. The decoder rejects sign bytes other than `0x00`/`0x01`. Inlined consistently across `reflection/{marshal,unmarshal,sszsize,treeroot}.go` and the six codegen generators |
| **Optional availability byte was non-canonical and inconsistent** — reflection treated any non-zero byte as "present", codegen's buffer path treated any non-`1` byte as "absent", so the two engines decoded the same wire bytes to different values | Both paths now strictly accept only `0x00`/`0x01` and reject anything else with `ErrInvalidValueRange` (the codegen stream path was already strict via `DecodeBool`). This also closes the byte-level malleability |
| **Degenerate `dynssz-*` spec values silently disabled the size limit** — `ResolveSpecValue` cast every result through `float64` and `uint64(...)`, so `NaN`/`Inf`/negative/overflow saturated to an effectively unbounded limit, and large `uint64` spec values lost precision | `specvals.go`: values supplied directly under a name are read with their real type and full `uint64` precision; expression results are validated and `NaN`/`Inf`/negative/overflow are rejected with a clear error |
| **`CompatibleUnion` with a wrong-typed `Data` panicked** — after the nil guard, reflection recursed into the typed marshaler without checking the concrete type, panicking inside the primitive marshaler | `reflection/{marshal,treeroot,sszsize}.go`: after the nil guard, verify `Data`'s concrete type matches the variant and return `ErrUnionTypeMismatchFn()` (matching codegen) otherwise |

## Round 3 — root causes & fixes

| Root cause | Fix |
|---|---|
| **`CalculateLimit` overflowed uint64** — `(maxCapacity*size+31)/32` wrapped for a large `ssz-max`, collapsing to a tiny limit, so unrelated list capacities shared a merkleization depth and produced colliding hash tree roots | `sszutils/treeroot.go`: compute the chunk limit in 128-bit (`bits.Mul64`), clamping only at genuine uint64 overflow |
| **Codegen ignored auto-detected progressive containers** — a struct with `ssz-index` tags but no explicit `ssz-type:"progressive-container"` was emitted as a regular container, so codegen and reflection produced different hash tree roots | `codegen/parser.go`: detect `ssz-index` tags, validate (all present, strictly increasing) and upgrade to `SszProgressiveContainerType`, mirroring the runtime typecache |
| **Public API panicked on a `nil` argument** — an untyped `nil` (vs a typed-nil pointer) dereferenced inside the type cache | `dynssz.go`: every entry point (`MarshalSSZ`/`MarshalSSZTo`/`MarshalSSZWriter`/`SizeSSZ`/`UnmarshalSSZ`/`UnmarshalSSZReader`/`HashTreeRoot`/`HashTreeRootWith`/`GetTree`) returns `ErrInvalidValueRange` for a nil source/target |
| **`MarshalSSZTo` panicked on a short-capacity or non-empty buffer** — the buffer encoder indexed past `cap(buf)` | `dynssz.go`: pre-size from `SizeSSZ` and grow the buffer, giving the documented append semantics safely |
| **HTR accepted over-limit primitive lists** — the reflection list HTR compared the packed *chunk* count against the limit, so a `[]byte ssz-max:"4"` accepted up to 32 bytes while marshal rejected it | `reflection/treeroot.go`: enforce the element-count limit (`sliceLen > Limit`) for primitive lists, matching marshal and codegen |
| **`ssz-max:"0"` disagreed between engines** — `0` is a dynamic-ssz "no limit" placeholder (the real limit may arrive via `dynssz-max`), which codegen honored but reflection treated as a hard zero limit and rejected | `ssztypes/typecache.go`: a resolved limit of `0` no longer sets `SszTypeFlagHasLimit`, so reflection treats it as unbounded like codegen |
| **`uint64` spec values above 2^53 lost precision** — values were round-tripped through `float64` | already resolved by the round-2 spec rework (direct values keep their exact type); `uintptr` added for completeness |

`CalculateLimit` is shared by reflection and codegen, so the overflow fix applies
to both. Reflection vs codegen agreement for progressive containers and
`ssz-max:"0"` is verified by invoking the generated methods directly and comparing
against pure reflection.

### `big.Int` wire-format change

`big.Int` is not part of the SSZ spec, so dynamic-ssz uses its own dynamic
encoding for it. Preserving the sign changes that encoding: every `big.Int` now
serializes (and hashes) as `[sign byte][big-endian magnitude]` rather than the
bare magnitude. Previously-encoded `big.Int` payloads and their hash tree roots
will differ. Zero still encodes as a single `0x00` byte and hashes to the same
all-zero root as before.

## Testing

All tests were added to the existing test files (no new catch-all test file):

- `dynssz_test.go` — bitlist marshal, bitvector round-trips and padding, recursive
  rejection, small stream-writer buffers; plus `big.Int` sign round-trip, a golden
  sign-magnitude vector, positive-vs-negative HTR distinctness, invalid-sign-byte
  rejection, non-canonical optional rejection, and spec-value validation
  (degenerate rejection + full `uint64` precision).
- `union_test.go` — zero-value union across buffer/stream/HTR, top-level and
  dynamic-variant cases, and wrong-typed `Data` across marshal/HTR/size.
- `sszutils/stream_test.go` — `TestStreamEncoder_MinBufferSize`; the three existing
  small-buffer tests were updated to the new floor.
- `codegen/gen_hashtreeroot_test.go` — asserts the generated bitlist HTR emits the
  terminator-bit guard.
- `codegen/tests/codegen_test.go` — `TestCodegenBigIntGolden` pins the generated
  `big.Int` hash tree root (value and pointer) against hardcoded golden roots. The
  other codegen extended-type tests are purely differential (codegen vs
  reflection), so a simultaneous change to both engines would otherwise go
  unnoticed.

Verification performed:

- **Statement coverage:** every newly added executable line is hit
  (`go test -coverpkg=./...`).
- **Mutation testing:** re-introducing each fixed bug fails a targeted test
  (panic / stack overflow / assertion / build break). The `treeroot.go` bitvector
  `%8` change is behaviorally equivalent to the prior condition there (a
  symmetry-only change — the real bitvector bug was in `unmarshal.go`), so it has
  no dedicated failing test by design. The codegen-vs-reflection round-3 tests
  invoke the generated methods directly (not via a value passed to the reflection
  API, which would fall back to reflection on both sides and never compare codegen
  output).
- Full suite passes, including `-race` and the regenerated codegen fixtures.
- `golangci-lint run --new-from-rev=origin/master` reports 0 issues.

## Files changed

```
codegen/gen_hashtreeroot.go         bitlist terminator guard + inlined big.Int sign encoding
codegen/gen_marshal.go              inlined big.Int sign encoding (buffer)
codegen/gen_encoder.go              inlined big.Int sign encoding (stream)
codegen/gen_size.go                 big.Int size = 1 (sign byte) + magnitude
codegen/gen_unmarshal.go            big.Int sign decode + strict optional availability byte
codegen/gen_decoder.go              big.Int sign decode (stream)
codegen/gen_hashtreeroot_test.go    codegen regression test (bitlist terminator)
codegen/tests/codegen_test.go       TestCodegenBigIntGolden
reflection/sszsize.go               empty-bitlist size; union nil + type-mismatch guards; big.Int size
reflection/marshal.go               union nil + type-mismatch guards; big.Int sign encode
reflection/unmarshal.go             bitvector %8 padding; strict optional byte; big.Int sign decode
reflection/treeroot.go              bitvector %8; bitlist terminator; union type-mismatch; big.Int sign hash
reflection/common_test.go           updated big.Int golden vectors (new sign-magnitude format)
ssztypes/typecache.go               recursive-type detection
sszutils/encoder_stream.go          minimum stream encoder buffer size (8)
sszutils/stream_test.go             tests + small-buffer test updates
specvals.go                         spec value type/precision handling + degenerate-value rejection
dynssz_test.go                      behavioral regression tests
union_test.go                       union regression tests
```

## Note for maintainers

The codegen templates changed (bitlist terminator guard and the `big.Int`
sign-magnitude encoding). Regenerate any committed/cached generated SSZ code
(e.g. `go generate ./codegen/tests/`) so it picks up the new output; the
`TestCodegenBigIntGolden` golden roots require the regenerated code.
