### PR TITLE
intercept type tree traversal for fully delegated types

### DIFF
--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -644,6 +644,21 @@ type CodeGenerator struct {
 	typeCache   *ssztypes.TypeCache
 	packageName string
 	compatFlags map[string]ssztypes.SszCompatFlag
+
+	// annotationResolver returns the merged ssz annotation tag for a go/types
+	// type (or ""), letting the parser read a referenced, fully-delegated type's
+	// ssz-static declaration without traversing its subtree. Set via
+	// WithAnnotationResolver; nil disables the parser's shallow-build gate.
+	annotationResolver func(types.Type) string
+}
+
+// SetAnnotationResolver registers a resolver that returns the merged ssz
+// annotation tag for a go/types type (or ""). The code generator passes it to
+// the parser so referenced, fully-delegated types declaring ssz-static are
+// shallow-built instead of traversed. Typically backed by the source scan that
+// also feeds per-type Annotate options.
+func (cg *CodeGenerator) SetAnnotationResolver(resolver func(types.Type) string) {
+	cg.annotationResolver = resolver
 }
 
 // NewCodeGenerator creates a new code generator instance with the specified DynSsz configuration.

--- a/codegen/gen_common.go
+++ b/codegen/gen_common.go
@@ -130,6 +130,22 @@ func (g *staticSizeVarGenerator) getStaticSizeVar(desc *ssztypes.TypeDescriptor)
 	g.varCounter++
 	sizeVar := fmt.Sprintf("%s%d", g.prefix, g.varCounter)
 
+	// A shallow-built, fully-delegated type (parser gate) has no traversed subtree
+	// to sum: it computes its own (possibly spec-dependent) fixed size, so query
+	// the type's sizer on a zero value at runtime.
+	if desc.SszType == ssztypes.SszUnspecifiedType {
+		switch {
+		case desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicSizer != 0:
+			appendCode(g.codeBuf, 0, "%s := new(%s).SizeSSZDyn(ds)\n", sizeVar, g.typePrinter.InnerTypeString(desc))
+			g.varMap[descHash] = sizeVar
+			return sizeVar, nil
+		case desc.SszCompatFlags&ssztypes.SszCompatFlagFastSSZMarshaler != 0:
+			appendCode(g.codeBuf, 0, "%s := new(%s).SizeSSZ()\n", sizeVar, g.typePrinter.InnerTypeString(desc))
+			g.varMap[descHash] = sizeVar
+			return sizeVar, nil
+		}
+	}
+
 	// recursive resolve static size with size expressions
 	switch desc.SszType {
 	case ssztypes.SszTypeWrapperType:

--- a/codegen/gen_common.go
+++ b/codegen/gen_common.go
@@ -132,18 +132,13 @@ func (g *staticSizeVarGenerator) getStaticSizeVar(desc *ssztypes.TypeDescriptor)
 
 	// A shallow-built, fully-delegated type (parser gate) has no traversed subtree
 	// to sum: it computes its own (possibly spec-dependent) fixed size, so query
-	// the type's sizer on a zero value at runtime.
-	if desc.SszType == ssztypes.SszUnspecifiedType {
-		switch {
-		case desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicSizer != 0:
-			appendCode(g.codeBuf, 0, "%s := new(%s).SizeSSZDyn(ds)\n", sizeVar, g.typePrinter.InnerTypeString(desc))
-			g.varMap[descHash] = sizeVar
-			return sizeVar, nil
-		case desc.SszCompatFlags&ssztypes.SszCompatFlagFastSSZMarshaler != 0:
-			appendCode(g.codeBuf, 0, "%s := new(%s).SizeSSZ()\n", sizeVar, g.typePrinter.InnerTypeString(desc))
-			g.varMap[descHash] = sizeVar
-			return sizeVar, nil
-		}
+	// the type's sizer on a zero value at runtime. The gate only admits types that
+	// implement DynamicSizer (fullyDelegatesSSZ requires it), so that is the only
+	// case to handle here.
+	if desc.SszType == ssztypes.SszUnspecifiedType && desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicSizer != 0 {
+		appendCode(g.codeBuf, 0, "%s := new(%s).SizeSSZDyn(ds)\n", sizeVar, g.typePrinter.InnerTypeString(desc))
+		g.varMap[descHash] = sizeVar
+		return sizeVar, nil
 	}
 
 	// recursive resolve static size with size expressions

--- a/codegen/gen_encoder.go
+++ b/codegen/gen_encoder.go
@@ -681,20 +681,20 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 		ctx.appendCode(indent, "\tenc.EncodeZeroPadding(%s * 4)\n", limitVar)
 		ctx.appendCode(indent, "} else {\n")
 
+		// The offset header has one 4-byte entry per vector slot (limit entries),
+		// so the first element's data starts at limit*4. Emit an offset for each
+		// real element, then for each zero-padding slot when the vector is
+		// under-filled. (Byte-identical to a full vector; correct when shorter.)
 		sizeFnCall := ctx.getSizeFnCall(desc.ElemDesc, fmt.Sprintf("%s[i]", getValueVar(false, "")))
-		ctx.appendCode(indent, "\toffset := %s * 4\n", lenVar)
-		ctx.appendCode(indent, "\tenc.EncodeOffset(uint32(offset))\n")
-		ctx.appendCode(indent, "\tfor i := range %s-1 {\n", lenVar)
-		ctx.appendCode(indent, "\t\toffset += %s\n", sizeFnCall)
+		ctx.appendCode(indent, "\toffset := %s * 4\n", limitVar)
+		ctx.appendCode(indent, "\tfor i := range %s {\n", lenVar)
 		ctx.appendCode(indent, "\t\tenc.EncodeOffset(uint32(offset))\n")
+		ctx.appendCode(indent, "\t\toffset += %s\n", sizeFnCall)
 		ctx.appendCode(indent, "\t}\n")
 
 		if desc.Kind != reflect.Array {
 			// append zero padding if we have less items than the limit
 			ctx.appendCode(indent, "\tif %s < %s {\n", lenVar, limitVar)
-			sizeFnCall := ctx.getSizeFnCall(desc.ElemDesc, fmt.Sprintf("%s[%s]", getValueVar(false, ""), lenVar))
-			ctx.appendCode(indent, "\t\toffset += %s\n", sizeFnCall)
-			ctx.appendCode(indent, "\t\tenc.EncodeOffset(uint32(offset))\n")
 			if desc.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 {
 				ctx.appendCode(indent, "\t\tzeroItem := new(%s)\n", ctx.typePrinter.InnerTypeString(desc.ElemDesc))
 			} else {
@@ -703,9 +703,9 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 
 			zeroItemSizeFnCall := ctx.getSizeFnCall(desc.ElemDesc, "zeroItem")
 			ctx.appendCode(indent, "\t\tzeroSize := %s\n", zeroItemSizeFnCall)
-			ctx.appendCode(indent, "\t\tfor i := %s; i < %s-1; i++ {\n", lenVar, limitVar)
-			ctx.appendCode(indent, "\t\t\toffset += zeroSize\n")
+			ctx.appendCode(indent, "\t\tfor i := %s; i < %s; i++ {\n", lenVar, limitVar)
 			ctx.appendCode(indent, "\t\t\tenc.EncodeOffset(uint32(offset))\n")
+			ctx.appendCode(indent, "\t\t\toffset += zeroSize\n")
 			ctx.appendCode(indent, "\t\t}\n")
 			ctx.appendCode(indent, "\t}\n")
 		}

--- a/codegen/gen_hashtreeroot.go
+++ b/codegen/gen_hashtreeroot.go
@@ -891,7 +891,13 @@ func (ctx *hashTreeRootContext) hashBitlist(desc *ssztypes.TypeDescriptor, varNa
 	if maxVar != "" || desc.SszType == ssztypes.SszProgressiveBitlistType {
 		sizeVar = "size"
 	}
-	ctx.appendCode(indent, "bitlist, %s := %s.ParseBitlistWithHasher(hh, %s[:])\n", sizeVar, hasherAlias, varName)
+	// Progressive bitlists must keep all-zero top chunks (the chunk count defines
+	// the progressive tree shape), so parse without trailing-zero trimming.
+	parseFn := "ParseBitlistWithHasher"
+	if desc.SszType == ssztypes.SszProgressiveBitlistType {
+		parseFn = "ParseProgressiveBitlistWithHasher"
+	}
+	ctx.appendCode(indent, "bitlist, %s := %s.%s(hh, %s[:])\n", sizeVar, hasherAlias, parseFn, varName)
 
 	if maxVar != "" {
 		ctx.appendCode(indent, "if size > %s {\n", maxVar)

--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -311,6 +311,19 @@ func dataCompatFlags(opts *CodeGeneratorOptions) ssztypes.SszCompatFlag {
 //   - Organized import statements
 //   - Variable declarations for error handling
 //   - Generated SSZ methods for all specified types
+//
+// staticAnnotationFor returns the ssz-static annotation declaring whether a
+// generated type is fixed-size (static) or variable-size (dynamic). The
+// reflection typecache uses it to shallow-build the fully-delegated type without
+// descending into its subtree; for static types it reads the fixed size from the
+// type's own sizer.
+func staticAnnotationFor(desc *ssztypes.TypeDescriptor) string {
+	if desc.SszTypeFlags&ssztypes.SszTypeFlagIsDynamic != 0 {
+		return `ssz-static:"false"`
+	}
+	return `ssz-static:"true"`
+}
+
 func (cg *CodeGenerator) generateFile(packagePath string, opts *CodeGeneratorFileOptions) (string, error) {
 	if len(opts.Types) == 0 {
 		return "", fmt.Errorf("no types requested for generation")
@@ -319,6 +332,7 @@ func (cg *CodeGenerator) generateFile(packagePath string, opts *CodeGeneratorFil
 	typePrinter := NewTypePrinter(packagePath)
 	typePrinter.AddAlias("github.com/pk910/dynamic-ssz", "dynssz")
 	codeBuilder := strings.Builder{}
+	annotationsBuilder := strings.Builder{}
 	hashParts := [][]byte{}
 
 	for _, t := range opts.Types {
@@ -334,6 +348,10 @@ func (cg *CodeGenerator) generateFile(packagePath string, opts *CodeGeneratorFil
 			if err != nil {
 				return "", fmt.Errorf("failed to generate code for %s: %w", t.TypeName, err)
 			}
+
+			// Declare static/dynamic so the reflection typecache can shallow-build
+			// this fully-delegated type without descending into its subtree.
+			fmt.Fprintf(&annotationsBuilder, "var _ = sszutils.Annotate[%s](`%s`)\n", typePrinter.InnerTypeString(t.Descriptor), staticAnnotationFor(t.Descriptor))
 		}
 
 		if len(t.ViewDescriptors) > 0 {
@@ -345,6 +363,12 @@ func (cg *CodeGenerator) generateFile(packagePath string, opts *CodeGeneratorFil
 			err := cg.generateSSZViewMethods(t.Descriptor, t.ViewDescriptors, typePrinter, &codeBuilder, &t.Options)
 			if err != nil {
 				return "", fmt.Errorf("failed to generate code for view types of %s: %w", t.TypeName, err)
+			}
+
+			// Each view schema type may have its own static/dynamic shape, so the
+			// annotation is emitted per view schema type (not the base type).
+			for _, viewDesc := range t.ViewDescriptors {
+				fmt.Fprintf(&annotationsBuilder, "var _ = sszutils.Annotate[%s](`%s`)\n", typePrinter.ViewTypeString(viewDesc, false), staticAnnotationFor(viewDesc))
 			}
 		}
 	}
@@ -423,6 +447,13 @@ func (cg *CodeGenerator) generateFile(packagePath string, opts *CodeGeneratorFil
 
 	// Variable declarations
 	mainCodeBuilder.WriteString("var _ = sszutils.ErrListTooBig\n\n")
+
+	// Type annotations (ssz-static declarations) up front so the reflection
+	// typecache can shallow-build these fully-delegated types.
+	if annotationsBuilder.Len() > 0 {
+		mainCodeBuilder.WriteString(annotationsBuilder.String())
+		mainCodeBuilder.WriteString("\n")
+	}
 
 	// Generated code
 	generatedCode := codeBuilder.String()

--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -147,6 +147,7 @@ func (cg *CodeGenerator) analyzeTypes() error {
 					parser = NewParser()
 					parser.CompatFlags = cg.compatFlags
 					parser.ExtendedTypes = t.Options.ExtendedTypes
+					parser.AnnotationResolver = cg.annotationResolver
 				}
 				if _, ok := t.GoTypesType.(*types.Pointer); !ok {
 					t.GoTypesType = types.NewPointer(t.GoTypesType)
@@ -176,6 +177,7 @@ func (cg *CodeGenerator) analyzeTypes() error {
 					if parser == nil {
 						parser = NewParser()
 						parser.CompatFlags = cg.compatFlags
+						parser.AnnotationResolver = cg.annotationResolver
 					}
 					baseType := viewType
 					if named, ok := baseType.(*types.Named); ok {

--- a/codegen/parser.go
+++ b/codegen/parser.go
@@ -375,13 +375,16 @@ func (p *Parser) buildTypeDescriptor(dataType, schemaType types.Type, typeHints 
 	// are already handled inline by the caller (it strips delegation flags).
 	if p.AnnotationResolver != nil && len(typeHints) == 0 && len(sizeHints) == 0 && len(maxSizeHints) == 0 && p.getCompatFlag(innerDataType, innerSchemaType) == 0 && p.fullyDelegatesSSZ(originalType) {
 		if staticStr, ok := reflect.StructTag(p.AnnotationResolver(originalType)).Lookup("ssz-static"); ok {
-			if staticStr == "true" {
+			switch staticStr {
+			case "true":
 				// Static: the generated code resolves the exact size at runtime via
 				// the type's own sizer, so drive sizing/offsets at runtime rather
 				// than from a (here unknown) compile-time constant.
 				desc.SszTypeFlags |= ssztypes.SszTypeFlagHasSizeExpr
-			} else {
+			case "false":
 				desc.SszTypeFlags |= ssztypes.SszTypeFlagIsDynamic
+			default:
+				return nil, fmt.Errorf("invalid ssz-static value %q for type %v (must be \"true\" or \"false\")", staticStr, originalType)
 			}
 			p.detectCompatFlags(desc, originalType, innerDataType, innerSchemaType)
 			// Delegate through the spec-aware dynamic methods, not the fastssz ones.

--- a/codegen/parser.go
+++ b/codegen/parser.go
@@ -67,6 +67,11 @@ type Parser struct {
 	cache         map[string]*ssztypes.TypeDescriptor
 	CompatFlags   map[string]ssztypes.SszCompatFlag
 	ExtendedTypes bool
+
+	// AnnotationResolver returns the merged ssz annotation tag for a type (or "").
+	// It lets the parser read a referenced, fully-delegated type's ssz-static
+	// declaration so its subtree need not be traversed or validated.
+	AnnotationResolver func(types.Type) string
 }
 
 // NewParser creates a new compile-time type parser for code generation.
@@ -166,6 +171,91 @@ func (p *Parser) getCompatFlag(dataType, schemaType types.Type) ssztypes.SszComp
 		typeName = fmt.Sprintf("%v|%v", dataType.String(), schemaType.String())
 	}
 	return p.CompatFlags[typeName]
+}
+
+// detectCompatFlags records which SSZ delegation interfaces the type implements,
+// checking both the value and pointer forms. The fastssz family is only flagged
+// when the descriptor does not carry a dynamic size/max (those use the static
+// fastssz layout). Mirrors the reflection typecache's detection.
+func (p *Parser) detectCompatFlags(desc *ssztypes.TypeDescriptor, originalType, innerDataType, innerSchemaType types.Type) {
+	otherType := originalType
+	if ptr, ok := otherType.(*types.Pointer); ok {
+		otherType = ptr.Elem()
+	} else {
+		otherType = types.NewPointer(otherType)
+	}
+
+	if (desc.SszTypeFlags&ssztypes.SszTypeFlagHasDynamicSize == 0 || desc.SszType == ssztypes.SszCustomType) && (p.getFastsszConvertCompatibility(originalType) || p.getFastsszConvertCompatibility(otherType)) {
+		desc.SszCompatFlags |= ssztypes.SszCompatFlagFastSSZMarshaler
+	}
+	if desc.SszTypeFlags&ssztypes.SszTypeFlagHasDynamicMax == 0 || desc.SszType == ssztypes.SszCustomType {
+		if p.getFastsszHashCompatibility(originalType) || p.getFastsszHashCompatibility(otherType) {
+			desc.SszCompatFlags |= ssztypes.SszCompatFlagFastSSZHasher
+		}
+		if p.getHashTreeRootWithCompatibility(originalType) || p.getHashTreeRootWithCompatibility(otherType) {
+			desc.SszCompatFlags |= ssztypes.SszCompatFlagHashTreeRootWith
+		}
+	}
+
+	// Check for dynamic interface implementations
+	if p.getDynamicMarshalerCompatibility(originalType) || p.getDynamicMarshalerCompatibility(otherType) {
+		desc.SszCompatFlags |= ssztypes.SszCompatFlagDynamicMarshaler
+	}
+	if p.getDynamicUnmarshalerCompatibility(originalType) || p.getDynamicUnmarshalerCompatibility(otherType) {
+		desc.SszCompatFlags |= ssztypes.SszCompatFlagDynamicUnmarshaler
+	}
+	if p.getDynamicEncoderCompatibility(originalType) || p.getDynamicEncoderCompatibility(otherType) {
+		desc.SszCompatFlags |= ssztypes.SszCompatFlagDynamicEncoder
+	}
+	if p.getDynamicDecoderCompatibility(originalType) || p.getDynamicDecoderCompatibility(otherType) {
+		desc.SszCompatFlags |= ssztypes.SszCompatFlagDynamicDecoder
+	}
+	if p.getDynamicSizerCompatibility(originalType) || p.getDynamicSizerCompatibility(otherType) {
+		desc.SszCompatFlags |= ssztypes.SszCompatFlagDynamicSizer
+	}
+	if p.getDynamicHashRootCompatibility(originalType) || p.getDynamicHashRootCompatibility(otherType) {
+		desc.SszCompatFlags |= ssztypes.SszCompatFlagDynamicHashRoot
+	}
+
+	// Check for dynamic view interface implementations (for fork-dependent SSZ schemas)
+	if p.getDynamicViewMarshalerCompatibility(originalType) || p.getDynamicViewMarshalerCompatibility(otherType) {
+		desc.SszCompatFlags |= ssztypes.SszCompatFlagDynamicViewMarshaler
+	}
+	if p.getDynamicViewUnmarshalerCompatibility(originalType) || p.getDynamicViewUnmarshalerCompatibility(otherType) {
+		desc.SszCompatFlags |= ssztypes.SszCompatFlagDynamicViewUnmarshaler
+	}
+	if p.getDynamicViewEncoderCompatibility(originalType) || p.getDynamicViewEncoderCompatibility(otherType) {
+		desc.SszCompatFlags |= ssztypes.SszCompatFlagDynamicViewEncoder
+	}
+	if p.getDynamicViewDecoderCompatibility(originalType) || p.getDynamicViewDecoderCompatibility(otherType) {
+		desc.SszCompatFlags |= ssztypes.SszCompatFlagDynamicViewDecoder
+	}
+	if p.getDynamicViewSizerCompatibility(originalType) || p.getDynamicViewSizerCompatibility(otherType) {
+		desc.SszCompatFlags |= ssztypes.SszCompatFlagDynamicViewSizer
+	}
+	if p.getDynamicViewHashRootCompatibility(originalType) || p.getDynamicViewHashRootCompatibility(otherType) {
+		desc.SszCompatFlags |= ssztypes.SszCompatFlagDynamicViewHashRoot
+	}
+
+	desc.SszCompatFlags |= p.getCompatFlag(innerDataType, innerSchemaType)
+}
+
+// fullyDelegatesSSZ reports whether the type implements the complete set of
+// dynamic SSZ operation interfaces (marshal, unmarshal, size, hash-tree-root),
+// checking both value and pointer forms. Such a type handles every operation in
+// its own generated code, so a reference to it need not be traversed.
+func (p *Parser) fullyDelegatesSSZ(t types.Type) bool {
+	other := t
+	if ptr, ok := other.(*types.Pointer); ok {
+		other = ptr.Elem()
+	} else {
+		other = types.NewPointer(other)
+	}
+	any2 := func(f func(types.Type) bool) bool { return f(t) || f(other) }
+	return (any2(p.getDynamicMarshalerCompatibility) || any2(p.getDynamicEncoderCompatibility)) &&
+		(any2(p.getDynamicUnmarshalerCompatibility) || any2(p.getDynamicDecoderCompatibility)) &&
+		any2(p.getDynamicSizerCompatibility) &&
+		any2(p.getDynamicHashRootCompatibility)
 }
 
 //nolint:gocyclo // SSZ type descriptor builder is inherently complex
@@ -272,6 +362,38 @@ func (p *Parser) buildTypeDescriptor(dataType, schemaType types.Type, typeHints 
 		}
 		desc.GoTypeFlags |= ssztypes.GoTypeFlagIsView
 	}
+
+	// A fully-delegated, already-implemented type handles every SSZ operation in
+	// its own code, so the descriptor subtree below it is never consulted. When
+	// such a type declares ssz-static, build a shallow descriptor from that
+	// declaration and skip traversing — and validating — its subtree.
+	//
+	// This only applies to EXTERNAL types (getCompatFlag == 0): a type that is
+	// itself being generated in this run is registered in CompatFlags and must be
+	// traversed so its own code can be emitted, regardless of whether it appears
+	// at the top level or as a field of another generated type. Field-level hints
+	// are already handled inline by the caller (it strips delegation flags).
+	if p.AnnotationResolver != nil && len(typeHints) == 0 && len(sizeHints) == 0 && len(maxSizeHints) == 0 && p.getCompatFlag(innerDataType, innerSchemaType) == 0 && p.fullyDelegatesSSZ(originalType) {
+		if staticStr, ok := reflect.StructTag(p.AnnotationResolver(originalType)).Lookup("ssz-static"); ok {
+			if staticStr == "true" {
+				// Static: the generated code resolves the exact size at runtime via
+				// the type's own sizer, so drive sizing/offsets at runtime rather
+				// than from a (here unknown) compile-time constant.
+				desc.SszTypeFlags |= ssztypes.SszTypeFlagHasSizeExpr
+			} else {
+				desc.SszTypeFlags |= ssztypes.SszTypeFlagIsDynamic
+			}
+			p.detectCompatFlags(desc, originalType, innerDataType, innerSchemaType)
+			// Delegate through the spec-aware dynamic methods, not the fastssz ones.
+			desc.SszCompatFlags &^= ssztypes.SszCompatFlagFastSSZMarshaler | ssztypes.SszCompatFlagFastSSZHasher | ssztypes.SszCompatFlagHashTreeRootWith
+			// A shallow descriptor must not be cached as the type's full descriptor.
+			if cacheable {
+				delete(p.cache, typeKey)
+			}
+			return desc, nil
+		}
+	}
+
 	// Set kind based on underlying type
 	switch t := schemaType.(type) {
 	case *types.Basic:
@@ -711,67 +833,7 @@ func (p *Parser) buildTypeDescriptor(dataType, schemaType types.Type, typeHints 
 		return nil, fmt.Errorf("bit size tag is only allowed for bitvector or bitlist types, got %v", desc.SszType)
 	}
 
-	// Check interface compatibility (like reflection-based code)
-	otherType := originalType
-	if ptr, ok := otherType.(*types.Pointer); ok {
-		otherType = ptr.Elem()
-	} else {
-		otherType = types.NewPointer(otherType)
-	}
-
-	if (desc.SszTypeFlags&ssztypes.SszTypeFlagHasDynamicSize == 0 || desc.SszType == ssztypes.SszCustomType) && (p.getFastsszConvertCompatibility(originalType) || p.getFastsszConvertCompatibility(otherType)) {
-		desc.SszCompatFlags |= ssztypes.SszCompatFlagFastSSZMarshaler
-	}
-	if desc.SszTypeFlags&ssztypes.SszTypeFlagHasDynamicMax == 0 || desc.SszType == ssztypes.SszCustomType {
-		if p.getFastsszHashCompatibility(originalType) || p.getFastsszHashCompatibility(otherType) {
-			desc.SszCompatFlags |= ssztypes.SszCompatFlagFastSSZHasher
-		}
-		if p.getHashTreeRootWithCompatibility(originalType) || p.getHashTreeRootWithCompatibility(otherType) {
-			desc.SszCompatFlags |= ssztypes.SszCompatFlagHashTreeRootWith
-		}
-	}
-
-	// Check for dynamic interface implementations
-	if p.getDynamicMarshalerCompatibility(originalType) || p.getDynamicMarshalerCompatibility(otherType) {
-		desc.SszCompatFlags |= ssztypes.SszCompatFlagDynamicMarshaler
-	}
-	if p.getDynamicUnmarshalerCompatibility(originalType) || p.getDynamicUnmarshalerCompatibility(otherType) {
-		desc.SszCompatFlags |= ssztypes.SszCompatFlagDynamicUnmarshaler
-	}
-	if p.getDynamicEncoderCompatibility(originalType) || p.getDynamicEncoderCompatibility(otherType) {
-		desc.SszCompatFlags |= ssztypes.SszCompatFlagDynamicEncoder
-	}
-	if p.getDynamicDecoderCompatibility(originalType) || p.getDynamicDecoderCompatibility(otherType) {
-		desc.SszCompatFlags |= ssztypes.SszCompatFlagDynamicDecoder
-	}
-	if p.getDynamicSizerCompatibility(originalType) || p.getDynamicSizerCompatibility(otherType) {
-		desc.SszCompatFlags |= ssztypes.SszCompatFlagDynamicSizer
-	}
-	if p.getDynamicHashRootCompatibility(originalType) || p.getDynamicHashRootCompatibility(otherType) {
-		desc.SszCompatFlags |= ssztypes.SszCompatFlagDynamicHashRoot
-	}
-
-	// Check for dynamic view interface implementations (for fork-dependent SSZ schemas)
-	if p.getDynamicViewMarshalerCompatibility(originalType) || p.getDynamicViewMarshalerCompatibility(otherType) {
-		desc.SszCompatFlags |= ssztypes.SszCompatFlagDynamicViewMarshaler
-	}
-	if p.getDynamicViewUnmarshalerCompatibility(originalType) || p.getDynamicViewUnmarshalerCompatibility(otherType) {
-		desc.SszCompatFlags |= ssztypes.SszCompatFlagDynamicViewUnmarshaler
-	}
-	if p.getDynamicViewEncoderCompatibility(originalType) || p.getDynamicViewEncoderCompatibility(otherType) {
-		desc.SszCompatFlags |= ssztypes.SszCompatFlagDynamicViewEncoder
-	}
-	if p.getDynamicViewDecoderCompatibility(originalType) || p.getDynamicViewDecoderCompatibility(otherType) {
-		desc.SszCompatFlags |= ssztypes.SszCompatFlagDynamicViewDecoder
-	}
-	if p.getDynamicViewSizerCompatibility(originalType) || p.getDynamicViewSizerCompatibility(otherType) {
-		desc.SszCompatFlags |= ssztypes.SszCompatFlagDynamicViewSizer
-	}
-	if p.getDynamicViewHashRootCompatibility(originalType) || p.getDynamicViewHashRootCompatibility(otherType) {
-		desc.SszCompatFlags |= ssztypes.SszCompatFlagDynamicViewHashRoot
-	}
-
-	desc.SszCompatFlags |= p.getCompatFlag(innerDataType, innerSchemaType)
+	p.detectCompatFlags(desc, originalType, innerDataType, innerSchemaType)
 
 	// Optional and optional-list reshape the encoding around the inner type
 	// (presence byte / List[T,1] framing). The inner type's own SSZ methods

--- a/codegen/parser_test.go
+++ b/codegen/parser_test.go
@@ -12,7 +12,47 @@ import (
 	"testing"
 
 	"github.com/pk910/dynamic-ssz/ssztypes"
+	"golang.org/x/tools/go/packages"
 )
+
+// TestParserShallowGate exercises the parser's shallow-build gate for an external,
+// fully-delegated type. NestedDelegatedContainer (loaded with its generated
+// methods) fully delegates and is not registered in the parser's CompatFlags, so
+// the gate fires; the resolver supplies the ssz-static declaration. An invalid
+// value is rejected.
+func TestParserShallowGate(t *testing.T) {
+	cfg := &packages.Config{Mode: packages.NeedTypes | packages.NeedName | packages.NeedImports}
+	pkgs, err := packages.Load(cfg, "github.com/pk910/dynamic-ssz/codegen/tests")
+	if err != nil || len(pkgs) == 0 {
+		t.Fatalf("load tests package: %v", err)
+	}
+	container := pkgs[0].Types.Scope().Lookup("NestedDelegatedContainer")
+	if container == nil {
+		t.Fatal("NestedDelegatedContainer not found")
+	}
+	ptrType := types.NewPointer(container.Type())
+
+	t.Run("InvalidStaticValue", func(t *testing.T) {
+		p := NewParser()
+		p.AnnotationResolver = func(types.Type) string { return `ssz-static:"bogus"` }
+		_, err := p.GetTypeDescriptor(ptrType, nil, nil, nil)
+		if err == nil || !strings.Contains(err.Error(), "invalid ssz-static value") {
+			t.Fatalf("expected invalid ssz-static error, got %v", err)
+		}
+	})
+
+	t.Run("StaticTrueShallow", func(t *testing.T) {
+		p := NewParser()
+		p.AnnotationResolver = func(types.Type) string { return `ssz-static:"true"` }
+		desc, err := p.GetTypeDescriptor(ptrType, nil, nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if desc.ContainerDesc != nil {
+			t.Error("expected shallow descriptor (nil ContainerDesc) for delegated type")
+		}
+	})
+}
 
 func TestNewParser(t *testing.T) {
 	parser := NewParser()

--- a/codegen/tests/codegen_test.go
+++ b/codegen/tests/codegen_test.go
@@ -173,6 +173,15 @@ func TestCodegenCoverageTypes1(t *testing.T) {
 	testCodegenPayloadByReflection(t, CoverageTypes1_Payload, SimpleTypesWithSpecs_Specs)
 }
 
+// TestCodegenNestedDelegated exercises the shallow-build gate. NestedDelegatedContainer
+// references nestedDelegatedInner, a fully-delegated type carrying a structurally
+// illegal innard ([0]uint64). It only generates (parser gate) and round-trips
+// (reflection typecache gate) because both shallow-build the nested type via its
+// ssz-static annotation instead of traversing — and rejecting — that innard.
+func TestCodegenNestedDelegated(t *testing.T) {
+	testCodegenPayloadByReflection(t, NestedDelegatedContainer_Payload, nil)
+}
+
 // TestCodegenAnnotatedTypes tests root-level annotated non-struct types
 // and containers that use annotated types as fields.
 func TestCodegenAnnotatedTypes(t *testing.T) {

--- a/codegen/tests/codegen_test.go
+++ b/codegen/tests/codegen_test.go
@@ -173,13 +173,19 @@ func TestCodegenCoverageTypes1(t *testing.T) {
 	testCodegenPayloadByReflection(t, CoverageTypes1_Payload, SimpleTypesWithSpecs_Specs)
 }
 
-// TestCodegenNestedDelegated exercises the shallow-build gate. NestedDelegatedContainer
-// references nestedDelegatedInner, a fully-delegated type carrying a structurally
-// illegal innard ([0]uint64). It only generates (parser gate) and round-trips
-// (reflection typecache gate) because both shallow-build the nested type via its
-// ssz-static annotation instead of traversing — and rejecting — that innard.
+// TestCodegenNestedDelegated exercises the shallow-build gate. The containers
+// reference fully-delegated types carrying a structurally illegal innard
+// ([0]uint64). They only generate (parser gate) and round-trip (reflection
+// typecache gate) because both shallow-build the nested type via its ssz-static
+// annotation instead of traversing — and rejecting — that innard. The Static case
+// uses ssz-static:"true" (fixed, runtime delegated size); Dynamic uses "false".
 func TestCodegenNestedDelegated(t *testing.T) {
-	testCodegenPayloadByReflection(t, NestedDelegatedContainer_Payload, nil)
+	t.Run("Static", func(t *testing.T) {
+		testCodegenPayloadByReflection(t, NestedDelegatedContainer_Payload, nil)
+	})
+	t.Run("Dynamic", func(t *testing.T) {
+		testCodegenPayloadByReflection(t, NestedDelegatedDynContainer_Payload, nil)
+	})
 }
 
 // TestCodegenAnnotatedTypes tests root-level annotated non-struct types

--- a/codegen/tests/codegen_test.go
+++ b/codegen/tests/codegen_test.go
@@ -70,6 +70,17 @@ var testMatrix = []TestPayload{
 		Hash:    "0100000000000000020000000000000003000000000000000000000000000000",
 	},
 	{
+		// EIP-7916 progressive-bitlist with an all-zero top 256-bit chunk. The
+		// golden root is cross-checked against ethereum/remerkleable and an
+		// independent raw-SHA256 implementation. Reflection and codegen share the
+		// hasher, so this golden (not the differential check) is what guards the
+		// chunk-count regression. See ProgBitlistZeroTop in types.go.
+		Name:    "ProgBitlistZeroTop",
+		Payload: ProgBitlistZeroTop_Payload,
+		Specs:   map[string]any{},
+		Hash:    "b039aa14167fdfd184839eb032e714ef89e0b42478e2db1ed1353759c200dda5",
+	},
+	{
 		Name:    "ViewTypes_View1",
 		Payload: ViewTypes1_Payload,
 		View:    (*ViewTypes1_View1)(nil),

--- a/codegen/tests/gen_ssz.yaml
+++ b/codegen/tests/gen_ssz.yaml
@@ -55,6 +55,8 @@ types:
     output: gen_progressive.go
   - name: ZeroMaxList
     output: gen_progressive.go
+  - name: ProgBitlistZeroTop
+    output: gen_progressive.go
   - name: CustomTypes1
     output: gen_custom.go
   - name: CoverageTypes1

--- a/codegen/tests/gen_ssz.yaml
+++ b/codegen/tests/gen_ssz.yaml
@@ -24,6 +24,8 @@ types:
 
   - name: NestedDelegatedContainer
     output: gen_nesteddelegated.go
+  - name: NestedDelegatedDynContainer
+    output: gen_nesteddelegated.go
 
   - name: SimpleTypes2
     output: gen_simple2.go
@@ -63,7 +65,7 @@ types:
   - name: CoverageTypes1
     output: gen_coverage.go
   - name: CoverageTypes7
-    output: gen_coverage7.go
+    output: gen_coverage.go
 
   - name: OptionalListTypes
     output: gen_optionallist.go

--- a/codegen/tests/gen_ssz.yaml
+++ b/codegen/tests/gen_ssz.yaml
@@ -22,6 +22,9 @@ types:
   - name: SimpleTypes1_C1
     output: gen_simple1.go
 
+  - name: NestedDelegatedContainer
+    output: gen_nesteddelegated.go
+
   - name: SimpleTypes2
     output: gen_simple2.go
   - name: SimpleTypes3

--- a/codegen/tests/types.go
+++ b/codegen/tests/types.go
@@ -1150,9 +1150,7 @@ func (n *nestedDelegatedInner) MarshalSSZDyn(_ sszutils.DynamicSpecs, buf []byte
 }
 
 func (n *nestedDelegatedInner) UnmarshalSSZDyn(_ sszutils.DynamicSpecs, buf []byte) error {
-	if len(buf) < 4 {
-		return sszutils.ErrUnexpectedEOF
-	}
+	// The caller (a fixed 4-byte static field) always slices exactly 4 bytes.
 	n.Value = binary.LittleEndian.Uint32(buf)
 	return nil
 }
@@ -1173,4 +1171,53 @@ type NestedDelegatedContainer struct {
 var NestedDelegatedContainer_Payload = NestedDelegatedContainer{
 	A: 7,
 	N: nestedDelegatedInner{Value: 0x11223344},
+}
+
+// nestedDelegatedDyn is the variable-size counterpart of nestedDelegatedInner: a
+// fully-delegated type declaring ssz-static:"false". It also carries an illegal
+// innard that the parser must not traverse.
+type nestedDelegatedDyn struct {
+	Bad   [0]uint64 // illegal Vector[uint64, 0] if ever traversed
+	Items []uint32
+}
+
+var _ = sszutils.Annotate[nestedDelegatedDyn](`ssz-static:"false"`)
+
+func (n *nestedDelegatedDyn) SizeSSZDyn(_ sszutils.DynamicSpecs) int { return len(n.Items) * 4 }
+
+func (n *nestedDelegatedDyn) MarshalSSZDyn(_ sszutils.DynamicSpecs, buf []byte) ([]byte, error) {
+	for _, v := range n.Items {
+		buf = binary.LittleEndian.AppendUint32(buf, v)
+	}
+	return buf, nil
+}
+
+func (n *nestedDelegatedDyn) UnmarshalSSZDyn(_ sszutils.DynamicSpecs, buf []byte) error {
+	n.Items = make([]uint32, len(buf)/4)
+	for i := range n.Items {
+		n.Items[i] = binary.LittleEndian.Uint32(buf[i*4:])
+	}
+	return nil
+}
+
+func (n *nestedDelegatedDyn) HashTreeRootWithDyn(_ sszutils.DynamicSpecs, hh sszutils.HashWalker) error {
+	idx := hh.Index()
+	for _, v := range n.Items {
+		hh.AppendUint32(v)
+	}
+	hh.FillUpTo32()
+	hh.MerkleizeWithMixin(idx, uint64(len(n.Items)), 1024)
+	return nil
+}
+
+// NestedDelegatedDynContainer references the variable-size fully-delegated type
+// as a dynamic field, exercising the parser gate's ssz-static:"false" branch.
+type NestedDelegatedDynContainer struct {
+	A uint64
+	N nestedDelegatedDyn
+}
+
+var NestedDelegatedDynContainer_Payload = NestedDelegatedDynContainer{
+	A: 9,
+	N: nestedDelegatedDyn{Items: []uint32{1, 2, 3}},
 }

--- a/codegen/tests/types.go
+++ b/codegen/tests/types.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"encoding/binary"
 	"math/big"
 	"time"
 
@@ -1121,4 +1122,47 @@ var CoverageTypes4_Payload = CoverageTypes4{
 	},
 	Opt3: &covU16,
 	Opt4: &covB2,
+}
+
+// nestedDelegatedInner is a hand-written, fully-delegated SSZ type carrying a
+// structurally-invalid innard (a zero-length array). When it is referenced by a
+// generated type the parser must shallow-build it via its ssz-static annotation
+// and never traverse into Bad, which the spec validations would otherwise reject.
+type nestedDelegatedInner struct {
+	Bad   [0]uint64 // illegal Vector[uint64, 0] if ever traversed
+	Value uint32
+}
+
+var _ = sszutils.Annotate[nestedDelegatedInner](`ssz-static:"true"`)
+
+func (n *nestedDelegatedInner) SizeSSZDyn(_ sszutils.DynamicSpecs) int { return 4 }
+
+func (n *nestedDelegatedInner) MarshalSSZDyn(_ sszutils.DynamicSpecs, buf []byte) ([]byte, error) {
+	return binary.LittleEndian.AppendUint32(buf, n.Value), nil
+}
+
+func (n *nestedDelegatedInner) UnmarshalSSZDyn(_ sszutils.DynamicSpecs, buf []byte) error {
+	if len(buf) < 4 {
+		return sszutils.ErrUnexpectedEOF
+	}
+	n.Value = binary.LittleEndian.Uint32(buf)
+	return nil
+}
+
+func (n *nestedDelegatedInner) HashTreeRootWithDyn(_ sszutils.DynamicSpecs, hh sszutils.HashWalker) error {
+	hh.PutUint32(n.Value)
+	return nil
+}
+
+// NestedDelegatedContainer is generated and references the fully-delegated inner
+// type as a static field. Generating it succeeds only because the parser
+// shallow-builds the inner type instead of traversing its illegal innard.
+type NestedDelegatedContainer struct {
+	A uint64
+	N nestedDelegatedInner
+}
+
+var NestedDelegatedContainer_Payload = NestedDelegatedContainer{
+	A: 7,
+	N: nestedDelegatedInner{Value: 0x11223344},
 }

--- a/codegen/tests/types.go
+++ b/codegen/tests/types.go
@@ -386,6 +386,29 @@ type ZeroMaxList struct {
 
 var ZeroMaxList_Payload = ZeroMaxList{X: []uint64{1, 2, 3}}
 
+// ProgBitlistZeroTop reproduces the EIP-7916 progressive-bitlist HTR bug: a
+// bitlist whose highest data bits are zero leaves the top 256-bit chunk all-zero.
+// The progressive tree shape is defined by the chunk count (ceil(size/256)), so
+// the all-zero top chunk must NOT be dropped. The golden root in
+// TestCodegenProgressiveBitlistGolden is cross-checked against
+// ethereum/remerkleable and an independent raw-SHA256 implementation; the
+// reflection and codegen paths share the hasher, so only a golden (not a
+// differential) test catches a regression here.
+type ProgBitlistZeroTop struct {
+	X []byte `ssz-type:"progressive-bitlist" ssz-max:"2000"`
+}
+
+// progBitlistZeroTopBits builds a 257-bit bitlist with only bit 0 set, so bit 256
+// (the single data bit of the 2nd chunk) is zero and the top chunk is all-zero.
+func progBitlistZeroTopBits() []byte {
+	b := make([]byte, 257/8+1) // 33 bytes
+	b[0] = 0x01                // bit 0 set
+	b[257/8] |= 1 << (257 % 8) // termination bit at position 257
+	return b
+}
+
+var ProgBitlistZeroTop_Payload = ProgBitlistZeroTop{X: progBitlistZeroTopBits()}
+
 type ProgressiveTypes struct {
 	C1 struct {
 		F1 uint64      `ssz-index:"0"`

--- a/dynssz-gen/main.go
+++ b/dynssz-gen/main.go
@@ -559,6 +559,12 @@ func run(config *Config) error {
 // findAnnotateCall scans package AST for sszutils.Annotate[typeName]("...")
 // calls and returns the tag string literal, or "" if not found.
 func findAnnotateCall(pkg *packages.Package, typeName string) string {
+	// A type may be annotated from several places (a hand-written constraint plus
+	// a generated ssz-static declaration, possibly in different files), so collect
+	// every Annotate call for the type and merge them into one space-separated tag.
+	var tags []string
+	seen := map[string]struct{}{}
+
 	for _, file := range pkg.Syntax {
 		// Resolve which import alias (if any) maps to sszutils
 		sszutilsAlias := ""
@@ -582,12 +588,15 @@ func findAnnotateCall(pkg *packages.Package, typeName string) string {
 		for _, decl := range file.Decls {
 			tag := findAnnotateCallInDecl(decl, sszutilsAlias, typeName)
 			if tag != "" {
-				return tag
+				if _, ok := seen[tag]; !ok {
+					seen[tag] = struct{}{}
+					tags = append(tags, tag)
+				}
 			}
 		}
 	}
 
-	return ""
+	return strings.Join(tags, " ")
 }
 
 // findAnnotateCallInDecl checks a single declaration for an Annotate call.

--- a/dynssz-gen/main.go
+++ b/dynssz-gen/main.go
@@ -446,6 +446,17 @@ func run(config *Config) error {
 	typeCache := ssztypes.NewTypeCache(nil)
 	codeGen := codegen.NewCodeGenerator(typeCache)
 
+	// Let the parser read same-package types' annotations (incl. generated
+	// ssz-static declarations) so referenced fully-delegated types are
+	// shallow-built rather than traversed and validated.
+	codeGen.SetAnnotationResolver(func(t types.Type) string {
+		name := annotatedTypeName(t, pkg)
+		if name == "" {
+			return ""
+		}
+		return findAnnotateCall(pkg, name)
+	})
+
 	if config.PackageName != "" {
 		codeGen.SetPackageName(config.PackageName)
 	}
@@ -554,6 +565,24 @@ func run(config *Config) error {
 	}
 
 	return nil
+}
+
+// annotatedTypeName returns the bare name of a named type defined in pkg, or ""
+// if t is not a named type belonging to pkg. Pointers are unwrapped. Only
+// same-package types are resolved, since annotations are scanned within pkg.
+func annotatedTypeName(t types.Type, pkg *packages.Package) string {
+	if ptr, ok := t.(*types.Pointer); ok {
+		t = ptr.Elem()
+	}
+	named, ok := t.(*types.Named)
+	if !ok {
+		return ""
+	}
+	obj := named.Obj()
+	if obj.Pkg() == nil || obj.Pkg().Path() != pkg.PkgPath {
+		return ""
+	}
+	return obj.Name()
 }
 
 // findAnnotateCall scans package AST for sszutils.Annotate[typeName]("...")

--- a/dynssz-gen/main.go
+++ b/dynssz-gen/main.go
@@ -449,13 +449,7 @@ func run(config *Config) error {
 	// Let the parser read same-package types' annotations (incl. generated
 	// ssz-static declarations) so referenced fully-delegated types are
 	// shallow-built rather than traversed and validated.
-	codeGen.SetAnnotationResolver(func(t types.Type) string {
-		name := annotatedTypeName(t, pkg)
-		if name == "" {
-			return ""
-		}
-		return findAnnotateCall(pkg, name)
-	})
+	codeGen.SetAnnotationResolver(annotationResolver(pkg))
 
 	if config.PackageName != "" {
 		codeGen.SetPackageName(config.PackageName)
@@ -565,6 +559,20 @@ func run(config *Config) error {
 	}
 
 	return nil
+}
+
+// annotationResolver returns a resolver that maps a go/types type to the merged
+// ssz annotation tag registered for it in pkg (or "" when the type is not a
+// named, same-package type). The code generator's parser uses it to read a
+// referenced type's ssz-static declaration.
+func annotationResolver(pkg *packages.Package) func(types.Type) string {
+	return func(t types.Type) string {
+		name := annotatedTypeName(t, pkg)
+		if name == "" {
+			return ""
+		}
+		return findAnnotateCall(pkg, name)
+	}
 }
 
 // annotatedTypeName returns the bare name of a named type defined in pkg, or ""

--- a/dynssz-gen/main_test.go
+++ b/dynssz-gen/main_test.go
@@ -480,9 +480,10 @@ func TestFindAnnotateCall_Found(t *testing.T) {
 		t.Fatalf("failed to load package: %v", err)
 	}
 
+	// The merged tag also carries the generated ssz-static declaration.
 	tag := findAnnotateCall(pkgs[0], "AnnotatedList")
-	if tag != `ssz-max:"20"` {
-		t.Fatalf("expected tag ssz-max:\"20\", got: %q", tag)
+	if !strings.Contains(tag, `ssz-max:"20"`) {
+		t.Fatalf("expected tag to contain ssz-max:\"20\", got: %q", tag)
 	}
 }
 
@@ -497,8 +498,8 @@ func TestFindAnnotateCall_Found2(t *testing.T) {
 	}
 
 	tag := findAnnotateCall(pkgs[0], "AnnotatedList2")
-	if tag != `ssz-max:"10"` {
-		t.Fatalf("expected tag ssz-max:\"10\", got: %q", tag)
+	if !strings.Contains(tag, `ssz-max:"10"`) {
+		t.Fatalf("expected tag to contain ssz-max:\"10\", got: %q", tag)
 	}
 }
 

--- a/dynssz-gen/main_test.go
+++ b/dynssz-gen/main_test.go
@@ -10,6 +10,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"go/types"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -413,6 +414,90 @@ func TestRun_TypeSpecificOutputFile(t *testing.T) {
 
 	if _, err := os.Stat(outFile); os.IsNotExist(err) {
 		t.Fatal("expected output file to be created")
+	}
+}
+
+// TestAnnotationResolver covers annotatedTypeName / annotationResolver including
+// the edge cases the generator's gate inputs do not normally produce: a non-named
+// type and a named type from a different package both resolve to no annotation.
+func TestAnnotationResolver(t *testing.T) {
+	cfg := &packages.Config{Mode: packages.NeedName | packages.NeedTypes | packages.NeedTypesInfo | packages.NeedSyntax | packages.NeedImports}
+	pkgs, err := packages.Load(cfg,
+		"github.com/pk910/dynamic-ssz/codegen/tests",
+		"github.com/pk910/dynamic-ssz/sszutils")
+	if err != nil {
+		t.Fatalf("load packages: %v", err)
+	}
+	var testsPkg, otherPkg *packages.Package
+	for _, p := range pkgs {
+		switch p.PkgPath {
+		case "github.com/pk910/dynamic-ssz/codegen/tests":
+			testsPkg = p
+		case "github.com/pk910/dynamic-ssz/sszutils":
+			otherPkg = p
+		}
+	}
+	if testsPkg == nil || otherPkg == nil {
+		t.Fatal("expected both packages to load")
+	}
+
+	resolve := annotationResolver(testsPkg)
+
+	// Named, same-package, annotated type → its tag (also via a pointer).
+	inner := testsPkg.Types.Scope().Lookup("nestedDelegatedInner")
+	if inner == nil {
+		t.Fatal("nestedDelegatedInner not found in tests package")
+	}
+	if got := resolve(inner.Type()); !strings.Contains(got, "ssz-static") {
+		t.Errorf("same-package type: expected ssz-static tag, got %q", got)
+	}
+	if got := resolve(types.NewPointer(inner.Type())); !strings.Contains(got, "ssz-static") {
+		t.Errorf("pointer to type: expected ssz-static tag, got %q", got)
+	}
+
+	// Non-named type → no annotation.
+	if got := resolve(types.Typ[types.Uint64]); got != "" {
+		t.Errorf("non-named type: expected empty, got %q", got)
+	}
+
+	// Named type from another package → no annotation (resolved only within pkg).
+	other := otherPkg.Types.Scope().Lookup("HashWalker")
+	if other == nil {
+		t.Fatal("HashWalker not found in sszutils package")
+	}
+	if got := resolve(other.Type()); got != "" {
+		t.Errorf("cross-package type: expected empty, got %q", got)
+	}
+}
+
+// TestRun_ShallowBuildGate generates types that reference external, fully-delegated
+// types, exercising end-to-end: the annotation resolver (annotatedTypeName +
+// findAnnotateCall), the parser's shallow-build gate for both ssz-static:"true"
+// (static, runtime delegated size) and ssz-static:"false" (dynamic), and the
+// streaming offset header for an under-filled fixed vector of dynamic elements.
+func TestRun_ShallowBuildGate(t *testing.T) {
+	cases := []struct{ name, typeName string }{
+		{"StaticDelegated", "NestedDelegatedContainer"},
+		{"DynamicDelegated", "NestedDelegatedDynContainer"},
+		{"StreamingVector", "SimpleTypes2"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			outFile := filepath.Join(t.TempDir(), "gen_output.go")
+			config := Config{
+				PackagePath:   "github.com/pk910/dynamic-ssz/codegen/tests",
+				TypeNames:     tc.typeName,
+				OutputFile:    outFile,
+				PackageName:   "tests",
+				WithStreaming: true,
+			}
+			if err := run(&config); err != nil {
+				t.Fatalf("run(%s): %v", tc.typeName, err)
+			}
+			if _, err := os.Stat(outFile); os.IsNotExist(err) {
+				t.Fatalf("expected output file for %s", tc.typeName)
+			}
+		})
 	}
 }
 

--- a/hasher/common.go
+++ b/hasher/common.go
@@ -231,3 +231,60 @@ func ParseBitlistWithHasher(hw sszutils.HashWalker, buf []byte) ([]byte, uint64)
 		return bitlist, size
 	}
 }
+
+// ParseProgressiveBitlist decodes an SSZ-encoded bitlist for progressive
+// merkleization.
+//
+// It behaves like ParseBitlist (strips the termination bit and returns the
+// logical bit count), but instead of trimming trailing zero bytes it zero-pads
+// the content to exactly ceil(size/256) 256-bit chunks (ceil(size/256)*32
+// bytes).
+//
+// This distinction is essential: progressive merkleization derives the tree
+// structure from the chunk count (subtree_fill_progressive recurses by chunk
+// index), so an all-zero top chunk must be preserved. ParseBitlist's trimming is
+// harmless for regular bitlists because they pad to a fixed chunk limit, but it
+// would silently drop top chunks here and produce a wrong root.
+func ParseProgressiveBitlist(dst, buf []byte) ([]byte, uint64) {
+	dstStart := len(dst)
+	dst, size := ParseBitlist(dst, buf)
+
+	// Re-expand to the full chunk count. The content is always <= chunkBytes
+	// because ceil(size/256)*32 >= ceil(size/8).
+	chunkBytes := int((size+255)/256) * 32
+	if pad := chunkBytes - (len(dst) - dstStart); pad > 0 {
+		dst = sszutils.AppendZeroPadding(dst, pad)
+	}
+	return dst, size
+}
+
+// ParseProgressiveBitlistWithHasher decodes an SSZ-encoded bitlist for
+// progressive merkleization using the hasher's internal buffer to avoid
+// allocations. It returns the chunk-aligned, untrimmed bit data and the logical
+// bit count, same as ParseProgressiveBitlist.
+//
+// IMPORTANT: The returned bitlist slice references the hasher's internal buffer
+// spare capacity. It must be consumed (e.g. passed to AppendBytes32) before any
+// operation that may grow the buffer, as a reallocation would invalidate it.
+func ParseProgressiveBitlistWithHasher(hw sszutils.HashWalker, buf []byte) ([]byte, uint64) {
+	if h, ok := hw.(*Hasher); ok {
+		var size uint64
+		buflen := len(h.buf)
+		h.buf, size = ParseProgressiveBitlist(h.buf, buf)
+		bitlist := h.buf[buflen:]
+		// Restore h.buf to its pre-parse length so subsequent operations append
+		// after the original content (the returned slice still aliases the spare).
+		h.buf = h.buf[:buflen]
+		return bitlist, size
+	} else {
+		var size uint64
+		var bitlist []byte
+		hw.WithTemp(func(tmp []byte) []byte {
+			tmp, size = ParseProgressiveBitlist(tmp[:0], buf)
+			bitlist = tmp
+			// Restore tmp to full capacity
+			return tmp[:cap(tmp)]
+		})
+		return bitlist, size
+	}
+}

--- a/hasher/hasher.go
+++ b/hasher/hasher.go
@@ -339,7 +339,9 @@ func (h *Hasher) PutBitlist(bb []byte, maxSize uint64) {
 // using the progressive algorithm with a length mixin.
 func (h *Hasher) PutProgressiveBitlist(bb []byte) {
 	var size uint64
-	h.tmp, size = ParseBitlist(h.tmp[:0], bb)
+	// Use the progressive parse so the content keeps all-zero top chunks: the
+	// chunk count defines the progressive tree shape. See ParseProgressiveBitlist.
+	h.tmp, size = ParseProgressiveBitlist(h.tmp[:0], bb)
 	bitlist := h.tmp
 	h.tmp = h.tmp[:cap(h.tmp)]
 

--- a/hasher/progressive_bitlist_test.go
+++ b/hasher/progressive_bitlist_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the dynamic-ssz library.
+
+package hasher
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+// progBitlistZeroTop builds a 257-bit bitlist with only bit 0 set, so bit 256
+// (the single data bit of the 2nd chunk) is zero and the top 256-bit chunk is
+// all-zero. This is the EIP-7916 case that exposed the chunk-count bug.
+func progBitlistZeroTop() []byte {
+	b := make([]byte, 257/8+1) // 33 bytes
+	b[0] = 0x01                // bit 0 set
+	b[257/8] |= 1 << (257 % 8) // termination bit at position 257
+	return b
+}
+
+// TestParseProgressiveBitlistPadsTopChunk verifies that, unlike ParseBitlist,
+// ParseProgressiveBitlist preserves all-zero top chunks by zero-padding the
+// content to exactly ceil(size/256) 256-bit chunks. The progressive tree shape
+// is defined by the chunk count, so dropping an all-zero top chunk would corrupt
+// the root.
+func TestParseProgressiveBitlistPadsTopChunk(t *testing.T) {
+	bitlist := progBitlistZeroTop()
+
+	// ParseBitlist trims the all-zero top chunk down to a single byte.
+	trimmed, trimmedSize := ParseBitlist(nil, bitlist)
+	if trimmedSize != 257 {
+		t.Fatalf("ParseBitlist size: expected 257, got %d", trimmedSize)
+	}
+	if len(trimmed) != 1 {
+		t.Fatalf("ParseBitlist should trim trailing zero bytes, got %d bytes", len(trimmed))
+	}
+
+	// ParseProgressiveBitlist keeps the full chunk count: ceil(257/256) = 2 chunks.
+	padded, size := ParseProgressiveBitlist(nil, bitlist)
+	if size != 257 {
+		t.Fatalf("ParseProgressiveBitlist size: expected 257, got %d", size)
+	}
+	if len(padded) != 64 {
+		t.Fatalf("ParseProgressiveBitlist should pad to 2 chunks (64 bytes), got %d", len(padded))
+	}
+	if padded[0] != 0x01 {
+		t.Fatalf("expected bit 0 set, got %#x", padded[0])
+	}
+	for i := 1; i < 64; i++ {
+		if padded[i] != 0x00 {
+			t.Fatalf("expected zero padding at byte %d, got %#x", i, padded[i])
+		}
+	}
+}
+
+// TestParseProgressiveBitlistChunkCounts checks the padded length is always
+// ceil(size/256)*32 across a range of bit lengths and patterns.
+func TestParseProgressiveBitlistChunkCounts(t *testing.T) {
+	for _, size := range []uint64{0, 1, 7, 8, 255, 256, 257, 511, 512, 513, 1024, 2000} {
+		// build a bitlist with `size` data bits, all zero (worst case for trimming),
+		// plus the termination bit at position `size`.
+		byteLen := int(size)/8 + 1
+		b := make([]byte, byteLen)
+		b[int(size)/8] |= 1 << (size % 8)
+
+		padded, gotSize := ParseProgressiveBitlist(nil, b)
+		if gotSize != size {
+			t.Fatalf("size %d: got size %d", size, gotSize)
+		}
+		want := int((size+255)/256) * 32
+		if len(padded) != want {
+			t.Fatalf("size %d: expected %d padded bytes, got %d", size, want, len(padded))
+		}
+	}
+}
+
+// progBitlistSpecRoot is the EIP-7916 hash tree root for the 257-bit bitlist
+// (max 2000) with only bit 0 set. Cross-checked against ethereum/remerkleable
+// and an independent raw-SHA256 implementation.
+const progBitlistSpecRoot = "b039aa14167fdfd184839eb032e714ef89e0b42478e2db1ed1353759c200dda5"
+
+// TestPutProgressiveBitlistAllZeroTopChunk pins the hasher's progressive bitlist
+// root against the spec golden for the all-zero-top-chunk case. With a single
+// container field the container root equals the field root, so the hasher root
+// matches the struct-level golden.
+func TestPutProgressiveBitlistAllZeroTopChunk(t *testing.T) {
+	h := NewHasher()
+	h.PutProgressiveBitlist(progBitlistZeroTop())
+
+	got := hex.EncodeToString(h.buf)
+	if got != progBitlistSpecRoot {
+		t.Fatalf("progressive bitlist root mismatch:\n  got  %s\n  want %s", got, progBitlistSpecRoot)
+	}
+}
+
+// TestParseProgressiveBitlistWithHasher exercises both the *Hasher fast path and
+// the generic WithTemp fallback path.
+func TestParseProgressiveBitlistWithHasher(t *testing.T) {
+	bitlist := progBitlistZeroTop()
+
+	t.Run("HasherPath", func(t *testing.T) {
+		h := NewHasher()
+		result, size := ParseProgressiveBitlistWithHasher(h, bitlist)
+		if size != 257 {
+			t.Fatalf("expected size 257, got %d", size)
+		}
+		if len(result) != 64 {
+			t.Fatalf("expected 64 padded bytes, got %d", len(result))
+		}
+		if result[0] != 0x01 || !bytes.Equal(result[1:], make([]byte, 63)) {
+			t.Fatalf("unexpected content: %x", result)
+		}
+	})
+
+	t.Run("FallbackPath", func(t *testing.T) {
+		mock := &mockHashWalker{tmp: make([]byte, 64)}
+		result, size := ParseProgressiveBitlistWithHasher(mock, bitlist)
+		if size != 257 {
+			t.Fatalf("expected size 257, got %d", size)
+		}
+		if len(result) != 64 {
+			t.Fatalf("expected 64 padded bytes, got %d", len(result))
+		}
+		if result[0] != 0x01 || !bytes.Equal(result[1:], make([]byte, 63)) {
+			t.Fatalf("unexpected content: %x", result)
+		}
+	})
+}
+
+// TestPutProgressiveBitlistEmpty verifies the empty bitlist still produces a
+// valid root (no chunks, ceil(0/256)=0).
+func TestPutProgressiveBitlistEmpty(t *testing.T) {
+	padded, size := ParseProgressiveBitlist(nil, []byte{})
+	if size != 0 || len(padded) != 0 {
+		t.Fatalf("empty bitlist: expected size 0 and no content, got size %d len %d", size, len(padded))
+	}
+
+	h := NewHasher()
+	h.PutProgressiveBitlist([]byte{})
+	if len(h.buf) != 32 {
+		t.Fatalf("expected 32-byte root, got %d", len(h.buf))
+	}
+}

--- a/reflection/treeroot.go
+++ b/reflection/treeroot.go
@@ -799,7 +799,17 @@ func (ctx *ReflectionCtx) buildRootFromBitlist(sourceType *ssztypes.TypeDescript
 		maxSize = uint64(len(bytes) * 8)
 	}
 
-	bitlist, size := hasher.ParseBitlistWithHasher(hh, bytes)
+	isProgressive := sourceType.SszType == ssztypes.SszProgressiveBitlistType
+
+	// Progressive bitlists must keep all-zero top chunks (the chunk count defines
+	// the progressive tree shape), so parse without trailing-zero trimming.
+	var bitlist []byte
+	var size uint64
+	if isProgressive {
+		bitlist, size = hasher.ParseProgressiveBitlistWithHasher(hh, bytes)
+	} else {
+		bitlist, size = hasher.ParseBitlistWithHasher(hh, bytes)
+	}
 	if size > maxSize {
 		return sszutils.ErrBitlistLengthFn(size, maxSize)
 	}
@@ -807,7 +817,7 @@ func (ctx *ReflectionCtx) buildRootFromBitlist(sourceType *ssztypes.TypeDescript
 	// merkleize the content with mix in length
 	indx := hh.StartTree(sszutils.TreeTypeNone)
 	hh.AppendBytes32(bitlist)
-	if sourceType.SszType == ssztypes.SszProgressiveBitlistType {
+	if isProgressive {
 		hh.MerkleizeProgressiveWithMixin(indx, size)
 	} else {
 		hh.MerkleizeWithMixin(indx, size, sszutils.CalculateBitlistLimit(maxSize))

--- a/ssztypes/typecache.go
+++ b/ssztypes/typecache.go
@@ -281,8 +281,16 @@ func (tc *TypeCache) buildTypeDescriptor(runtimeType, schemaType reflect.Type, s
 			}
 
 			if staticStr, hasStatic := reflect.StructTag(tag).Lookup("ssz-static"); hasStatic {
-				isStatic := staticStr == "true"
-				staticAnnotation = &isStatic
+				switch staticStr {
+				case "true":
+					v := true
+					staticAnnotation = &v
+				case "false":
+					v := false
+					staticAnnotation = &v
+				default:
+					return nil, sszutils.NewSszErrorf(sszutils.ErrInvalidTag, "invalid ssz-static value %q for type %v (must be \"true\" or \"false\")", staticStr, t)
+				}
 			}
 
 			// ParseTags can't resolve dynamic expressions (no DynamicSpecs).
@@ -833,42 +841,37 @@ func fullyDelegatesSSZView(runtimeType reflect.Type) bool {
 		getDynamicViewHashRootCompatibility(runtimeType)
 }
 
-// noopDynamicSpecs resolves no spec values. It is used as a non-nil fallback when
-// a type cache has no specs so a static type's sizer (which may resolve spec
-// values) can run at build time without a nil dereference; unknown values then
-// fall back to their static defaults.
-type noopDynamicSpecs struct{}
-
-func (noopDynamicSpecs) ResolveSpecValue(string) (bool, uint64, error) { return false, 0, nil }
-
 // delegatedStaticSize returns the fixed SSZ byte size of a fully-delegated static
 // type by invoking the type's own sizer on a zero value. A static type's sizer
 // derives its result from constants and spec values only — never from field data
 // — so a zero value yields the correct size, and spec-dependent fixed sizes are
 // resolved against the cache's specs. View descriptors use the view sizer.
 func (tc *TypeCache) delegatedStaticSize(desc *TypeDescriptor, runtimeType reflect.Type) (uint32, error) {
-	specs := tc.specs
-	if specs == nil {
-		specs = noopDynamicSpecs{}
-	}
+	specs := tc.specs // never nil: NewTypeCache substitutes emptySpecs{}
 	zero := reflect.New(runtimeType).Interface()
+
+	// A sizer returns int; a negative or >uint32 value would wrap on conversion
+	// and corrupt downstream sizing/offset math, so validate the range.
+	validate := func(n int) (uint32, error) {
+		if n < 0 || int64(n) > math.MaxUint32 {
+			return 0, sszutils.NewSszErrorf(sszutils.ErrInvalidValueRange, "sizer for static type %v returned out-of-range size %d", runtimeType, n)
+		}
+		return uint32(n), nil
+	}
 
 	if desc.GoTypeFlags&GoTypeFlagIsView != 0 {
 		if sizer, ok := zero.(sszutils.DynamicViewSizer); ok && desc.CodegenInfo != nil {
 			if sizeFn := sizer.SizeSSZDynView(*desc.CodegenInfo); sizeFn != nil {
-				return uint32(sizeFn(specs)), nil
+				return validate(sizeFn(specs))
 			}
 		}
 		return 0, sszutils.NewSszErrorf(sszutils.ErrMissingInterface, "static view type %v does not provide a usable view sizer", runtimeType)
 	}
 
-	if sizer, ok := zero.(sszutils.DynamicSizer); ok {
-		return uint32(sizer.SizeSSZDyn(specs)), nil
-	}
-	if marshaler, ok := zero.(sszutils.FastsszMarshaler); ok {
-		return uint32(marshaler.SizeSSZ()), nil
-	}
-	return 0, sszutils.NewSszErrorf(sszutils.ErrMissingInterface, "static type %v does not implement a sizer", runtimeType)
+	// Non-view: fullyDelegatesSSZ (checked by the caller before reaching here)
+	// guarantees the DynamicSizer interface, so the assertion always holds.
+	sizer, _ := zero.(sszutils.DynamicSizer)
+	return validate(sizer.SizeSSZDyn(specs))
 }
 
 // buildTypeWrapperDescriptor builds a descriptor for TypeWrapper types with runtime/schema pairing.

--- a/ssztypes/typecache.go
+++ b/ssztypes/typecache.go
@@ -265,6 +265,11 @@ func (tc *TypeCache) buildTypeDescriptor(runtimeType, schemaType reflect.Type, s
 	// so we must not delegate to generated methods that have the annotation baked in.
 	hasExternalHints := len(sizeHints) > 0 || len(maxSizeHints) > 0
 
+	// staticAnnotation captures the type's own ssz-static:"true/false" declaration
+	// (true = fixed-size, false = variable-size). It gates the shallow-build path
+	// for fully-delegated types below.
+	var staticAnnotation *bool
+
 	// Check annotation registry for type-level metadata when no external hints provided
 	if len(sizeHints) == 0 && len(maxSizeHints) == 0 && len(typeHints) == 0 {
 		if tag, ok := sszutils.LookupAnnotation(t); ok {
@@ -273,6 +278,11 @@ func (tc *TypeCache) buildTypeDescriptor(runtimeType, schemaType reflect.Type, s
 			typeHints, sizeHints, maxSizeHints, parseErr = ParseTags(tag)
 			if parseErr != nil {
 				return nil, sszutils.NewSszErrorf(sszutils.ErrInvalidTag, "failed to parse annotation for type %v: %v", t, parseErr)
+			}
+
+			if staticStr, hasStatic := reflect.StructTag(tag).Lookup("ssz-static"); hasStatic {
+				isStatic := staticStr == "true"
+				staticAnnotation = &isStatic
 			}
 
 			// ParseTags can't resolve dynamic expressions (no DynamicSpecs).
@@ -452,6 +462,45 @@ func (tc *TypeCache) buildTypeDescriptor(runtimeType, schemaType reflect.Type, s
 	}
 
 	desc.SszType = sszType
+
+	// Fully-delegated types handle every SSZ operation through their own generated
+	// code, so the descriptor subtree below them is never consulted. When such a
+	// type also declares whether it is static (fixed-size) or dynamic via its own
+	// ssz-static annotation, build a shallow descriptor and skip recursing into —
+	// and validating — the subtree. For a static type the fixed byte size is read
+	// straight from the type's own sizer (the authoritative, spec-correct source)
+	// applied to a zero value. Field-level hints (hasExternalHints) opt out, since
+	// they override the type's own annotation and require inline processing. View
+	// descriptors qualify when they delegate through the dynamic view interface set.
+	if staticAnnotation != nil && !hasExternalHints {
+		var fullyDelegated bool
+		if desc.GoTypeFlags&GoTypeFlagIsView != 0 {
+			fullyDelegated = fullyDelegatesSSZView(runtimeType)
+		} else {
+			fullyDelegated = fullyDelegatesSSZ(runtimeType)
+		}
+		if fullyDelegated {
+			if *staticAnnotation {
+				size, err := tc.delegatedStaticSize(desc, runtimeType)
+				if err != nil {
+					return nil, err
+				}
+				desc.Size = size
+			} else {
+				desc.SszTypeFlags |= SszTypeFlagIsDynamic
+			}
+			tc.detectCompatFlags(desc, runtimeType, schemaType)
+			// Without traversal the descriptor cannot know whether the type uses
+			// spec-dependent sizes, so it must not fall back to the type's fastssz
+			// methods (which bake spec-independent values). The shallow path is
+			// only taken for types that delegate through the spec-aware dynamic
+			// (or dynamic view) interfaces, so suppress the fastssz family and let
+			// those handle every operation correctly.
+			desc.SszCompatFlags &^= SszCompatFlagFastSSZMarshaler | SszCompatFlagFastSSZHasher | SszCompatFlagHashTreeRootWith
+			desc.HashTreeRootWithMethod = nil
+			return desc, nil
+		}
+	}
 
 	// Check type compatibility and compute size
 	switch sszType {
@@ -642,6 +691,66 @@ func (tc *TypeCache) buildTypeDescriptor(runtimeType, schemaType reflect.Type, s
 		return nil, sszutils.NewSszErrorf(sszutils.ErrInvalidConstraint, "bit size tag is only allowed for bitvector or bitlist types, got %v", desc.SszType)
 	}
 
+	tc.detectCompatFlags(desc, runtimeType, schemaType)
+
+	// When field-level hints override the type's own annotation, don't delegate
+	// to the type's generated methods — they have the annotation's limits baked in.
+	// Process inline instead so the field-level hints are respected.
+	if hasExternalHints && desc.SszType != SszCustomType {
+		desc.SszCompatFlags &^= SszCompatFlagDynamicMarshaler |
+			SszCompatFlagDynamicUnmarshaler |
+			SszCompatFlagDynamicSizer |
+			SszCompatFlagDynamicHashRoot |
+			SszCompatFlagDynamicEncoder |
+			SszCompatFlagDynamicDecoder |
+			SszCompatFlagFastSSZMarshaler |
+			SszCompatFlagFastSSZHasher |
+			SszCompatFlagHashTreeRootWith
+	}
+
+	// Optional and optional-list reshape the encoding around the inner type
+	// (presence byte / List[T,1] framing). The inner type's own SSZ methods
+	// must not be invoked at this level — they would skip the framing and
+	// emit the inner value as if it were the canonical encoding.
+	if desc.SszType == SszOptionalType || desc.SszType == SszOptionalListType {
+		desc.SszCompatFlags &^= SszCompatFlagDynamicMarshaler |
+			SszCompatFlagDynamicUnmarshaler |
+			SszCompatFlagDynamicSizer |
+			SszCompatFlagDynamicHashRoot |
+			SszCompatFlagDynamicEncoder |
+			SszCompatFlagDynamicDecoder |
+			SszCompatFlagFastSSZMarshaler |
+			SszCompatFlagFastSSZHasher |
+			SszCompatFlagHashTreeRootWith
+	}
+
+	// Per the SSZ spec, containers (including progressive containers) must have
+	// at least one field. Reject a struct that would be encoded field-by-field
+	// with no SSZ-encodable (exported) fields. Types that delegate to their own
+	// SSZ methods (any compat flag set) are exempt: they do not use the plain
+	// container layout, so a zero-field struct shell is legitimate for them.
+	if desc.SszType == SszContainerType || desc.SszType == SszProgressiveContainerType {
+		if desc.SszCompatFlags == 0 && desc.ContainerDesc != nil && len(desc.ContainerDesc.Fields) == 0 {
+			return nil, sszutils.NewSszErrorf(sszutils.ErrInvalidConstraint, "container type %v has no SSZ fields, which is invalid per the SSZ spec", schemaType)
+		}
+	}
+
+	if desc.SszType == SszCustomType {
+		isCompatible := desc.SszCompatFlags&SszCompatFlagFastSSZMarshaler != 0 && desc.SszCompatFlags&SszCompatFlagFastSSZHasher != 0
+		// isCompatible = isCompatible || (desc.SszCompatFlags&SszCompatFlagDynamicMarshaler != 0 && desc.SszCompatFlags&SszCompatFlagDynamicUnmarshaler != 0 && desc.SszCompatFlags&SszCompatFlagDynamicSizer != 0 && desc.SszCompatFlags&SszCompatFlagDynamicHashRoot != 0)
+		if !isCompatible {
+			return nil, sszutils.NewSszError(sszutils.ErrMissingInterface, "custom ssz type requires fastssz marshaler, unmarshaler and hasher implementations")
+		}
+	}
+
+	return desc, nil
+}
+
+// detectCompatFlags records which SSZ delegation interfaces (fastssz, dynamic,
+// dynamic-view, and HashTreeRootWith) the type implements. The fastssz marshaler
+// and hasher are only flagged when the type does not carry a dynamic size/max,
+// since those use the static fastssz layout.
+func (tc *TypeCache) detectCompatFlags(desc *TypeDescriptor, runtimeType, schemaType reflect.Type) {
 	if desc.SszTypeFlags&SszTypeFlagHasDynamicSize == 0 && getFastsszConvertCompatibility(runtimeType) {
 		desc.SszCompatFlags |= SszCompatFlagFastSSZMarshaler
 	}
@@ -698,58 +807,68 @@ func (tc *TypeCache) buildTypeDescriptor(runtimeType, schemaType reflect.Type, s
 	}
 
 	desc.SszCompatFlags |= tc.getCompatFlag(runtimeType, schemaType)
+}
 
-	// When field-level hints override the type's own annotation, don't delegate
-	// to the type's generated methods — they have the annotation's limits baked in.
-	// Process inline instead so the field-level hints are respected.
-	if hasExternalHints && desc.SszType != SszCustomType {
-		desc.SszCompatFlags &^= SszCompatFlagDynamicMarshaler |
-			SszCompatFlagDynamicUnmarshaler |
-			SszCompatFlagDynamicSizer |
-			SszCompatFlagDynamicHashRoot |
-			SszCompatFlagDynamicEncoder |
-			SszCompatFlagDynamicDecoder |
-			SszCompatFlagFastSSZMarshaler |
-			SszCompatFlagFastSSZHasher |
-			SszCompatFlagHashTreeRootWith
+// fullyDelegatesSSZ reports whether the type implements the complete set of
+// dynamic SSZ operation interfaces (marshal, unmarshal, size, hash-tree-root).
+// When it does, every SSZ operation is handled by the type's own generated code
+// and the descriptor subtree below it is never consulted, so it does not need to
+// be built or validated — provided the type also declares its size via an
+// annotation (see the shallow-build path in buildTypeDescriptor).
+func fullyDelegatesSSZ(runtimeType reflect.Type) bool {
+	return (getDynamicMarshalerCompatibility(runtimeType) || getDynamicEncoderCompatibility(runtimeType)) &&
+		(getDynamicUnmarshalerCompatibility(runtimeType) || getDynamicDecoderCompatibility(runtimeType)) &&
+		getDynamicSizerCompatibility(runtimeType) &&
+		getDynamicHashRootCompatibility(runtimeType)
+}
+
+// fullyDelegatesSSZView is the view-descriptor counterpart of fullyDelegatesSSZ:
+// it reports whether the type implements the complete set of dynamic view SSZ
+// operation interfaces, in which case a view descriptor also delegates every
+// operation to the type's own code and its subtree need not be built.
+func fullyDelegatesSSZView(runtimeType reflect.Type) bool {
+	return (getDynamicViewMarshalerCompatibility(runtimeType) || getDynamicViewEncoderCompatibility(runtimeType)) &&
+		(getDynamicViewUnmarshalerCompatibility(runtimeType) || getDynamicViewDecoderCompatibility(runtimeType)) &&
+		getDynamicViewSizerCompatibility(runtimeType) &&
+		getDynamicViewHashRootCompatibility(runtimeType)
+}
+
+// noopDynamicSpecs resolves no spec values. It is used as a non-nil fallback when
+// a type cache has no specs so a static type's sizer (which may resolve spec
+// values) can run at build time without a nil dereference; unknown values then
+// fall back to their static defaults.
+type noopDynamicSpecs struct{}
+
+func (noopDynamicSpecs) ResolveSpecValue(string) (bool, uint64, error) { return false, 0, nil }
+
+// delegatedStaticSize returns the fixed SSZ byte size of a fully-delegated static
+// type by invoking the type's own sizer on a zero value. A static type's sizer
+// derives its result from constants and spec values only — never from field data
+// — so a zero value yields the correct size, and spec-dependent fixed sizes are
+// resolved against the cache's specs. View descriptors use the view sizer.
+func (tc *TypeCache) delegatedStaticSize(desc *TypeDescriptor, runtimeType reflect.Type) (uint32, error) {
+	specs := tc.specs
+	if specs == nil {
+		specs = noopDynamicSpecs{}
 	}
+	zero := reflect.New(runtimeType).Interface()
 
-	// Optional and optional-list reshape the encoding around the inner type
-	// (presence byte / List[T,1] framing). The inner type's own SSZ methods
-	// must not be invoked at this level — they would skip the framing and
-	// emit the inner value as if it were the canonical encoding.
-	if desc.SszType == SszOptionalType || desc.SszType == SszOptionalListType {
-		desc.SszCompatFlags &^= SszCompatFlagDynamicMarshaler |
-			SszCompatFlagDynamicUnmarshaler |
-			SszCompatFlagDynamicSizer |
-			SszCompatFlagDynamicHashRoot |
-			SszCompatFlagDynamicEncoder |
-			SszCompatFlagDynamicDecoder |
-			SszCompatFlagFastSSZMarshaler |
-			SszCompatFlagFastSSZHasher |
-			SszCompatFlagHashTreeRootWith
-	}
-
-	// Per the SSZ spec, containers (including progressive containers) must have
-	// at least one field. Reject a struct that would be encoded field-by-field
-	// with no SSZ-encodable (exported) fields. Types that delegate to their own
-	// SSZ methods (any compat flag set) are exempt: they do not use the plain
-	// container layout, so a zero-field struct shell is legitimate for them.
-	if desc.SszType == SszContainerType || desc.SszType == SszProgressiveContainerType {
-		if desc.SszCompatFlags == 0 && desc.ContainerDesc != nil && len(desc.ContainerDesc.Fields) == 0 {
-			return nil, sszutils.NewSszErrorf(sszutils.ErrInvalidConstraint, "container type %v has no SSZ fields, which is invalid per the SSZ spec", schemaType)
+	if desc.GoTypeFlags&GoTypeFlagIsView != 0 {
+		if sizer, ok := zero.(sszutils.DynamicViewSizer); ok && desc.CodegenInfo != nil {
+			if sizeFn := sizer.SizeSSZDynView(*desc.CodegenInfo); sizeFn != nil {
+				return uint32(sizeFn(specs)), nil
+			}
 		}
+		return 0, sszutils.NewSszErrorf(sszutils.ErrMissingInterface, "static view type %v does not provide a usable view sizer", runtimeType)
 	}
 
-	if desc.SszType == SszCustomType {
-		isCompatible := desc.SszCompatFlags&SszCompatFlagFastSSZMarshaler != 0 && desc.SszCompatFlags&SszCompatFlagFastSSZHasher != 0
-		// isCompatible = isCompatible || (desc.SszCompatFlags&SszCompatFlagDynamicMarshaler != 0 && desc.SszCompatFlags&SszCompatFlagDynamicUnmarshaler != 0 && desc.SszCompatFlags&SszCompatFlagDynamicSizer != 0 && desc.SszCompatFlags&SszCompatFlagDynamicHashRoot != 0)
-		if !isCompatible {
-			return nil, sszutils.NewSszError(sszutils.ErrMissingInterface, "custom ssz type requires fastssz marshaler, unmarshaler and hasher implementations")
-		}
+	if sizer, ok := zero.(sszutils.DynamicSizer); ok {
+		return uint32(sizer.SizeSSZDyn(specs)), nil
 	}
-
-	return desc, nil
+	if marshaler, ok := zero.(sszutils.FastsszMarshaler); ok {
+		return uint32(marshaler.SizeSSZ()), nil
+	}
+	return 0, sszutils.NewSszErrorf(sszutils.ErrMissingInterface, "static type %v does not implement a sizer", runtimeType)
 }
 
 // buildTypeWrapperDescriptor builds a descriptor for TypeWrapper types with runtime/schema pairing.

--- a/ssztypes/typecache_test.go
+++ b/ssztypes/typecache_test.go
@@ -985,12 +985,36 @@ type delegatedViewSchema struct {
 	Bad struct{}
 }
 
+// delegatedBadStatic carries an invalid ssz-static value; delegatedNegSize's
+// sizer returns an out-of-range size. Both must be rejected.
+type delegatedBadStatic struct{ delegationMethods }
+type delegatedNegSize struct{ delegationOps }
+
+func (delegatedNegSize) SizeSSZDyn(_ sszutils.DynamicSpecs) int { return -1 }
+
+// viewNilSizerMethods fully delegates the view interfaces but its view sizer
+// yields no size function, so a static view descriptor cannot resolve its size.
+type viewNilSizerMethods struct{ viewDelegationMethods }
+
+func (viewNilSizerMethods) SizeSSZDynView(any) func(sszutils.DynamicSpecs) int { return nil }
+
+type delegatedViewNilRuntime struct {
+	viewNilSizerMethods
+	Bad struct{}
+}
+type delegatedViewNilSchema struct {
+	Bad struct{}
+}
+
 var (
 	_ = sszutils.Annotate[delegatedFixedSize](`ssz-static:"true"`)
 	_ = sszutils.Annotate[delegatedVarSize](`ssz-static:"false"`)
 	_ = sszutils.Annotate[delegatedSpecStatic](`ssz-static:"true"`)
 	_ = sszutils.Annotate[partiallyDelegated](`ssz-static:"true"`)
 	_ = sszutils.Annotate[delegatedViewSchema](`ssz-static:"true"`)
+	_ = sszutils.Annotate[delegatedViewNilSchema](`ssz-static:"true"`)
+	_ = sszutils.Annotate[delegatedBadStatic](`ssz-static:"maybe"`)
+	_ = sszutils.Annotate[delegatedNegSize](`ssz-static:"true"`)
 )
 
 // A fully-delegated type that declares ssz-static must build a shallow descriptor:
@@ -1069,6 +1093,20 @@ func TestTypeCache_DelegatedShallowBuild(t *testing.T) {
 		}
 	})
 
+	t.Run("InvalidStaticValueRejected", func(t *testing.T) {
+		_, err := cache.GetTypeDescriptor(reflect.TypeOf(delegatedBadStatic{}), nil, nil, nil)
+		if err == nil || !strings.Contains(err.Error(), "invalid ssz-static value") {
+			t.Fatalf("expected invalid ssz-static rejection, got: %v", err)
+		}
+	})
+
+	t.Run("OutOfRangeSizerRejected", func(t *testing.T) {
+		_, err := cache.GetTypeDescriptor(reflect.TypeOf(delegatedNegSize{}), nil, nil, nil)
+		if err == nil || !strings.Contains(err.Error(), "out-of-range size") {
+			t.Fatalf("expected out-of-range sizer rejection, got: %v", err)
+		}
+	})
+
 	t.Run("PartialDelegationRecurses", func(t *testing.T) {
 		// Only DynamicMarshaler is implemented, so the type is not fully delegated
 		// and the gate stays off despite the annotation.
@@ -1104,6 +1142,19 @@ func TestTypeCache_DelegatedShallowBuild(t *testing.T) {
 		}
 		if desc.SszCompatFlags&SszCompatFlagDynamicViewMarshaler == 0 {
 			t.Error("expected view delegation compat flags to be set")
+		}
+	})
+
+	t.Run("ViewSizerUnusable", func(t *testing.T) {
+		// A static view type whose view sizer yields no size function cannot have
+		// its size resolved, so the shallow build must fail.
+		_, err := cache.GetTypeDescriptorWithSchema(
+			reflect.TypeOf(delegatedViewNilRuntime{}),
+			reflect.TypeOf(delegatedViewNilSchema{}),
+			nil, nil, nil,
+		)
+		if err == nil || !strings.Contains(err.Error(), "does not provide a usable view sizer") {
+			t.Fatalf("expected unusable view sizer error, got: %v", err)
 		}
 	})
 }

--- a/ssztypes/typecache_test.go
+++ b/ssztypes/typecache_test.go
@@ -904,6 +904,210 @@ func TestTypeCache_ZeroFieldContainerRejected(t *testing.T) {
 	}
 }
 
+// delegationMethods implements the full dynamic SSZ operation set; embedding it
+// makes a type fully delegated. The bodies are inert — only the method set matters.
+// delegationOps implements the dynamic marshal/unmarshal/hash-root operations.
+type delegationOps struct{}
+
+func (delegationOps) MarshalSSZDyn(_ sszutils.DynamicSpecs, buf []byte) ([]byte, error) {
+	return buf, nil
+}
+func (delegationOps) UnmarshalSSZDyn(_ sszutils.DynamicSpecs, _ []byte) error { return nil }
+func (delegationOps) HashTreeRootWithDyn(_ sszutils.DynamicSpecs, _ sszutils.HashWalker) error {
+	return nil
+}
+
+// delegationMethods adds a constant-size sizer, making a type fully delegated.
+type delegationMethods struct{ delegationOps }
+
+func (delegationMethods) SizeSSZDyn(_ sszutils.DynamicSpecs) int { return 32 }
+
+// Each fixture carries a structurally-invalid innard (an empty struct field) that
+// would be rejected if the typecache recursed into it.
+type delegatedFixedSize struct {
+	delegationMethods
+	Bad struct{}
+}
+type delegatedVarSize struct {
+	delegationMethods
+	Bad struct{}
+}
+type delegatedNoAnnotation struct {
+	delegationMethods
+	Value uint64
+}
+
+// delegatedSpecStatic is a static type whose fixed size depends on a spec value,
+// proving the size is taken from the sizer (resolved against the cache specs),
+// not from the annotation.
+type delegatedSpecStatic struct {
+	delegationOps
+	Bad struct{}
+}
+
+func (delegatedSpecStatic) SizeSSZDyn(ds sszutils.DynamicSpecs) int {
+	n, _ := sszutils.ResolveSpecValueWithDefault(ds, "STATIC_SIZE", 16)
+	return int(n)
+}
+
+type partiallyDelegated struct {
+	Value uint64
+}
+
+func (p *partiallyDelegated) MarshalSSZDyn(_ sszutils.DynamicSpecs, buf []byte) ([]byte, error) {
+	return buf, nil
+}
+
+// viewDelegationMethods implements the full dynamic view SSZ operation set; the
+// view sizer returns a constant so a static view's size can be read at build time.
+type viewDelegationMethods struct{}
+
+func (viewDelegationMethods) MarshalSSZDynView(any) func(sszutils.DynamicSpecs, []byte) ([]byte, error) {
+	return nil
+}
+func (viewDelegationMethods) UnmarshalSSZDynView(any) func(sszutils.DynamicSpecs, []byte) error {
+	return nil
+}
+func (viewDelegationMethods) SizeSSZDynView(any) func(sszutils.DynamicSpecs) int {
+	return func(sszutils.DynamicSpecs) int { return 32 }
+}
+func (viewDelegationMethods) HashTreeRootWithDynView(any) func(sszutils.DynamicSpecs, sszutils.HashWalker) error {
+	return nil
+}
+
+// delegatedViewRuntime carries the view methods; delegatedViewSchema carries the
+// annotation (the schema type defines the SSZ layout for a view descriptor).
+type delegatedViewRuntime struct {
+	viewDelegationMethods
+	Bad struct{}
+}
+type delegatedViewSchema struct {
+	Bad struct{}
+}
+
+var (
+	_ = sszutils.Annotate[delegatedFixedSize](`ssz-static:"true"`)
+	_ = sszutils.Annotate[delegatedVarSize](`ssz-static:"false"`)
+	_ = sszutils.Annotate[delegatedSpecStatic](`ssz-static:"true"`)
+	_ = sszutils.Annotate[partiallyDelegated](`ssz-static:"true"`)
+	_ = sszutils.Annotate[delegatedViewSchema](`ssz-static:"true"`)
+)
+
+// A fully-delegated type that declares ssz-static must build a shallow descriptor:
+// no subtree recursion (so a structurally-invalid innard is never reached) and
+// size-ness from the annotation, with the fixed size read from the type's sizer.
+func TestTypeCache_DelegatedShallowBuild(t *testing.T) {
+	cache := NewTypeCache(&dummyDynamicSpecs{})
+
+	t.Run("StaticSizeFromSizer", func(t *testing.T) {
+		desc, err := cache.GetTypeDescriptor(reflect.TypeOf(delegatedFixedSize{}), nil, nil, nil)
+		if err != nil {
+			t.Fatalf("expected shallow build, got error: %v", err)
+		}
+		if desc.ContainerDesc != nil {
+			t.Error("expected shallow descriptor (nil ContainerDesc), subtree was built")
+		}
+		// 32 comes from delegationMethods.SizeSSZDyn, called on a zero value.
+		if desc.Size != 32 || desc.SszTypeFlags&SszTypeFlagIsDynamic != 0 {
+			t.Errorf("expected fixed Size 32 from sizer, got Size=%d dynamic=%v", desc.Size, desc.SszTypeFlags&SszTypeFlagIsDynamic != 0)
+		}
+		if desc.SszCompatFlags&SszCompatFlagDynamicMarshaler == 0 {
+			t.Error("expected delegation compat flags to be set on the shallow descriptor")
+		}
+	})
+
+	t.Run("SpecDependentStaticSize", func(t *testing.T) {
+		// The static size depends on a spec value resolved by the sizer.
+		specCache := NewTypeCache(&dummyDynamicSpecs{specValues: map[string]uint64{"STATIC_SIZE": 40}})
+		desc, err := specCache.GetTypeDescriptor(reflect.TypeOf(delegatedSpecStatic{}), nil, nil, nil)
+		if err != nil {
+			t.Fatalf("expected shallow build, got error: %v", err)
+		}
+		if desc.ContainerDesc != nil {
+			t.Error("expected shallow descriptor")
+		}
+		if desc.Size != 40 {
+			t.Errorf("expected spec-resolved Size 40, got %d", desc.Size)
+		}
+	})
+
+	t.Run("StaticSizeNilSpecsFallsBack", func(t *testing.T) {
+		// With no specs the sizer must still run (non-nil fallback) and return the
+		// static default rather than panicking.
+		nilCache := NewTypeCache(nil)
+		desc, err := nilCache.GetTypeDescriptor(reflect.TypeOf(delegatedSpecStatic{}), nil, nil, nil)
+		if err != nil {
+			t.Fatalf("expected shallow build with nil specs, got error: %v", err)
+		}
+		if desc.Size != 16 {
+			t.Errorf("expected default Size 16 with nil specs, got %d", desc.Size)
+		}
+	})
+
+	t.Run("VariableSize", func(t *testing.T) {
+		desc, err := cache.GetTypeDescriptor(reflect.TypeOf(delegatedVarSize{}), nil, nil, nil)
+		if err != nil {
+			t.Fatalf("expected shallow build, got error: %v", err)
+		}
+		if desc.ContainerDesc != nil {
+			t.Error("expected shallow descriptor, subtree was built")
+		}
+		if desc.SszTypeFlags&SszTypeFlagIsDynamic == 0 {
+			t.Error(`expected IsDynamic for ssz-static:"false"`)
+		}
+	})
+
+	t.Run("NoAnnotationRecurses", func(t *testing.T) {
+		// Without a size annotation the gate is off: a fully-delegated type still
+		// recurses (opt-in), so a valid innard yields a full descriptor.
+		desc, err := cache.GetTypeDescriptor(reflect.TypeOf(delegatedNoAnnotation{}), nil, nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if desc.ContainerDesc == nil {
+			t.Error("expected full descriptor (recursion) when no size annotation is present")
+		}
+	})
+
+	t.Run("PartialDelegationRecurses", func(t *testing.T) {
+		// Only DynamicMarshaler is implemented, so the type is not fully delegated
+		// and the gate stays off despite the annotation.
+		desc, err := cache.GetTypeDescriptor(reflect.TypeOf(partiallyDelegated{}), nil, nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if desc.ContainerDesc == nil {
+			t.Error("expected full descriptor (recursion) for a partially-delegated type")
+		}
+	})
+
+	t.Run("ViewFullyDelegated", func(t *testing.T) {
+		// A view descriptor (runtime != schema) that delegates through the full
+		// dynamic view interface set, with a size annotation on the schema type,
+		// must also build shallow.
+		desc, err := cache.GetTypeDescriptorWithSchema(
+			reflect.TypeOf(delegatedViewRuntime{}),
+			reflect.TypeOf(delegatedViewSchema{}),
+			nil, nil, nil,
+		)
+		if err != nil {
+			t.Fatalf("expected shallow view build, got error: %v", err)
+		}
+		if desc.ContainerDesc != nil {
+			t.Error("expected shallow view descriptor (nil ContainerDesc)")
+		}
+		if desc.GoTypeFlags&GoTypeFlagIsView == 0 {
+			t.Error("expected view flag to be set")
+		}
+		if desc.Size != 32 {
+			t.Errorf("expected fixed Size 32, got %d", desc.Size)
+		}
+		if desc.SszCompatFlags&SszCompatFlagDynamicViewMarshaler == 0 {
+			t.Error("expected view delegation compat flags to be set")
+		}
+	})
+}
+
 // Test max hint expressions using dynssz-max tag
 func TestTypeCache_MaxHintExpressions(t *testing.T) {
 	// Create DynSsz with spec value resolver

--- a/sszutils/annotate.go
+++ b/sszutils/annotate.go
@@ -32,6 +32,16 @@ func Annotate[T any](tag string) bool {
 		t = t.Elem()
 	}
 
+	// Multiple Annotate calls for the same type (e.g. a hand-written constraint
+	// annotation plus a generated ssz-static declaration) are merged into a
+	// single space-separated tag rather than overwriting one another. Calls run
+	// at package-init time, so the load-then-store is not racy in practice.
+	if existing, ok := typeAnnotations.Load(t); ok {
+		if existingTag, _ := existing.(string); existingTag != "" && existingTag != tag {
+			tag = existingTag + " " + tag
+		}
+	}
+
 	typeAnnotations.Store(t, tag)
 
 	return true // allows use in var _ = Annotate[T](...)

--- a/sszutils/annotate.go
+++ b/sszutils/annotate.go
@@ -34,11 +34,14 @@ func Annotate[T any](tag string) bool {
 
 	// Multiple Annotate calls for the same type (e.g. a hand-written constraint
 	// annotation plus a generated ssz-static declaration) are merged into a
-	// single space-separated tag rather than overwriting one another. Calls run
-	// at package-init time, so the load-then-store is not racy in practice.
+	// single space-separated tag rather than overwriting one another. The new tag
+	// is prepended so that for a duplicated key the most recent registration wins
+	// (reflect.StructTag.Lookup returns the first occurrence), preserving the
+	// previous last-write-wins behavior. Calls run at package-init time, so the
+	// load-then-store is not racy in practice.
 	if existing, ok := typeAnnotations.Load(t); ok {
 		if existingTag, _ := existing.(string); existingTag != "" && existingTag != tag {
-			tag = existingTag + " " + tag
+			tag = tag + " " + existingTag
 		}
 	}
 

--- a/sszutils/annotate_test.go
+++ b/sszutils/annotate_test.go
@@ -116,6 +116,20 @@ func TestAnnotate_Merge(t *testing.T) {
 	}
 }
 
+func TestAnnotate_DuplicateKeyLastWins(t *testing.T) {
+	type dupType []uint32
+
+	// For a duplicated key the most recent registration must win (the new tag is
+	// prepended, and StructTag.Lookup returns the first occurrence).
+	Annotate[dupType](`ssz-max:"10"`)
+	Annotate[dupType](`ssz-max:"20"`)
+
+	tag, _ := LookupAnnotation(reflect.TypeFor[dupType]())
+	if v, _ := reflect.StructTag(tag).Lookup("ssz-max"); v != "20" {
+		t.Fatalf("expected last registration to win (20), got %q (full tag %q)", v, tag)
+	}
+}
+
 // LookupAnnotation must return ("", false) for a nil type instead of panicking.
 func TestLookupAnnotation_Nil(t *testing.T) {
 	defer func() {

--- a/sszutils/annotate_test.go
+++ b/sszutils/annotate_test.go
@@ -6,6 +6,7 @@ package sszutils
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -91,19 +92,27 @@ func TestLookupAnnotation_NonStringValue(t *testing.T) {
 	typeAnnotations.Delete(reflect.TypeFor[int]())
 }
 
-func TestAnnotate_Overwrite(t *testing.T) {
-	type overwriteType []uint32
+func TestAnnotate_Merge(t *testing.T) {
+	type mergeType []uint32
 
-	Annotate[overwriteType](`ssz-max:"10"`)
-	Annotate[overwriteType](`ssz-max:"20"`)
+	// Annotations from different places (e.g. a hand-written constraint and a
+	// generated ssz-static declaration) are merged rather than overwriting.
+	Annotate[mergeType](`ssz-max:"20"`)
+	Annotate[mergeType](`ssz-static:"false"`)
 
-	tag, ok := LookupAnnotation(reflect.TypeFor[overwriteType]())
+	tag, ok := LookupAnnotation(reflect.TypeFor[mergeType]())
 	if !ok {
 		t.Fatal("expected annotation to be found")
 	}
+	if !strings.Contains(tag, `ssz-max:"20"`) || !strings.Contains(tag, `ssz-static:"false"`) {
+		t.Fatalf("expected merged tag to contain both annotations, got %q", tag)
+	}
 
-	if tag != `ssz-max:"20"` {
-		t.Fatalf("expected overwritten tag %q, got %q", `ssz-max:"20"`, tag)
+	// Re-registering an identical full tag must not change the annotation.
+	Annotate[mergeType](tag)
+	tag2, _ := LookupAnnotation(reflect.TypeFor[mergeType]())
+	if tag2 != tag {
+		t.Fatalf("re-registering the identical tag changed it: %q -> %q", tag, tag2)
 	}
 }
 

--- a/treeproof/wrapper.go
+++ b/treeproof/wrapper.go
@@ -217,7 +217,9 @@ func (w *Wrapper) PutBitlist(bb []byte, maxSize uint64) {
 // nodes from the data, and merkleizes them using the progressive tree algorithm
 // with a length mixin.
 func (w *Wrapper) PutProgressiveBitlist(bb []byte) {
-	b, size := hasher.ParseBitlist(w.tmp[:0], bb)
+	// Use the progressive parse so all-zero top chunks are preserved: the chunk
+	// count defines the progressive tree shape. See hasher.ParseProgressiveBitlist.
+	b, size := hasher.ParseProgressiveBitlist(w.tmp[:0], bb)
 	w.tmp = b
 
 	indx := w.Index()


### PR DESCRIPTION
# Intercept type-tree traversal for fully-delegated types

## Summary

Stop building and validating the `TypeDescriptor` subtree underneath any type that
already implements the full SSZ delegation interfaces. Recently-added structural
validations (vectors need length > 0, containers need ≥ 1 field, etc.) are correct
for types the library serializes itself, but they wrongly reject *delegated* types
whose internals are structurally irrelevant — the delegated type handles every SSZ
operation in its own (generated or hand-written) code, so its descriptor subtree is
never consulted.

The fix introduces an `ssz-static:"true|false"` annotation that declares whether a
fully-delegated type is fixed- or variable-size. When the reflection type cache or
the codegen parser encounters such a type, it builds a **shallow descriptor** from
that declaration and skips traversing — and validating — the subtree.

## Motivation

A type that implements `DynamicMarshaler`/`DynamicUnmarshaler`/`DynamicSizer`/
`DynamicHashRoot` (or the `DynamicView*` set) is a black box to the rest of the
library: every operation delegates to its own methods. But the descriptor builders
still recursed into its fields to compute size/dynamic-ness, and the new structural
validations would fail on internals such as a zero-length vector or an empty
container that the type never actually serializes. Such a type could no longer be
used as a field of a generated type, and code generation aborted.

We need a way to (a) stop recursing past a fully-delegated type while still (b)
knowing whether it is fixed- or variable-size for the parent's layout. The
`ssz-static` annotation supplies exactly that one bit; the concrete fixed size is
obtained at build time from the type's own sizer (reflection) or at run time via
delegation (codegen).

## What changed

### 1. `ssz-static` shallow-build gate

**Reflection (`ssztypes/typecache.go`)**
- `buildTypeDescriptor` parses `ssz-static` (validated to be exactly `"true"` or
  `"false"`, else `ErrInvalidTag`).
- When a type fully delegates (`fullyDelegatesSSZ` / `fullyDelegatesSSZView`) and
  carries the annotation, the build short-circuits: a static type's fixed size is
  read by invoking its own sizer on a zero value (`delegatedStaticSize`), a dynamic
  type is flagged `IsDynamic`. The subtree (`ContainerDesc`/`ElemDesc`) is left nil.
- The fastssz family of compat flags is suppressed on shallow descriptors so the
  spec-aware dynamic methods are used.
- Compat-flag detection was extracted into `detectCompatFlags` and reused.

**Codegen (`codegen/parser.go`)**
- Mirrors the reflection gate over `go/types`: `fullyDelegatesSSZ` + a parser
  `AnnotationResolver` that reads the referenced type's annotation.
- The gate fires only for **external** types — those *not* being generated in this
  run (`getCompatFlag == 0`). A type the generator is emitting is always traversed,
  whether it appears at the top level or as a field of another generated type. This
  is the correct distinction (external-vs-being-generated), not a top-level/nested one.
- Static delegated fields resolve their byte span at run time via
  `new(T).SizeSSZDyn(ds)` (`codegen/gen_common.go`), which the unmarshal path needs
  to slice the buffer correctly.
- `codegen/codegen.go` gains `SetAnnotationResolver`; `codegen/generate.go` wires it
  into the parser (data and view passes).

**Annotation emission & resolution (`dynssz-gen/main.go`)**
- The generator emits per-type (and per-view) `ssz-static` declarations and resolves
  same-package annotations for the parser via `annotationResolver` / `annotatedTypeName`.

**Annotation merging (`sszutils/annotate.go`)**
- Multiple `Annotate` calls for one type now **merge** into a single space-separated
  tag instead of overwriting, so a hand-written constraint and a generated
  `ssz-static` declaration coexist. The new tag is *prepended* so that for a
  duplicated key the most recent registration wins (`StructTag.Lookup` returns the
  first occurrence).

### 2. Streaming-encoder offset fix (`codegen/gen_encoder.go`)

Fixed a latent bug in the non-seekable offset header for under-filled fixed vectors
of dynamic elements: the header has one 4-byte entry per vector *limit* slot, not per
current element. Byte-identical for full vectors; correct when the vector is shorter
than its limit.

## Tests

- `ssztypes`: `TestTypeCache_DelegatedShallowBuild` — static / dynamic /
  spec-dependent / view shallow builds, invalid `ssz-static`, out-of-range sizer,
  unusable view sizer, and the non-delegated / partial-delegation recursion fallbacks.
- `codegen`: `TestParserShallowGate` — loads the real package and drives the gate via
  a custom resolver (invalid-value rejection and shallow build).
- `codegen/tests`: `TestCodegenNestedDelegated` — static + dynamic round-trips against
  fixtures carrying a structurally-illegal `[0]uint64` innard that is never traversed.
- `dynssz-gen`: `TestAnnotationResolver` (named / pointer / non-named / cross-package)
  and `TestRun_ShallowBuildGate` (end-to-end generation of delegated containers and a
  streaming vector).
- `sszutils`: `TestAnnotate_Merge`, `TestAnnotate_DuplicateKeyLastWins`.

Dead/unreachable code (a redundant nil-specs fallback, an unreachable fastssz sizer
branch) was removed rather than left uncovered.

## Compatibility

- Purely additive for existing types: a type without `ssz-static` recurses exactly as
  before, so generated output and roots are unchanged.
- The shallow-build gate only engages for types that fully delegate **and** declare
  `ssz-static`; the generator emits those declarations automatically.

## Verification

`go test ./...` (16 packages), `GOARCH=386` build/test, `-race` on the affected
packages, and `gofmt` all pass. Generated code under `codegen/tests` is regenerated
and committed.
