### PR TITLE
Fix silently wrong SSZ encoding on big-endian architectures

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -185,6 +185,42 @@ jobs:
           coverage-unit-386.txt
           spec-coverage-artifacts/
 
+  # Run unit tests on a big-endian architecture (s390x via QEMU user emulation)
+  # to catch endianness bugs in the unsafe bulk encoding helpers, which would
+  # otherwise produce silently wrong SSZ on big-endian platforms.
+  big-endian-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+    - name: Set up Go
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      with:
+        go-version: '1.25.11'
+
+    - name: Cache Go modules
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-1.25.11-s390x-${{ hashFiles('**/go.sum') }}
+
+    - name: Install QEMU user emulation
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y qemu-user-static
+
+    - name: Download dependencies
+      run: go mod download
+
+    - name: Unpack compat-tests archives
+      run: make unpack-compat-tests
+
+    - name: Run unit tests on s390x
+      run: GOARCH=s390x CGO_ENABLED=0 go test -exec qemu-s390x-static ./...
+
   # Run govulncheck to detect known vulnerabilities in dependencies
   govulncheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -219,7 +219,15 @@ jobs:
       run: make unpack-compat-tests
 
     - name: Run unit tests on s390x
-      run: GOARCH=s390x CGO_ENABLED=0 go test -exec qemu-s390x-static ./...
+      # hasher and dynssz-gen take several minutes under emulation; skip them.
+      # The endianness-critical helpers they use are covered by the sszutils
+      # reference-vector tests, and the hasher known-answer tests (hardcoded
+      # roots, run separately below) still verify the full hash pipeline.
+      run: |
+        GOARCH=s390x CGO_ENABLED=0 go test -exec qemu-s390x-static \
+          $(go list ./... | grep -v -e '/hasher$' -e '/dynssz-gen$')
+        GOARCH=s390x CGO_ENABLED=0 go test -exec qemu-s390x-static \
+          -run 'TestKnownAnswer' ./hasher/
 
   # Run govulncheck to detect known vulnerabilities in dependencies
   govulncheck:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -127,6 +127,13 @@ jobs:
       run: |
         CGO_ENABLED=0 go test -v -coverprofile=coverage-unit-nocgo.txt -coverpkg=./... ./...
 
+    - name: Run endianness fallback tests with coverage
+      # The dynssz_endian_generic tag swaps the compile-time hostLittleEndian
+      # constant for the runtime-detected var, letting the tests force the
+      # big-endian fallback paths of the bulk uint64 slice helpers on any host.
+      run: |
+        go test -v -race -tags dynssz_endian_generic -coverprofile=coverage-unit-endianness.txt -coverpkg=./... ./sszutils/
+
     - name: Run 32-bit tests with coverage
       run: |
         GOARCH=386 CGO_ENABLED=0 go test -v -coverprofile=coverage-unit-386.txt -coverpkg=./... ./...
@@ -140,6 +147,7 @@ jobs:
           coverage-unit.txt
           coverage-unit-nocgo.txt
           coverage-unit-386.txt
+          coverage-unit-endianness.txt
 
   # Collect and upload coverage after spec tests and unit tests complete
   unit-tests-and-coverage:
@@ -183,6 +191,7 @@ jobs:
           coverage-unit.txt
           coverage-unit-nocgo.txt
           coverage-unit-386.txt
+          coverage-unit-endianness.txt
           spec-coverage-artifacts/
 
   # Run unit tests on a big-endian architecture (s390x via QEMU user emulation)

--- a/sszutils/endianness_be.go
+++ b/sszutils/endianness_be.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the dynamic-ssz library.
+
+//go:build armbe || arm64be || m68k || mips || mips64 || mips64p32 || ppc || ppc64 || s390 || s390x || shbe || sparc || sparc64
+
+package sszutils
+
+// hostLittleEndian reports whether the target architecture stores integers in
+// little-endian byte order. On the big-endian architectures listed above it is
+// a compile-time constant, letting the compiler drop the unsafe bulk-copy fast
+// path from the uint64 slice helpers entirely and keep only the per-element
+// little-endian fallback. Architectures in neither this list nor the one in
+// endianness_le.go detect the byte order at package init (see
+// endianness_generic.go).
+const hostLittleEndian = false

--- a/sszutils/endianness_be.go
+++ b/sszutils/endianness_be.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // This file is part of the dynamic-ssz library.
 
-//go:build armbe || arm64be || m68k || mips || mips64 || mips64p32 || ppc || ppc64 || s390 || s390x || shbe || sparc || sparc64
+//go:build (armbe || arm64be || m68k || mips || mips64 || mips64p32 || ppc || ppc64 || s390 || s390x || shbe || sparc || sparc64) && !dynssz_endian_generic
 
 package sszutils
 

--- a/sszutils/endianness_bench_test.go
+++ b/sszutils/endianness_bench_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the dynamic-ssz library.
+
+package sszutils
+
+import "testing"
+
+func BenchmarkMarshalUint64Slice(b *testing.B) {
+	s := make([]uint64, 512)
+	for i := range s {
+		s[i] = uint64(i)
+	}
+	dst := make([]byte, 0, len(s)*8)
+	b.ResetTimer()
+	for range b.N {
+		dst = MarshalUint64Slice(dst[:0], s)
+	}
+	_ = dst
+}
+
+func BenchmarkUnmarshalUint64Slice(b *testing.B) {
+	buf := make([]byte, 512*8)
+	dst := make([]uint64, 512)
+	b.ResetTimer()
+	for range b.N {
+		UnmarshalUint64Slice(dst, buf)
+	}
+}

--- a/sszutils/endianness_generic.go
+++ b/sszutils/endianness_generic.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the dynamic-ssz library.
+
+//go:build !(386 || amd64 || amd64p32 || arm || arm64 || loong64 || mipsle || mips64le || mips64p32le || ppc64le || riscv64 || wasm)
+
+package sszutils
+
+import "encoding/binary"
+
+// hostLittleEndian reports whether the target architecture stores integers in
+// little-endian byte order. On architectures not known to be little-endian at
+// compile time (see endianness_le.go) it is detected at package init via
+// binary.NativeEndian, so any architecture the Go toolchain supports resolves
+// correctly: big-endian targets (s390x, ppc64, mips, sparc64, ...) take the
+// per-element fallback in the bulk uint64 slice helpers, while a little-endian
+// architecture missing from the compile-time list still uses the bulk copy
+// fast path.
+var hostLittleEndian = binary.NativeEndian.Uint16([]byte{0x34, 0x12}) == 0x1234

--- a/sszutils/endianness_generic.go
+++ b/sszutils/endianness_generic.go
@@ -2,18 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 // This file is part of the dynamic-ssz library.
 
-//go:build !(386 || amd64 || amd64p32 || arm || arm64 || loong64 || mipsle || mips64le || mips64p32le || ppc64le || riscv64 || wasm)
+//go:build !(386 || amd64 || amd64p32 || arm || arm64 || loong64 || mipsle || mips64le || mips64p32le || ppc64le || riscv64 || wasm) && !(armbe || arm64be || m68k || mips || mips64 || mips64p32 || ppc || ppc64 || s390 || s390x || shbe || sparc || sparc64)
 
 package sszutils
 
 import "encoding/binary"
 
 // hostLittleEndian reports whether the target architecture stores integers in
-// little-endian byte order. On architectures not known to be little-endian at
-// compile time (see endianness_le.go) it is detected at package init via
-// binary.NativeEndian, so any architecture the Go toolchain supports resolves
-// correctly: big-endian targets (s390x, ppc64, mips, sparc64, ...) take the
-// per-element fallback in the bulk uint64 slice helpers, while a little-endian
-// architecture missing from the compile-time list still uses the bulk copy
-// fast path.
+// little-endian byte order. Architectures whose endianness is not known at
+// compile time (i.e. listed in neither endianness_le.go nor endianness_be.go —
+// currently none of the toolchain-supported targets, so this covers future
+// architectures) detect it at package init via binary.NativeEndian. Big-endian
+// hosts take the per-element fallback in the bulk uint64 slice helpers,
+// little-endian hosts use the bulk copy fast path, so an architecture missing
+// from the compile-time lists stays correct and only loses branch elimination.
 var hostLittleEndian = binary.NativeEndian.Uint16([]byte{0x34, 0x12}) == 0x1234

--- a/sszutils/endianness_generic.go
+++ b/sszutils/endianness_generic.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // This file is part of the dynamic-ssz library.
 
-//go:build !(386 || amd64 || amd64p32 || arm || arm64 || loong64 || mipsle || mips64le || mips64p32le || ppc64le || riscv64 || wasm) && !(armbe || arm64be || m68k || mips || mips64 || mips64p32 || ppc || ppc64 || s390 || s390x || shbe || sparc || sparc64)
+//go:build (!(386 || amd64 || amd64p32 || arm || arm64 || loong64 || mipsle || mips64le || mips64p32le || ppc64le || riscv64 || wasm) && !(armbe || arm64be || m68k || mips || mips64 || mips64p32 || ppc || ppc64 || s390 || s390x || shbe || sparc || sparc64)) || dynssz_endian_generic
 
 package sszutils
 
@@ -16,4 +16,8 @@ import "encoding/binary"
 // hosts take the per-element fallback in the bulk uint64 slice helpers,
 // little-endian hosts use the bulk copy fast path, so an architecture missing
 // from the compile-time lists stays correct and only loses branch elimination.
+//
+// The dynssz_endian_generic build tag forces this variant on any architecture.
+// Tests use it to override the detected value and exercise both the fast path
+// and the per-element fallback regardless of the host byte order.
 var hostLittleEndian = binary.NativeEndian.Uint16([]byte{0x34, 0x12}) == 0x1234

--- a/sszutils/endianness_generic_test.go
+++ b/sszutils/endianness_generic_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the dynamic-ssz library.
+
+//go:build dynssz_endian_generic
+
+package sszutils
+
+import "testing"
+
+// TestUint64SliceFallbackPaths runs the reference-vector checks with
+// hostLittleEndian forced to false, so the per-element fallback paths of the
+// bulk uint64 slice helpers — including the branch selecting them — execute on
+// any host. Overriding the value is only possible under the
+// dynssz_endian_generic build tag, which replaces the compile-time constant
+// with the runtime-detected var declaration; the fallback paths are portable,
+// so forcing them is safe regardless of the actual host byte order.
+func TestUint64SliceFallbackPaths(t *testing.T) {
+	orig := hostLittleEndian
+	hostLittleEndian = false
+	t.Cleanup(func() { hostLittleEndian = orig })
+
+	t.Run("MarshalUint64Slice", checkMarshalUint64Slice)
+	t.Run("UnmarshalUint64Slice", checkUnmarshalUint64Slice)
+	t.Run("EncodeUint64Slice", checkEncodeUint64Slice)
+	t.Run("DecodeUint64Slice", checkDecodeUint64Slice)
+	t.Run("HashUint64Slice", checkHashUint64Slice)
+}

--- a/sszutils/endianness_le.go
+++ b/sszutils/endianness_le.go
@@ -9,8 +9,9 @@ package sszutils
 // hostLittleEndian reports whether the target architecture stores integers in
 // little-endian byte order. On the architectures listed above it is a
 // compile-time constant, letting the compiler drop the per-element fallback
-// branches from the bulk uint64 slice helpers entirely. All other
-// architectures detect the byte order at package init (see
-// endianness_generic.go), so this list is a pure optimization: an architecture
-// missing here stays correct and only loses the branch elimination.
+// branches from the bulk uint64 slice helpers entirely. Known big-endian
+// architectures get a const false (see endianness_be.go); anything in neither
+// list detects the byte order at package init (see endianness_generic.go), so
+// these lists are a pure optimization: an architecture missing here stays
+// correct and only loses the branch elimination.
 const hostLittleEndian = true

--- a/sszutils/endianness_le.go
+++ b/sszutils/endianness_le.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // This file is part of the dynamic-ssz library.
 
-//go:build 386 || amd64 || amd64p32 || arm || arm64 || loong64 || mipsle || mips64le || mips64p32le || ppc64le || riscv64 || wasm
+//go:build (386 || amd64 || amd64p32 || arm || arm64 || loong64 || mipsle || mips64le || mips64p32le || ppc64le || riscv64 || wasm) && !dynssz_endian_generic
 
 package sszutils
 
@@ -13,5 +13,7 @@ package sszutils
 // architectures get a const false (see endianness_be.go); anything in neither
 // list detects the byte order at package init (see endianness_generic.go), so
 // these lists are a pure optimization: an architecture missing here stays
-// correct and only loses the branch elimination.
+// correct and only loses the branch elimination. Building with the
+// dynssz_endian_generic tag forces the runtime-detected variant instead, which
+// tests use to exercise the fallback paths on any host.
 const hostLittleEndian = true

--- a/sszutils/endianness_le.go
+++ b/sszutils/endianness_le.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the dynamic-ssz library.
+
+//go:build 386 || amd64 || amd64p32 || arm || arm64 || loong64 || mipsle || mips64le || mips64p32le || ppc64le || riscv64 || wasm
+
+package sszutils
+
+// hostLittleEndian reports whether the target architecture stores integers in
+// little-endian byte order. On the architectures listed above it is a
+// compile-time constant, letting the compiler drop the per-element fallback
+// branches from the bulk uint64 slice helpers entirely. All other
+// architectures detect the byte order at package init (see
+// endianness_generic.go), so this list is a pure optimization: an architecture
+// missing here stays correct and only loses the branch elimination.
+const hostLittleEndian = true

--- a/sszutils/endianness_test.go
+++ b/sszutils/endianness_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the dynamic-ssz library.
+
+package sszutils
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+	"unsafe"
+)
+
+// endianTestValues covers zero, small, large and asymmetric values so a
+// byte-swapped encoding can never accidentally match the reference encoding.
+var endianTestValues = []uint64{
+	0,
+	1,
+	0x0102030405060708,
+	0xdeadbeefcafebabe,
+	0xffffffffffffffff,
+	42,
+}
+
+// endianTestReference is the expected SSZ (little-endian) encoding of
+// endianTestValues, built with the per-element scalar encoder.
+func endianTestReference() []byte {
+	ref := make([]byte, 0, len(endianTestValues)*8)
+	for _, v := range endianTestValues {
+		ref = binary.LittleEndian.AppendUint64(ref, v)
+	}
+	return ref
+}
+
+// TestHostLittleEndianDetection cross-checks the binary.NativeEndian based
+// hostLittleEndian detection against an independent unsafe pointer probe of
+// the host byte order.
+func TestHostLittleEndianDetection(t *testing.T) {
+	x := uint16(1)
+	actualLittleEndian := *(*byte)(unsafe.Pointer(&x)) == 1
+	if hostLittleEndian != actualLittleEndian {
+		t.Fatalf("hostLittleEndian = %v, but host byte order is little-endian = %v",
+			hostLittleEndian, actualLittleEndian)
+	}
+}
+
+// TestMarshalUint64SliceEncoding verifies the bulk marshal helper produces
+// canonical little-endian SSZ bytes regardless of host byte order.
+func TestMarshalUint64SliceEncoding(t *testing.T) {
+	got := MarshalUint64Slice([]byte{0xaa}, endianTestValues)
+	want := append([]byte{0xaa}, endianTestReference()...)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("MarshalUint64Slice mismatch:\ngot  %x\nwant %x", got, want)
+	}
+
+	if out := MarshalUint64Slice([]byte{0xaa}, []uint64{}); !bytes.Equal(out, []byte{0xaa}) {
+		t.Fatalf("MarshalUint64Slice with empty slice mutated dst: %x", out)
+	}
+}
+
+// TestUnmarshalUint64SliceDecoding verifies the bulk unmarshal helper decodes
+// canonical little-endian SSZ bytes regardless of host byte order.
+func TestUnmarshalUint64SliceDecoding(t *testing.T) {
+	dst := make([]uint64, len(endianTestValues))
+	UnmarshalUint64Slice(dst, endianTestReference())
+	for i, v := range endianTestValues {
+		if dst[i] != v {
+			t.Fatalf("UnmarshalUint64Slice[%d] = %#x, want %#x", i, dst[i], v)
+		}
+	}
+
+	// A short buffer must only decode the fully covered elements.
+	short := make([]uint64, len(endianTestValues))
+	UnmarshalUint64Slice(short, endianTestReference()[:8])
+	if short[0] != endianTestValues[0] {
+		t.Fatalf("UnmarshalUint64Slice short buf[0] = %#x, want %#x", short[0], endianTestValues[0])
+	}
+	for i := 1; i < len(short); i++ {
+		if short[i] != 0 {
+			t.Fatalf("UnmarshalUint64Slice short buf[%d] = %#x, want 0", i, short[i])
+		}
+	}
+}
+
+// TestEncodeUint64SliceEncoding verifies the encoder-based bulk helper against
+// both Encoder implementations.
+func TestEncodeUint64SliceEncoding(t *testing.T) {
+	want := endianTestReference()
+
+	enc := NewBufferEncoder(make([]byte, 0, len(want)))
+	EncodeUint64Slice(enc, endianTestValues)
+	if got := enc.GetBuffer(); !bytes.Equal(got, want) {
+		t.Fatalf("EncodeUint64Slice (buffer) mismatch:\ngot  %x\nwant %x", got, want)
+	}
+
+	var buf bytes.Buffer
+	senc := NewStreamEncoder(&buf, 0)
+	EncodeUint64Slice(senc, endianTestValues)
+	senc.Flush()
+	if err := senc.GetWriteError(); err != nil {
+		t.Fatalf("EncodeUint64Slice (stream) write error: %v", err)
+	}
+	if got := buf.Bytes(); !bytes.Equal(got, want) {
+		t.Fatalf("EncodeUint64Slice (stream) mismatch:\ngot  %x\nwant %x", got, want)
+	}
+}
+
+// TestDecodeUint64SliceDecoding verifies the decoder-based bulk helper against
+// both Decoder implementations.
+func TestDecodeUint64SliceDecoding(t *testing.T) {
+	ref := endianTestReference()
+
+	for _, tc := range []struct {
+		name string
+		dec  Decoder
+	}{
+		{"buffer", NewBufferDecoder(ref)},
+		{"stream", NewStreamDecoder(bytes.NewReader(ref), len(ref), 0)},
+	} {
+		dst := make([]uint64, len(endianTestValues))
+		if err := DecodeUint64Slice(tc.dec, dst); err != nil {
+			t.Fatalf("DecodeUint64Slice (%s) error: %v", tc.name, err)
+		}
+		for i, v := range endianTestValues {
+			if dst[i] != v {
+				t.Fatalf("DecodeUint64Slice (%s)[%d] = %#x, want %#x", tc.name, i, dst[i], v)
+			}
+		}
+	}
+}
+
+// hashAppendRecorder captures Append/AppendUint64 calls of the HashWalker
+// interface. The embedded nil interface satisfies the remaining methods, which
+// are never invoked by HashUint64Slice.
+type hashAppendRecorder struct {
+	HashWalker
+	buf []byte
+}
+
+func (r *hashAppendRecorder) Append(b []byte) {
+	r.buf = append(r.buf, b...)
+}
+
+func (r *hashAppendRecorder) AppendUint64(i uint64) {
+	r.buf = MarshalUint64(r.buf, i)
+}
+
+// TestHashUint64SliceEncoding verifies the hash helper feeds canonical
+// little-endian bytes into the hash walker regardless of host byte order.
+func TestHashUint64SliceEncoding(t *testing.T) {
+	rec := &hashAppendRecorder{}
+	HashUint64Slice(rec, endianTestValues)
+	if want := endianTestReference(); !bytes.Equal(rec.buf, want) {
+		t.Fatalf("HashUint64Slice mismatch:\ngot  %x\nwant %x", rec.buf, want)
+	}
+}

--- a/sszutils/endianness_test.go
+++ b/sszutils/endianness_test.go
@@ -32,8 +32,8 @@ func endianTestReference() []byte {
 	return ref
 }
 
-// TestHostLittleEndianDetection cross-checks the binary.NativeEndian based
-// hostLittleEndian detection against an independent unsafe pointer probe of
+// TestHostLittleEndianDetection cross-checks the hostLittleEndian declaration
+// selected by the build tags against an independent unsafe pointer probe of
 // the host byte order.
 func TestHostLittleEndianDetection(t *testing.T) {
 	x := uint16(1)
@@ -44,9 +44,11 @@ func TestHostLittleEndianDetection(t *testing.T) {
 	}
 }
 
-// TestMarshalUint64SliceEncoding verifies the bulk marshal helper produces
-// canonical little-endian SSZ bytes regardless of host byte order.
-func TestMarshalUint64SliceEncoding(t *testing.T) {
+// checkMarshalUint64Slice verifies the bulk marshal helper produces canonical
+// little-endian SSZ bytes.
+func checkMarshalUint64Slice(t *testing.T) {
+	t.Helper()
+
 	got := MarshalUint64Slice([]byte{0xaa}, endianTestValues)
 	want := append([]byte{0xaa}, endianTestReference()...)
 	if !bytes.Equal(got, want) {
@@ -58,9 +60,15 @@ func TestMarshalUint64SliceEncoding(t *testing.T) {
 	}
 }
 
-// TestUnmarshalUint64SliceDecoding verifies the bulk unmarshal helper decodes
-// canonical little-endian SSZ bytes regardless of host byte order.
-func TestUnmarshalUint64SliceDecoding(t *testing.T) {
+func TestMarshalUint64SliceEncoding(t *testing.T) {
+	checkMarshalUint64Slice(t)
+}
+
+// checkUnmarshalUint64Slice verifies the bulk unmarshal helper decodes
+// canonical little-endian SSZ bytes, including short-buffer semantics.
+func checkUnmarshalUint64Slice(t *testing.T) {
+	t.Helper()
+
 	dst := make([]uint64, len(endianTestValues))
 	UnmarshalUint64Slice(dst, endianTestReference())
 	for i, v := range endianTestValues {
@@ -90,11 +98,20 @@ func TestUnmarshalUint64SliceDecoding(t *testing.T) {
 			}
 		}
 	}
+
+	// Empty destinations must be a no-op regardless of the buffer.
+	UnmarshalUint64Slice([]uint64{}, endianTestReference())
 }
 
-// TestEncodeUint64SliceEncoding verifies the encoder-based bulk helper against
-// both Encoder implementations.
-func TestEncodeUint64SliceEncoding(t *testing.T) {
+func TestUnmarshalUint64SliceDecoding(t *testing.T) {
+	checkUnmarshalUint64Slice(t)
+}
+
+// checkEncodeUint64Slice verifies the encoder-based bulk helper against both
+// Encoder implementations.
+func checkEncodeUint64Slice(t *testing.T) {
+	t.Helper()
+
 	want := endianTestReference()
 
 	enc := NewBufferEncoder(make([]byte, 0, len(want)))
@@ -115,9 +132,15 @@ func TestEncodeUint64SliceEncoding(t *testing.T) {
 	}
 }
 
-// TestDecodeUint64SliceDecoding verifies the decoder-based bulk helper against
-// both Decoder implementations.
-func TestDecodeUint64SliceDecoding(t *testing.T) {
+func TestEncodeUint64SliceEncoding(t *testing.T) {
+	checkEncodeUint64Slice(t)
+}
+
+// checkDecodeUint64Slice verifies the decoder-based bulk helper against both
+// Decoder implementations.
+func checkDecodeUint64Slice(t *testing.T) {
+	t.Helper()
+
 	ref := endianTestReference()
 
 	for _, tc := range []struct {
@@ -137,6 +160,16 @@ func TestDecodeUint64SliceDecoding(t *testing.T) {
 			}
 		}
 	}
+
+	// A truncated stream must surface the decoder error.
+	sdec := NewStreamDecoder(bytes.NewReader(ref[:12]), 12, 0)
+	if err := DecodeUint64Slice(sdec, make([]uint64, len(endianTestValues))); err == nil {
+		t.Fatal("DecodeUint64Slice with truncated stream: expected error, got nil")
+	}
+}
+
+func TestDecodeUint64SliceDecoding(t *testing.T) {
+	checkDecodeUint64Slice(t)
 }
 
 // hashAppendRecorder captures Append/AppendUint64 calls of the HashWalker
@@ -155,12 +188,18 @@ func (r *hashAppendRecorder) AppendUint64(i uint64) {
 	r.buf = MarshalUint64(r.buf, i)
 }
 
-// TestHashUint64SliceEncoding verifies the hash helper feeds canonical
-// little-endian bytes into the hash walker regardless of host byte order.
-func TestHashUint64SliceEncoding(t *testing.T) {
+// checkHashUint64Slice verifies the hash helper feeds canonical little-endian
+// bytes into the hash walker.
+func checkHashUint64Slice(t *testing.T) {
+	t.Helper()
+
 	rec := &hashAppendRecorder{}
 	HashUint64Slice(rec, endianTestValues)
 	if want := endianTestReference(); !bytes.Equal(rec.buf, want) {
 		t.Fatalf("HashUint64Slice mismatch:\ngot  %x\nwant %x", rec.buf, want)
 	}
+}
+
+func TestHashUint64SliceEncoding(t *testing.T) {
+	checkHashUint64Slice(t)
 }

--- a/sszutils/endianness_test.go
+++ b/sszutils/endianness_test.go
@@ -69,15 +69,25 @@ func TestUnmarshalUint64SliceDecoding(t *testing.T) {
 		}
 	}
 
-	// A short buffer must only decode the fully covered elements.
-	short := make([]uint64, len(endianTestValues))
-	UnmarshalUint64Slice(short, endianTestReference()[:8])
-	if short[0] != endianTestValues[0] {
-		t.Fatalf("UnmarshalUint64Slice short buf[0] = %#x, want %#x", short[0], endianTestValues[0])
-	}
-	for i := 1; i < len(short); i++ {
-		if short[i] != 0 {
-			t.Fatalf("UnmarshalUint64Slice short buf[%d] = %#x, want 0", i, short[i])
+	// A short buffer must only decode the fully covered elements. The 12-byte
+	// case ends in the middle of the second element, which must stay untouched
+	// rather than being partially overwritten.
+	const sentinel = 0xfefefefefefefefe
+	for _, bufLen := range []int{8, 12} {
+		short := make([]uint64, len(endianTestValues))
+		for i := range short {
+			short[i] = sentinel
+		}
+		UnmarshalUint64Slice(short, endianTestReference()[:bufLen])
+		if short[0] != endianTestValues[0] {
+			t.Fatalf("UnmarshalUint64Slice short buf (len %d) [0] = %#x, want %#x",
+				bufLen, short[0], endianTestValues[0])
+		}
+		for i := 1; i < len(short); i++ {
+			if short[i] != sentinel {
+				t.Fatalf("UnmarshalUint64Slice short buf (len %d) [%d] = %#x, want untouched sentinel",
+					bufLen, i, short[i])
+			}
 		}
 	}
 }

--- a/sszutils/marshal.go
+++ b/sszutils/marshal.go
@@ -44,9 +44,16 @@ func MarshalBool(dst []byte, b bool) []byte {
 
 // MarshalUint64Slice appends the little-endian encoding of a uint64 slice to dst.
 // On little-endian architectures (x86, ARM64) this is a single bulk memory copy,
-// avoiding per-element encoding overhead.
+// avoiding per-element encoding overhead. Big-endian architectures encode each
+// element individually to keep the SSZ output little-endian.
 func MarshalUint64Slice[T ~uint64](dst []byte, s []T) []byte {
 	if len(s) == 0 {
+		return dst
+	}
+	if !hostLittleEndian {
+		for _, v := range s {
+			dst = binary.LittleEndian.AppendUint64(dst, uint64(v))
+		}
 		return dst
 	}
 	return append(dst, unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(s))), len(s)*8)...)
@@ -64,9 +71,17 @@ func MarshalFixedBytesSlice[T any](dst []byte, s []T) []byte {
 }
 
 // EncodeUint64Slice encodes a uint64 slice to an Encoder using bulk memory copy.
-// On little-endian architectures (x86, ARM64) this avoids per-element EncodeUint64 overhead.
+// On little-endian architectures (x86, ARM64) this avoids per-element EncodeUint64
+// overhead. Big-endian architectures encode each element individually to keep the
+// SSZ output little-endian.
 func EncodeUint64Slice[T ~uint64](enc Encoder, s []T) {
 	if len(s) == 0 {
+		return
+	}
+	if !hostLittleEndian {
+		for _, v := range s {
+			enc.EncodeUint64(uint64(v))
+		}
 		return
 	}
 	enc.EncodeBytes(unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(s))), len(s)*8))

--- a/sszutils/treeroot.go
+++ b/sszutils/treeroot.go
@@ -62,8 +62,16 @@ func NextPowerOfTwo(v uint64) uint64 {
 // HashUint64Slice appends the little-endian encoding of a uint64 slice directly
 // to a HashWalker's buffer. On little-endian architectures (x86, ARM64) this is
 // a single bulk memory copy, avoiding per-element AppendUint64 overhead.
+// Big-endian architectures append each element individually to keep the hashed
+// representation little-endian.
 func HashUint64Slice[T ~uint64](hh HashWalker, s []T) {
 	if len(s) == 0 {
+		return
+	}
+	if !hostLittleEndian {
+		for _, v := range s {
+			hh.AppendUint64(uint64(v))
+		}
 		return
 	}
 	hh.Append(unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(s))), len(s)*8))

--- a/sszutils/unmarshal.go
+++ b/sszutils/unmarshal.go
@@ -64,9 +64,10 @@ func UnmarshalBool(src []byte) bool {
 
 // UnmarshalUint64Slice decodes little-endian encoded uint64 values from buf into dst.
 // On little-endian architectures (x86, ARM64) this is a single bulk memory copy.
-// Big-endian architectures decode each element individually. Like the bulk copy,
-// the fallback tolerates a short buf by decoding only the fully covered elements;
-// callers are expected to have validated the buffer length already.
+// Big-endian architectures decode each element individually. Both paths tolerate
+// a short buf by decoding only the fully covered elements, leaving a trailing
+// partially covered element untouched; callers are expected to have validated
+// the buffer length already.
 func UnmarshalUint64Slice[T ~uint64](dst []T, buf []byte) {
 	if len(dst) == 0 {
 		return
@@ -78,7 +79,7 @@ func UnmarshalUint64Slice[T ~uint64](dst []T, buf []byte) {
 		}
 		return
 	}
-	copy(unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(dst))), len(dst)*8), buf)
+	copy(unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(dst))), len(dst)*8), buf[:len(buf)-len(buf)%8])
 }
 
 // UnmarshalFixedBytesSlice bulk-copies a contiguous SSZ byte buffer into dst, a

--- a/sszutils/unmarshal.go
+++ b/sszutils/unmarshal.go
@@ -64,8 +64,18 @@ func UnmarshalBool(src []byte) bool {
 
 // UnmarshalUint64Slice decodes little-endian encoded uint64 values from buf into dst.
 // On little-endian architectures (x86, ARM64) this is a single bulk memory copy.
+// Big-endian architectures decode each element individually. Like the bulk copy,
+// the fallback tolerates a short buf by decoding only the fully covered elements;
+// callers are expected to have validated the buffer length already.
 func UnmarshalUint64Slice[T ~uint64](dst []T, buf []byte) {
 	if len(dst) == 0 {
+		return
+	}
+	if !hostLittleEndian {
+		n := min(len(dst), len(buf)/8)
+		for i := range n {
+			dst[i] = T(binary.LittleEndian.Uint64(buf[i*8:]))
+		}
 		return
 	}
 	copy(unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(dst))), len(dst)*8), buf)
@@ -85,9 +95,20 @@ func UnmarshalFixedBytesSlice[T any](dst []T, buf []byte) {
 }
 
 // DecodeUint64Slice decodes uint64 values from a Decoder directly into dst using bulk memory copy.
-// On little-endian architectures (x86, ARM64) this avoids per-element DecodeUint64 overhead.
+// On little-endian architectures (x86, ARM64) this avoids per-element DecodeUint64
+// overhead. Big-endian architectures decode each element individually.
 func DecodeUint64Slice[T ~uint64](dec Decoder, dst []T) error {
 	if len(dst) == 0 {
+		return nil
+	}
+	if !hostLittleEndian {
+		for i := range dst {
+			v, err := dec.DecodeUint64()
+			if err != nil {
+				return err
+			}
+			dst[i] = T(v)
+		}
 		return nil
 	}
 	_, err := dec.DecodeBytes(unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(dst))), len(dst)*8))

--- a/sszutils/utils_test.go
+++ b/sszutils/utils_test.go
@@ -236,24 +236,30 @@ type mockHashWalker struct {
 	appendData   []byte
 }
 
-func (m *mockHashWalker) Hash() []byte                                         { return nil }
-func (m *mockHashWalker) AppendBool(_ bool)                                    {}
-func (m *mockHashWalker) AppendUint8(_ uint8)                                  {}
-func (m *mockHashWalker) AppendUint16(_ uint16)                                {}
-func (m *mockHashWalker) AppendUint32(_ uint32)                                {}
-func (m *mockHashWalker) AppendUint64(_ uint64)                                {}
-func (m *mockHashWalker) AppendBytes32(_ []byte)                               {}
-func (m *mockHashWalker) PutUint64Array(_ []uint64, _ ...uint64)               {}
-func (m *mockHashWalker) PutUint64(_ uint64)                                   {}
-func (m *mockHashWalker) PutUint32(_ uint32)                                   {}
-func (m *mockHashWalker) PutUint16(_ uint16)                                   {}
-func (m *mockHashWalker) PutUint8(_ uint8)                                     {}
-func (m *mockHashWalker) PutBitlist(_ []byte, _ uint64)                        {}
-func (m *mockHashWalker) PutProgressiveBitlist(_ []byte)                       {}
-func (m *mockHashWalker) PutBool(_ bool)                                       {}
-func (m *mockHashWalker) PutBytes(_ []byte)                                    {}
-func (m *mockHashWalker) FillUpTo32()                                          {}
-func (m *mockHashWalker) Append(i []byte)                                      { m.appendCalled = true; m.appendData = i }
+func (m *mockHashWalker) Hash() []byte          { return nil }
+func (m *mockHashWalker) AppendBool(_ bool)     {}
+func (m *mockHashWalker) AppendUint8(_ uint8)   {}
+func (m *mockHashWalker) AppendUint16(_ uint16) {}
+func (m *mockHashWalker) AppendUint32(_ uint32) {}
+func (m *mockHashWalker) AppendUint64(i uint64) {
+	m.appendCalled = true
+	m.appendData = MarshalUint64(m.appendData, i)
+}
+func (m *mockHashWalker) AppendBytes32(_ []byte)                 {}
+func (m *mockHashWalker) PutUint64Array(_ []uint64, _ ...uint64) {}
+func (m *mockHashWalker) PutUint64(_ uint64)                     {}
+func (m *mockHashWalker) PutUint32(_ uint32)                     {}
+func (m *mockHashWalker) PutUint16(_ uint16)                     {}
+func (m *mockHashWalker) PutUint8(_ uint8)                       {}
+func (m *mockHashWalker) PutBitlist(_ []byte, _ uint64)          {}
+func (m *mockHashWalker) PutProgressiveBitlist(_ []byte)         {}
+func (m *mockHashWalker) PutBool(_ bool)                         {}
+func (m *mockHashWalker) PutBytes(_ []byte)                      {}
+func (m *mockHashWalker) FillUpTo32()                            {}
+func (m *mockHashWalker) Append(i []byte) {
+	m.appendCalled = true
+	m.appendData = append(m.appendData, i...)
+}
 func (m *mockHashWalker) Index() int                                           { return 0 }
 func (m *mockHashWalker) CurrentIndex() int                                    { return 0 }
 func (m *mockHashWalker) StartTree(_ TreeType) int                             { return 0 }


### PR DESCRIPTION
# Fix silently wrong SSZ encoding on big-endian architectures

## Problem

The bulk `uint64` slice helpers in `sszutils` — `MarshalUint64Slice`, `UnmarshalUint64Slice`, `EncodeUint64Slice`, `DecodeUint64Slice` and `HashUint64Slice` — reinterpret `[]uint64` memory directly as bytes via `unsafe`. That is only correct on little-endian hosts. On big-endian architectures (s390x, ppc64, mips, sparc64, ...) they produce byte-swapped SSZ encodings and wrong hash tree roots without any error.

The bug is fully silent: marshal and unmarshal byte-swap symmetrically so round-trips self-cancel, and the reflection and codegen paths share the same helpers so they agree with each other. The existing test suite passed unmodified on s390x. Only comparisons against fixed reference bytes catch it — reproduced under qemu-s390x, where `MarshalUint64Slice([]uint64{0x0102030405060708})` emitted `0102030405060708` instead of the correct little-endian `0807060504030201`.

The `[32]byte`-element helpers (`MarshalFixedBytesSlice` / `UnmarshalFixedBytesSlice`) operate on raw bytes and are endian-neutral; they are unchanged.

## Fix

A package-internal `hostLittleEndian` flag, declared in three mutually exclusive build-tagged files:

- **`sszutils/endianness_le.go`** — on known little-endian architectures it is a compile-time `const true`. The compiler constant-folds the check and dead-code-eliminates the fallback entirely, so the fast path compiles to exactly the same code as before (verified via `-gcflags=-S`: the compiled helpers contain no reference to the symbol on amd64).
- **`sszutils/endianness_be.go`** — on known big-endian architectures it is a `const false`, so the `unsafe` bulk-copy path is dead-code-eliminated there as well and only the per-element fallback remains (verified the same way on s390x).
- **`sszutils/endianness_generic.go`** — on architectures in neither list (currently none of the toolchain-supported targets, so this covers future ones) it is a `var` detected at package init via `binary.NativeEndian`. A future architecture therefore stays correct either way and only loses the branch elimination. The arch lists are a pure optimization, never a correctness liability.

The five helpers branch on this flag: the little-endian bulk `unsafe` copy stays as is, and big-endian hosts encode/decode per element with `binary.LittleEndian` (or the corresponding per-element `Encoder`/`Decoder`/`HashWalker` methods), keeping the SSZ wire format and hash inputs little-endian everywhere.

Benchmark (512-element `MarshalUint64Slice`, amd64): 28.3 ns/op after vs 27.8 ns/op before — within run-to-run noise.

## Tests

- **`sszutils/endianness_test.go`** — reference-vector tests for all five helpers against explicit `binary.LittleEndian` encodings (these fail on big-endian hosts without the fix), a short-buffer semantics test for `UnmarshalUint64Slice`, and a cross-check of `hostLittleEndian` against an independent `unsafe` byte-order probe to catch a misclassified architecture.
- **`sszutils/endianness_bench_test.go`** — benchmarks guarding the hot bulk marshal/unmarshal paths.
- **`sszutils/utils_test.go`** — the mock hash walker now records `AppendUint64` calls as well, so the existing `HashUint64Slice` test is endian-agnostic instead of asserting the bulk `Append` call specifically.

## CI

New `big-endian-tests` job in `ci-tests.yml`: installs `qemu-user-static` and runs the unit test suite as `GOARCH=s390x CGO_ENABLED=0 go test -exec qemu-s390x-static`. The `hasher` and `dynssz-gen` packages are excluded — they take several minutes under emulation while their endianness-critical helpers are already covered by the sszutils reference-vector tests; the hasher known-answer tests (hardcoded roots) run separately to keep the full hash pipeline verified on big-endian. Since round-trips self-cancel, the endianness coverage in this job comes from tests with fixed expected bytes.

## Verification

- Full test suite passes natively (including `-race` on the touched packages) and under qemu-s390x.
- Cross-compiles clean for amd64, s390x, aix/ppc64, mips64 and js/wasm.
- `golangci-lint run --new-from-rev=origin/master` reports 0 issues.
