### PR TITLE
fix(treeproof): preserve leaf order when Append* interleaves with Put* or child scopes

### DIFF
--- a/treeproof/wrapper.go
+++ b/treeproof/wrapper.go
@@ -56,8 +56,10 @@ func (w *Wrapper) WithTemp(fn func(tmp []byte) []byte) {
 
 // Index returns the current number of nodes in the wrapper's node list. This
 // value is used as a checkpoint for subsequent Merkleize calls to identify
-// which nodes should be combined into a subtree.
+// which nodes should be combined into a subtree. Pending Append* bytes are
+// flushed first so the checkpoint separates them from the new scope.
 func (w *Wrapper) Index() int {
+	w.flushBuffer()
 	return len(w.nodes)
 }
 
@@ -68,8 +70,10 @@ func (w *Wrapper) CurrentIndex() int {
 
 // StartTree opens a new SSZ object scope. For the tree proof wrapper,
 // this is identical to Index() since the wrapper does not support
-// incremental hashing.
+// incremental hashing. Pending Append* bytes are flushed first so they
+// become leaves of the enclosing scope, not of the new child scope.
 func (w *Wrapper) StartTree(_ sszutils.TreeType) int {
+	w.flushBuffer()
 	return len(w.nodes)
 }
 
@@ -127,10 +131,7 @@ func (w *Wrapper) FillUpTo32() {
 // Merkle tree from all nodes added since the checkpoint index indx. The
 // resulting subtree replaces those nodes as a single tree node.
 func (w *Wrapper) Merkleize(indx int) {
-	if len(w.buf) != 0 {
-		w.appendBytesAsNodes(w.buf)
-		w.buf = w.buf[:0]
-	}
+	w.flushBuffer()
 	w.Commit(indx)
 }
 
@@ -144,10 +145,7 @@ func (w *Wrapper) MerkleizeWithMixin(indx int, num, limit uint64) {
 	if limit > math.MaxInt {
 		panic(fmt.Sprintf("MerkleizeWithMixin: limit %d exceeds max int", limit))
 	}
-	if len(w.buf) != 0 {
-		w.appendBytesAsNodes(w.buf)
-		w.buf = w.buf[:0]
-	}
+	w.flushBuffer()
 	w.CommitWithMixin(indx, int(num), int(limit))
 }
 
@@ -155,10 +153,7 @@ func (w *Wrapper) MerkleizeWithMixin(indx int, num, limit uint64) {
 // Merkle tree from nodes since indx using the progressive split pattern
 // (base sizes 1, 4, 16, 64...) instead of even binary splits.
 func (w *Wrapper) MerkleizeProgressive(indx int) {
-	if len(w.buf) != 0 {
-		w.appendBytesAsNodes(w.buf)
-		w.buf = w.buf[:0]
-	}
+	w.flushBuffer()
 	w.CommitProgressive(indx)
 }
 
@@ -169,10 +164,7 @@ func (w *Wrapper) MerkleizeProgressiveWithMixin(indx int, num uint64) {
 	if num > math.MaxInt {
 		panic(fmt.Sprintf("MerkleizeProgressiveWithMixin: num %d exceeds max int", num))
 	}
-	if len(w.buf) != 0 {
-		w.appendBytesAsNodes(w.buf)
-		w.buf = w.buf[:0]
-	}
+	w.flushBuffer()
 	w.CommitProgressiveWithMixin(indx, int(num))
 }
 
@@ -180,10 +172,7 @@ func (w *Wrapper) MerkleizeProgressiveWithMixin(indx int, num uint64) {
 // progressive Merkle tree from nodes since indx, and mixes in the active fields
 // bitvector as a right sibling. This is used for stable/progressive containers.
 func (w *Wrapper) MerkleizeProgressiveWithActiveFields(indx int, activeFields []byte) {
-	if len(w.buf) != 0 {
-		w.appendBytesAsNodes(w.buf)
-		w.buf = w.buf[:0]
-	}
+	w.flushBuffer()
 	w.CommitProgressiveWithActiveFields(indx, activeFields)
 }
 
@@ -229,6 +218,18 @@ func (w *Wrapper) PutProgressiveBitlist(bb []byte) {
 		panic(fmt.Sprintf("PutProgressiveBitlist: size %d exceeds max int", size))
 	}
 	w.CommitProgressiveWithMixin(indx, int(size))
+}
+
+// flushBuffer converts any bytes buffered by Append* calls into leaf nodes.
+// It must run before a node is added directly (Put*/Add*) and before a
+// checkpoint is captured (Index/StartTree), so buffered fields keep their
+// position in the leaf order — mirroring the single ordered byte buffer of
+// hasher.Hasher.
+func (w *Wrapper) flushBuffer() {
+	if len(w.buf) != 0 {
+		w.appendBytesAsNodes(w.buf)
+		w.buf = w.buf[:0]
+	}
 }
 
 func (w *Wrapper) appendBytesAsNodes(b []byte) {
@@ -336,10 +337,15 @@ func (w *Wrapper) AddUint8(i uint8) {
 }
 
 // AddNode appends a pre-constructed tree node to the wrapper's node list.
+// Bytes buffered by Append* calls are flushed to leaf nodes first so they
+// keep their position before this node.
 func (w *Wrapper) AddNode(n *Node) {
+	w.flushBuffer()
+
 	if w.nodes == nil {
 		w.nodes = []*Node{}
 	}
+
 	w.nodes = append(w.nodes, n)
 }
 

--- a/treeproof/wrapper_interleave_test.go
+++ b/treeproof/wrapper_interleave_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the dynamic-ssz library.
+
+package treeproof
+
+import (
+	"testing"
+
+	"github.com/pk910/dynamic-ssz/hasher"
+	"github.com/pk910/dynamic-ssz/sszutils"
+)
+
+// TestWrapperInterleavedAppendPut is a regression test for
+// https://github.com/pk910/dynamic-ssz/issues/191: the Wrapper must produce
+// the same root as hasher.Hasher when a container interleaves Append*-buffered
+// fields with Put* fields or child scopes. The Wrapper used to flush buffered
+// bytes only at Merkleize, reordering leaves relative to directly-added nodes.
+func TestWrapperInterleavedAppendPut(t *testing.T) {
+	fieldA := [32]byte{0x11}
+	fieldB := [32]byte{0x22}
+
+	tests := []struct {
+		name string
+		walk func(hh sszutils.HashWalker)
+	}{
+		{
+			// e.g. a uint256 root emitted via AppendBytes32 followed by a
+			// bytes32 field emitted via PutBytes (deneb.ExecutionPayloadHeader
+			// BaseFeePerGas -> BlockHash layout)
+			name: "append then put",
+			walk: func(hh sszutils.HashWalker) {
+				idx := hh.StartTree(sszutils.TreeTypeNone)
+				hh.AppendBytes32(fieldA[:])
+				hh.PutBytes(fieldB[:])
+				hh.Merkleize(idx)
+			},
+		},
+		{
+			name: "append then put uint64",
+			walk: func(hh sszutils.HashWalker) {
+				idx := hh.StartTree(sszutils.TreeTypeNone)
+				hh.AppendBytes32(fieldA[:])
+				hh.PutUint64(42)
+				hh.Merkleize(idx)
+			},
+		},
+		{
+			// an Append*-buffered field followed by a child scope: the buffered
+			// bytes must become leaves of the parent, not of the child list
+			name: "append then child scope",
+			walk: func(hh sszutils.HashWalker) {
+				idx := hh.StartTree(sszutils.TreeTypeNone)
+				hh.AppendBytes32(fieldA[:])
+				cidx := hh.StartTree(sszutils.TreeTypeNone)
+				hh.AppendUint64(42)
+				hh.AppendUint64(43)
+				hh.FillUpTo32()
+				hh.MerkleizeWithMixin(cidx, 2, 4)
+				hh.Merkleize(idx)
+			},
+		},
+		{
+			// deneb.ExecutionPayloadHeader-like tail: dynamic list scope,
+			// buffered uint256 root, then direct bytes32/uint64 fields
+			name: "payload header field tail",
+			walk: func(hh sszutils.HashWalker) {
+				idx := hh.StartTree(sszutils.TreeTypeNone)
+				hh.PutBytes(fieldA[:])                      // PrevRandao
+				hh.PutUint64(1)                             // BlockNumber
+				hh.PutUint64(2)                             // GasLimit
+				cidx := hh.StartTree(sszutils.TreeTypeNone) // ExtraData
+				hh.Append([]byte{0xff, 0xee})
+				hh.FillUpTo32()
+				hh.MerkleizeWithMixin(cidx, 2, 1)
+				hh.AppendBytes32(fieldB[:]) // BaseFeePerGas root
+				hh.PutBytes(fieldA[:])      // BlockHash
+				hh.PutUint64(3)             // BlobGasUsed
+				hh.Merkleize(idx)
+			},
+		},
+		{
+			name: "append then bitlist",
+			walk: func(hh sszutils.HashWalker) {
+				idx := hh.StartTree(sszutils.TreeTypeNone)
+				hh.AppendBytes32(fieldA[:])
+				hh.PutBitlist([]byte{0xff, 0x01}, 64)
+				hh.Merkleize(idx)
+			},
+		},
+		{
+			name: "append then large put bytes",
+			walk: func(hh sszutils.HashWalker) {
+				idx := hh.StartTree(sszutils.TreeTypeNone)
+				hh.AppendBytes32(fieldA[:])
+				large := make([]byte, 96)
+				large[0] = 0x33
+				hh.PutBytes(large)
+				hh.Merkleize(idx)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := hasher.FastHasherPool.Get()
+			defer hasher.FastHasherPool.Put(h)
+
+			tt.walk(h)
+			expected, err := h.HashRoot()
+			if err != nil {
+				t.Fatalf("hasher HashRoot failed: %v", err)
+			}
+
+			w := NewWrapper()
+			tt.walk(w)
+			actual, err := w.HashRoot()
+			if err != nil {
+				t.Fatalf("wrapper HashRoot failed: %v", err)
+			}
+
+			if expected != actual {
+				t.Errorf("wrapper root %x does not match hasher root %x", actual, expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# fix(treeproof): preserve leaf order when Append* interleaves with Put* or child scopes

Fixes #191

## Summary

`GetTree(x).Hash()` disagreed with `HashTreeRoot(x)` for any container whose `HashTreeRootWith` interleaves an `Append*`-buffered field with a `Put*` field inside the same merkleize scope. This affects real consensus types: `deneb.ExecutionPayloadHeader` / `ExecutionPayload` (the `BaseFeePerGas` uint256 root is emitted via `hh.AppendBytes32(root[:])`, followed by `PutBytes`/`PutUint64` fields) and therefore every Deneb+ `BeaconState`. `HashTreeRoot` via `hasher.Hasher` was always correct; only the `treeproof.Wrapper` tree (and thus all proofs generated from it) was wrong.

## Root cause

`hasher.Hasher` keeps a single ordered byte buffer: `Append*` and `Put*` both write into it in call order, and `StartTree`/`Index` checkpoint by byte offset, so field order is always preserved.

`treeproof.Wrapper` splits state in two:

- `Append*` → buffered in `w.buf`, flushed to leaf nodes only at `Merkleize*`.
- `Put*` / `Add*` → appended directly to `w.nodes` via `AddNode`, bypassing the buffer.

This breaks leaf ordering in two ways:

1. **`Append*` then `Put*`** (the reported bug): the directly-added node lands before the still-buffered bytes. At the closing `Merkleize` the buffer is flushed to the *end* of the node list, so e.g. `BaseFeePerGas` (field 11 of `ExecutionPayloadHeader`) ends up at leaf position 16.
2. **`Append*` then a child scope** (found while verifying the fix): `StartTree`/`Index` returned `len(w.nodes)` while pending bytes were still in `w.buf`, so a buffered field followed by e.g. a dynamic list field was flushed *after* the checkpoint and absorbed into the child scope's merkleization.

## Fix

Add a `flushBuffer()` helper that converts pending `Append*` bytes into leaf nodes, and call it at every ordering boundary:

- `AddNode` — covers all `Put*`/`Add*` paths (fixes 1),
- `StartTree` / `Index` — the checkpoint now separates pending bytes from the new scope (fixes 2),
- the five `Merkleize*` methods now reuse the same helper instead of duplicated flush blocks.

This mirrors the ordering semantics of `hasher.Hasher`'s single byte buffer.

## Testing

- New regression test `TestWrapperInterleavedAppendPut` (`treeproof/wrapper_interleave_test.go`) compares Wrapper roots against `hasher.Hasher` for six interleaved layouts: append-then-put (bytes32 and uint64), append-then-child-scope, an `ExecutionPayloadHeader`-like field tail, append-then-bitlist, and append-then-large-`PutBytes`. All six fail on the previous code and pass now.
- Real-world check: `ds.GetTree(&deneb.ExecutionPayloadHeader{BaseFeePerGas: ..., BlockHash: ...}).Hash()` now equals `ds.HashTreeRoot(...)` (previously mismatched), so Deneb+ `BeaconState` trees match the chain state root again.
- `go test -race ./...` passes; the `tests/spectests` module builds against the change.
