### PR TITLE
fix htr mismatch for progressive bitlists

### DIFF
--- a/codegen/gen_hashtreeroot.go
+++ b/codegen/gen_hashtreeroot.go
@@ -891,7 +891,13 @@ func (ctx *hashTreeRootContext) hashBitlist(desc *ssztypes.TypeDescriptor, varNa
 	if maxVar != "" || desc.SszType == ssztypes.SszProgressiveBitlistType {
 		sizeVar = "size"
 	}
-	ctx.appendCode(indent, "bitlist, %s := %s.ParseBitlistWithHasher(hh, %s[:])\n", sizeVar, hasherAlias, varName)
+	// Progressive bitlists must keep all-zero top chunks (the chunk count defines
+	// the progressive tree shape), so parse without trailing-zero trimming.
+	parseFn := "ParseBitlistWithHasher"
+	if desc.SszType == ssztypes.SszProgressiveBitlistType {
+		parseFn = "ParseProgressiveBitlistWithHasher"
+	}
+	ctx.appendCode(indent, "bitlist, %s := %s.%s(hh, %s[:])\n", sizeVar, hasherAlias, parseFn, varName)
 
 	if maxVar != "" {
 		ctx.appendCode(indent, "if size > %s {\n", maxVar)

--- a/codegen/tests/codegen_test.go
+++ b/codegen/tests/codegen_test.go
@@ -70,6 +70,17 @@ var testMatrix = []TestPayload{
 		Hash:    "0100000000000000020000000000000003000000000000000000000000000000",
 	},
 	{
+		// EIP-7916 progressive-bitlist with an all-zero top 256-bit chunk. The
+		// golden root is cross-checked against ethereum/remerkleable and an
+		// independent raw-SHA256 implementation. Reflection and codegen share the
+		// hasher, so this golden (not the differential check) is what guards the
+		// chunk-count regression. See ProgBitlistZeroTop in types.go.
+		Name:    "ProgBitlistZeroTop",
+		Payload: ProgBitlistZeroTop_Payload,
+		Specs:   map[string]any{},
+		Hash:    "b039aa14167fdfd184839eb032e714ef89e0b42478e2db1ed1353759c200dda5",
+	},
+	{
 		Name:    "ViewTypes_View1",
 		Payload: ViewTypes1_Payload,
 		View:    (*ViewTypes1_View1)(nil),

--- a/codegen/tests/gen_ssz.yaml
+++ b/codegen/tests/gen_ssz.yaml
@@ -55,6 +55,8 @@ types:
     output: gen_progressive.go
   - name: ZeroMaxList
     output: gen_progressive.go
+  - name: ProgBitlistZeroTop
+    output: gen_progressive.go
   - name: CustomTypes1
     output: gen_custom.go
   - name: CoverageTypes1

--- a/codegen/tests/types.go
+++ b/codegen/tests/types.go
@@ -386,6 +386,29 @@ type ZeroMaxList struct {
 
 var ZeroMaxList_Payload = ZeroMaxList{X: []uint64{1, 2, 3}}
 
+// ProgBitlistZeroTop reproduces the EIP-7916 progressive-bitlist HTR bug: a
+// bitlist whose highest data bits are zero leaves the top 256-bit chunk all-zero.
+// The progressive tree shape is defined by the chunk count (ceil(size/256)), so
+// the all-zero top chunk must NOT be dropped. The golden root in
+// TestCodegenProgressiveBitlistGolden is cross-checked against
+// ethereum/remerkleable and an independent raw-SHA256 implementation; the
+// reflection and codegen paths share the hasher, so only a golden (not a
+// differential) test catches a regression here.
+type ProgBitlistZeroTop struct {
+	X []byte `ssz-type:"progressive-bitlist" ssz-max:"2000"`
+}
+
+// progBitlistZeroTopBits builds a 257-bit bitlist with only bit 0 set, so bit 256
+// (the single data bit of the 2nd chunk) is zero and the top chunk is all-zero.
+func progBitlistZeroTopBits() []byte {
+	b := make([]byte, 257/8+1) // 33 bytes
+	b[0] = 0x01                // bit 0 set
+	b[257/8] |= 1 << (257 % 8) // termination bit at position 257
+	return b
+}
+
+var ProgBitlistZeroTop_Payload = ProgBitlistZeroTop{X: progBitlistZeroTopBits()}
+
 type ProgressiveTypes struct {
 	C1 struct {
 		F1 uint64      `ssz-index:"0"`

--- a/hasher/common.go
+++ b/hasher/common.go
@@ -231,3 +231,60 @@ func ParseBitlistWithHasher(hw sszutils.HashWalker, buf []byte) ([]byte, uint64)
 		return bitlist, size
 	}
 }
+
+// ParseProgressiveBitlist decodes an SSZ-encoded bitlist for progressive
+// merkleization.
+//
+// It behaves like ParseBitlist (strips the termination bit and returns the
+// logical bit count), but instead of trimming trailing zero bytes it zero-pads
+// the content to exactly ceil(size/256) 256-bit chunks (ceil(size/256)*32
+// bytes).
+//
+// This distinction is essential: progressive merkleization derives the tree
+// structure from the chunk count (subtree_fill_progressive recurses by chunk
+// index), so an all-zero top chunk must be preserved. ParseBitlist's trimming is
+// harmless for regular bitlists because they pad to a fixed chunk limit, but it
+// would silently drop top chunks here and produce a wrong root.
+func ParseProgressiveBitlist(dst, buf []byte) ([]byte, uint64) {
+	dstStart := len(dst)
+	dst, size := ParseBitlist(dst, buf)
+
+	// Re-expand to the full chunk count. The content is always <= chunkBytes
+	// because ceil(size/256)*32 >= ceil(size/8).
+	chunkBytes := int((size+255)/256) * 32
+	if pad := chunkBytes - (len(dst) - dstStart); pad > 0 {
+		dst = sszutils.AppendZeroPadding(dst, pad)
+	}
+	return dst, size
+}
+
+// ParseProgressiveBitlistWithHasher decodes an SSZ-encoded bitlist for
+// progressive merkleization using the hasher's internal buffer to avoid
+// allocations. It returns the chunk-aligned, untrimmed bit data and the logical
+// bit count, same as ParseProgressiveBitlist.
+//
+// IMPORTANT: The returned bitlist slice references the hasher's internal buffer
+// spare capacity. It must be consumed (e.g. passed to AppendBytes32) before any
+// operation that may grow the buffer, as a reallocation would invalidate it.
+func ParseProgressiveBitlistWithHasher(hw sszutils.HashWalker, buf []byte) ([]byte, uint64) {
+	if h, ok := hw.(*Hasher); ok {
+		var size uint64
+		buflen := len(h.buf)
+		h.buf, size = ParseProgressiveBitlist(h.buf, buf)
+		bitlist := h.buf[buflen:]
+		// Restore h.buf to its pre-parse length so subsequent operations append
+		// after the original content (the returned slice still aliases the spare).
+		h.buf = h.buf[:buflen]
+		return bitlist, size
+	} else {
+		var size uint64
+		var bitlist []byte
+		hw.WithTemp(func(tmp []byte) []byte {
+			tmp, size = ParseProgressiveBitlist(tmp[:0], buf)
+			bitlist = tmp
+			// Restore tmp to full capacity
+			return tmp[:cap(tmp)]
+		})
+		return bitlist, size
+	}
+}

--- a/hasher/hasher.go
+++ b/hasher/hasher.go
@@ -339,7 +339,9 @@ func (h *Hasher) PutBitlist(bb []byte, maxSize uint64) {
 // using the progressive algorithm with a length mixin.
 func (h *Hasher) PutProgressiveBitlist(bb []byte) {
 	var size uint64
-	h.tmp, size = ParseBitlist(h.tmp[:0], bb)
+	// Use the progressive parse so the content keeps all-zero top chunks: the
+	// chunk count defines the progressive tree shape. See ParseProgressiveBitlist.
+	h.tmp, size = ParseProgressiveBitlist(h.tmp[:0], bb)
 	bitlist := h.tmp
 	h.tmp = h.tmp[:cap(h.tmp)]
 

--- a/hasher/progressive_bitlist_test.go
+++ b/hasher/progressive_bitlist_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the dynamic-ssz library.
+
+package hasher
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+// progBitlistZeroTop builds a 257-bit bitlist with only bit 0 set, so bit 256
+// (the single data bit of the 2nd chunk) is zero and the top 256-bit chunk is
+// all-zero. This is the EIP-7916 case that exposed the chunk-count bug.
+func progBitlistZeroTop() []byte {
+	b := make([]byte, 257/8+1) // 33 bytes
+	b[0] = 0x01                // bit 0 set
+	b[257/8] |= 1 << (257 % 8) // termination bit at position 257
+	return b
+}
+
+// TestParseProgressiveBitlistPadsTopChunk verifies that, unlike ParseBitlist,
+// ParseProgressiveBitlist preserves all-zero top chunks by zero-padding the
+// content to exactly ceil(size/256) 256-bit chunks. The progressive tree shape
+// is defined by the chunk count, so dropping an all-zero top chunk would corrupt
+// the root.
+func TestParseProgressiveBitlistPadsTopChunk(t *testing.T) {
+	bitlist := progBitlistZeroTop()
+
+	// ParseBitlist trims the all-zero top chunk down to a single byte.
+	trimmed, trimmedSize := ParseBitlist(nil, bitlist)
+	if trimmedSize != 257 {
+		t.Fatalf("ParseBitlist size: expected 257, got %d", trimmedSize)
+	}
+	if len(trimmed) != 1 {
+		t.Fatalf("ParseBitlist should trim trailing zero bytes, got %d bytes", len(trimmed))
+	}
+
+	// ParseProgressiveBitlist keeps the full chunk count: ceil(257/256) = 2 chunks.
+	padded, size := ParseProgressiveBitlist(nil, bitlist)
+	if size != 257 {
+		t.Fatalf("ParseProgressiveBitlist size: expected 257, got %d", size)
+	}
+	if len(padded) != 64 {
+		t.Fatalf("ParseProgressiveBitlist should pad to 2 chunks (64 bytes), got %d", len(padded))
+	}
+	if padded[0] != 0x01 {
+		t.Fatalf("expected bit 0 set, got %#x", padded[0])
+	}
+	for i := 1; i < 64; i++ {
+		if padded[i] != 0x00 {
+			t.Fatalf("expected zero padding at byte %d, got %#x", i, padded[i])
+		}
+	}
+}
+
+// TestParseProgressiveBitlistChunkCounts checks the padded length is always
+// ceil(size/256)*32 across a range of bit lengths and patterns.
+func TestParseProgressiveBitlistChunkCounts(t *testing.T) {
+	for _, size := range []uint64{0, 1, 7, 8, 255, 256, 257, 511, 512, 513, 1024, 2000} {
+		// build a bitlist with `size` data bits, all zero (worst case for trimming),
+		// plus the termination bit at position `size`.
+		byteLen := int(size)/8 + 1
+		b := make([]byte, byteLen)
+		b[int(size)/8] |= 1 << (size % 8)
+
+		padded, gotSize := ParseProgressiveBitlist(nil, b)
+		if gotSize != size {
+			t.Fatalf("size %d: got size %d", size, gotSize)
+		}
+		want := int((size+255)/256) * 32
+		if len(padded) != want {
+			t.Fatalf("size %d: expected %d padded bytes, got %d", size, want, len(padded))
+		}
+	}
+}
+
+// progBitlistSpecRoot is the EIP-7916 hash tree root for the 257-bit bitlist
+// (max 2000) with only bit 0 set. Cross-checked against ethereum/remerkleable
+// and an independent raw-SHA256 implementation.
+const progBitlistSpecRoot = "b039aa14167fdfd184839eb032e714ef89e0b42478e2db1ed1353759c200dda5"
+
+// TestPutProgressiveBitlistAllZeroTopChunk pins the hasher's progressive bitlist
+// root against the spec golden for the all-zero-top-chunk case. With a single
+// container field the container root equals the field root, so the hasher root
+// matches the struct-level golden.
+func TestPutProgressiveBitlistAllZeroTopChunk(t *testing.T) {
+	h := NewHasher()
+	h.PutProgressiveBitlist(progBitlistZeroTop())
+
+	got := hex.EncodeToString(h.buf)
+	if got != progBitlistSpecRoot {
+		t.Fatalf("progressive bitlist root mismatch:\n  got  %s\n  want %s", got, progBitlistSpecRoot)
+	}
+}
+
+// TestParseProgressiveBitlistWithHasher exercises both the *Hasher fast path and
+// the generic WithTemp fallback path.
+func TestParseProgressiveBitlistWithHasher(t *testing.T) {
+	bitlist := progBitlistZeroTop()
+
+	t.Run("HasherPath", func(t *testing.T) {
+		h := NewHasher()
+		result, size := ParseProgressiveBitlistWithHasher(h, bitlist)
+		if size != 257 {
+			t.Fatalf("expected size 257, got %d", size)
+		}
+		if len(result) != 64 {
+			t.Fatalf("expected 64 padded bytes, got %d", len(result))
+		}
+		if result[0] != 0x01 || !bytes.Equal(result[1:], make([]byte, 63)) {
+			t.Fatalf("unexpected content: %x", result)
+		}
+	})
+
+	t.Run("FallbackPath", func(t *testing.T) {
+		mock := &mockHashWalker{tmp: make([]byte, 64)}
+		result, size := ParseProgressiveBitlistWithHasher(mock, bitlist)
+		if size != 257 {
+			t.Fatalf("expected size 257, got %d", size)
+		}
+		if len(result) != 64 {
+			t.Fatalf("expected 64 padded bytes, got %d", len(result))
+		}
+		if result[0] != 0x01 || !bytes.Equal(result[1:], make([]byte, 63)) {
+			t.Fatalf("unexpected content: %x", result)
+		}
+	})
+}
+
+// TestPutProgressiveBitlistEmpty verifies the empty bitlist still produces a
+// valid root (no chunks, ceil(0/256)=0).
+func TestPutProgressiveBitlistEmpty(t *testing.T) {
+	padded, size := ParseProgressiveBitlist(nil, []byte{})
+	if size != 0 || len(padded) != 0 {
+		t.Fatalf("empty bitlist: expected size 0 and no content, got size %d len %d", size, len(padded))
+	}
+
+	h := NewHasher()
+	h.PutProgressiveBitlist([]byte{})
+	if len(h.buf) != 32 {
+		t.Fatalf("expected 32-byte root, got %d", len(h.buf))
+	}
+}

--- a/reflection/treeroot.go
+++ b/reflection/treeroot.go
@@ -799,7 +799,17 @@ func (ctx *ReflectionCtx) buildRootFromBitlist(sourceType *ssztypes.TypeDescript
 		maxSize = uint64(len(bytes) * 8)
 	}
 
-	bitlist, size := hasher.ParseBitlistWithHasher(hh, bytes)
+	isProgressive := sourceType.SszType == ssztypes.SszProgressiveBitlistType
+
+	// Progressive bitlists must keep all-zero top chunks (the chunk count defines
+	// the progressive tree shape), so parse without trailing-zero trimming.
+	var bitlist []byte
+	var size uint64
+	if isProgressive {
+		bitlist, size = hasher.ParseProgressiveBitlistWithHasher(hh, bytes)
+	} else {
+		bitlist, size = hasher.ParseBitlistWithHasher(hh, bytes)
+	}
 	if size > maxSize {
 		return sszutils.ErrBitlistLengthFn(size, maxSize)
 	}
@@ -807,7 +817,7 @@ func (ctx *ReflectionCtx) buildRootFromBitlist(sourceType *ssztypes.TypeDescript
 	// merkleize the content with mix in length
 	indx := hh.StartTree(sszutils.TreeTypeNone)
 	hh.AppendBytes32(bitlist)
-	if sourceType.SszType == ssztypes.SszProgressiveBitlistType {
+	if isProgressive {
 		hh.MerkleizeProgressiveWithMixin(indx, size)
 	} else {
 		hh.MerkleizeWithMixin(indx, size, sszutils.CalculateBitlistLimit(maxSize))

--- a/treeproof/wrapper.go
+++ b/treeproof/wrapper.go
@@ -217,7 +217,9 @@ func (w *Wrapper) PutBitlist(bb []byte, maxSize uint64) {
 // nodes from the data, and merkleizes them using the progressive tree algorithm
 // with a length mixin.
 func (w *Wrapper) PutProgressiveBitlist(bb []byte) {
-	b, size := hasher.ParseBitlist(w.tmp[:0], bb)
+	// Use the progressive parse so all-zero top chunks are preserved: the chunk
+	// count defines the progressive tree shape. See hasher.ParseProgressiveBitlist.
+	b, size := hasher.ParseProgressiveBitlist(w.tmp[:0], bb)
 	w.tmp = b
 
 	indx := w.Index()


### PR DESCRIPTION
# Fix: progressive-bitlist HashTreeRoot is wrong when the top 256-bit chunk is all-zero

## Summary

A progressive bitlist (`ssz-type:"progressive-bitlist"`, EIP-7916) whose highest
data bits are zero — so its last 256-bit chunk(s) are all-zero — produced a hash
tree root that disagrees with the spec. This affected **both** the reflection and
codegen paths because they share the hasher, so both engines agreed on the same
**wrong** root (a differential test could not catch it).

Regular progressive *lists* were unaffected; only progressive *bitlists* were.

## Root cause

`hasher.ParseBitlist` strips the bitlist termination bit and then **trims trailing
zero bytes** from the content. For a **regular** bitlist this is harmless:
regular merkleization pads to a fixed chunk limit, so trimmed-then-padded equals
the full content.

For a **progressive** bitlist the chunk count *defines the tree structure* — the
progressive split (`subtree_fill_progressive`) recurses by chunk index. The chunk
count must be `ceil(bit_length / 256)`, not `ceil(len(trimmed_content) / 32)`.
When the top chunk is all-zero, trimming drops it, so the bitlist was merkleized
with fewer chunks than the spec requires, yielding a different progressive tree
and a wrong root.

### Reproducer

```go
ds := dynssz.NewDynSsz(nil)
type T struct { X []byte `ssz-type:"progressive-bitlist" ssz-max:"2000"` }

// 257-bit bitlist, only bit 0 set -> bit 256 (the single bit of the 2nd chunk)
// is zero, so the top chunk is all-zero.
b := make([]byte, 257/8+1) // 33 bytes
b[0] = 0x01                // bit 0 set
b[257/8] |= 1 << (257 % 8) // termination bit at position 257

root, _ := ds.HashTreeRoot(&T{X: b})
//   before fix: 70d184a55cfc22ca11620ecd90d571aa23ee73c77dc11b28495b252fda080bc8
//   after  fix: b039aa14167fdfd184839eb032e714ef89e0b42478e2db1ed1353759c200dda5
```

The fixed root is cross-checked against two independent references:
`ethereum/remerkleable` and a from-scratch raw-SHA256 implementation.

## Fix

Added a non-trimming parse helper in `hasher/common.go`:

- `ParseProgressiveBitlist(dst, buf)` — like `ParseBitlist`, but instead of
  trimming trailing zero bytes it zero-pads the content to exactly
  `ceil(size/256)` 256-bit chunks (`ceil(size/256)*32` bytes), preserving
  all-zero top chunks so the progressive tree shape is correct.
- `ParseProgressiveBitlistWithHasher(hw, buf)` — the no-alloc variant mirroring
  `ParseBitlistWithHasher` (Hasher fast path + generic `WithTemp` fallback).

Wired it into every progressive-bitlist HTR path so the chunk count is always
`ceil(bit_length/256)`:

- `hasher/hasher.go` — `PutProgressiveBitlist`
- `reflection/treeroot.go` — `buildRootFromBitlist`
- `codegen/gen_hashtreeroot.go` — generated code now emits
  `ParseProgressiveBitlistWithHasher` for progressive bitlists
- `treeproof/wrapper.go` — `PutProgressiveBitlist`

The regular-bitlist path (`PutBitlist` / non-progressive `buildRootFromBitlist`)
is unchanged — it keeps using the trimming parse, which is correct there because
it pads to a fixed chunk limit anyway.

## Tests

Because reflection and codegen share the hasher, only a **golden** test (not a
differential reflection-vs-codegen check) can catch a regression. The golden root
is asserted in exactly two places to avoid duplicating the same assertion across
every package:

- **`hasher/progressive_bitlist_test.go`** (new) — unit coverage where the logic
  lives: padding to `ceil(size/256)` chunks across many bit lengths, both
  `…WithHasher` branches (Hasher fast path and `WithTemp` fallback), the empty
  case, and the spec golden root (`b039aa14…`) via `PutProgressiveBitlist`.
- **`codegen/tests`** — added type `ProgBitlistZeroTop` (the all-zero-top-chunk
  reproducer) to the generated batch and the golden test matrix, pinning the
  codegen HTR path against the spec root. This is the requested regression guard
  in the codegen harness.

The new wiring lines in `reflection`, `treeproof`, and `codegen` are exercised by
those packages' existing progressive-bitlist tests rather than by re-pasting the
same golden assertion.

### Verification

- The golden tests were confirmed to **fail** with the padding disabled (old
  behavior) and **pass** with the fix.
- All new production lines have unit-test coverage (`hasher` parse helpers at
  100%); the only uncovered lines remaining in the touched functions are
  pre-existing (e.g. treeproof's `size > MaxInt` panic).
- Full suite passes, including `go test -race`.

## Files changed

| File | Change |
|---|---|
| `hasher/common.go` | new `ParseProgressiveBitlist` + `ParseProgressiveBitlistWithHasher` |
| `hasher/hasher.go` | `PutProgressiveBitlist` uses the progressive parse |
| `reflection/treeroot.go` | `buildRootFromBitlist` uses the progressive parse for progressive bitlists |
| `codegen/gen_hashtreeroot.go` | generate `ParseProgressiveBitlistWithHasher` for progressive bitlists |
| `treeproof/wrapper.go` | `PutProgressiveBitlist` uses the progressive parse |
| `hasher/progressive_bitlist_test.go` | new unit tests + spec golden |
| `codegen/tests/types.go`, `gen_ssz.yaml`, `codegen_test.go` | new `ProgBitlistZeroTop` golden case |

## Compatibility note

This changes the computed hash tree root for any progressive bitlist whose top
256-bit chunk(s) were all-zero. Roots produced by previous versions for such
values were incorrect; they now match the EIP-7916 spec. Roots for all other
values (including all progressive lists and regular bitlists) are unchanged.
