### PR TITLE
Align CompatibleUnion with EIP-8016 & add Union

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -112,6 +112,12 @@ jobs:
     - name: Unpack compat-tests archives
       run: make unpack-compat-tests
 
+    - name: Run codegen test suite without generated code
+      # The gen_*.go files are gitignored, so before go generate runs the
+      # suite exercises the pure reflection engine — the state fresh checkouts
+      # and the big-endian job see. It must pass in both modes.
+      run: go test ./codegen/tests/...
+
     - name: Run codegen tests with coverage
       run: |
         mkdir coverage

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Dynamic SSZ is a production-ready Go library for [SSZ](https://github.com/ethere
 
 - **📚 Complete SSZ Type Support** — vectors, lists, containers, bitvectors/bitlists (`ssz-bitsize`), `uint128`/`uint256`, multi-dimensional arrays with per-dimension limits, `time.Time`, and auto-detection of common types (`holiman/uint256`, `go-bitfield`)
 - **🚀 Progressive Types** — progressive lists & bitlists ([EIP-7916](https://eips.ethereum.org/EIPS/eip-7916)) and progressive containers with `ssz-index` ([EIP-7495](https://eips.ethereum.org/EIPS/eip-7495))
-- **🧬 Compatible Unions** — type-safe SSZ unions via the generic `CompatibleUnion[T]` type
+- **🧬 Unions** — type-safe SSZ unions via the generic `Union[T]` (classic spec, incl. the `None` option) and `CompatibleUnion[T]` ([EIP-8016](https://eips.ethereum.org/EIPS/eip-8016)) types
 - **🧩 Extended Types** — opt-in support for signed integers, floats, `big.Int`, and optional types (non-standard, disabled by default)
 
 ### Quality

--- a/codegen/gen_decoder.go
+++ b/codegen/gen_decoder.go
@@ -392,7 +392,7 @@ func (ctx *decoderContext) unmarshalType(desc *ssztypes.TypeDescriptor, varName 
 	case ssztypes.SszBitlistType, ssztypes.SszProgressiveBitlistType:
 		return ctx.unmarshalBitlist(desc, varName, typePath, indent)
 
-	case ssztypes.SszCompatibleUnionType:
+	case ssztypes.SszUnionType, ssztypes.SszCompatibleUnionType:
 		return ctx.unmarshalUnion(desc, varName, typePath, indent)
 
 	case ssztypes.SszCustomType:
@@ -1108,6 +1108,13 @@ func (ctx *decoderContext) unmarshalUnion(desc *ssztypes.TypeDescriptor, varName
 	ctx.appendCode(indent, "if err != nil {\n\treturn %s\n}\n", typePath.getErrorWith("err"))
 	ctx.appendCode(indent, "%s.Variant = selector\n", varName)
 	ctx.appendCode(indent, "switch selector {\n")
+
+	if desc.SszTypeFlags&ssztypes.SszTypeFlagHasNoneVariant != 0 {
+		// The None option carries no value, so its region is the bare selector
+		// byte (trailing bytes surface through the surrounding region checks).
+		ctx.appendCode(indent, "case 0:\n")
+		ctx.appendCode(indent, "\t%s.Data = nil\n", varName)
+	}
 
 	variants := make([]int, 0, len(desc.UnionVariants))
 	for variant := range desc.UnionVariants {

--- a/codegen/gen_encoder.go
+++ b/codegen/gen_encoder.go
@@ -381,7 +381,7 @@ func (ctx *encoderContext) marshalType(desc *ssztypes.TypeDescriptor, varName st
 	case ssztypes.SszBitlistType, ssztypes.SszProgressiveBitlistType:
 		return ctx.marshalBitlist(desc, varName, typePath, indent)
 
-	case ssztypes.SszCompatibleUnionType:
+	case ssztypes.SszUnionType, ssztypes.SszCompatibleUnionType:
 		return ctx.marshalUnion(desc, varName, typePath, indent)
 
 	case ssztypes.SszCustomType:
@@ -960,6 +960,14 @@ func (ctx *encoderContext) marshalBitlist(desc *ssztypes.TypeDescriptor, varName
 func (ctx *encoderContext) marshalUnion(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int) error {
 	ctx.appendCode(indent, "enc.EncodeUint8(%s.Variant)\n", varName)
 	ctx.appendCode(indent, "switch %s.Variant {\n", varName)
+
+	if desc.SszTypeFlags&ssztypes.SszTypeFlagHasNoneVariant != 0 {
+		// The None option carries no value and serializes as the bare selector.
+		ctx.appendCode(indent, "case 0:\n")
+		ctx.appendCode(indent, "\tif %s.Data != nil {\n", varName)
+		ctx.appendCode(indent, "\t\treturn %s\n", typePath.getErrorWith(errCodeUnionTypeMismatch))
+		ctx.appendCode(indent, "\t}\n")
+	}
 
 	variants := make([]int, 0, len(desc.UnionVariants))
 	for variant := range desc.UnionVariants {

--- a/codegen/gen_hashtreeroot.go
+++ b/codegen/gen_hashtreeroot.go
@@ -344,7 +344,7 @@ func (ctx *hashTreeRootContext) hashType(desc *ssztypes.TypeDescriptor, varName 
 	case ssztypes.SszBitlistType, ssztypes.SszProgressiveBitlistType:
 		return ctx.hashBitlist(desc, varName, typePath, indent)
 
-	case ssztypes.SszCompatibleUnionType:
+	case ssztypes.SszUnionType, ssztypes.SszCompatibleUnionType:
 		return ctx.hashUnion(desc, varName, typePath, indent)
 
 	case ssztypes.SszCustomType:
@@ -935,6 +935,16 @@ func (ctx *hashTreeRootContext) hashBitlist(desc *ssztypes.TypeDescriptor, varNa
 func (ctx *hashTreeRootContext) hashUnion(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int) error {
 	ctx.appendCode(indent, "idx := hh.StartTree(sszutils.TreeTypeNone)\n")
 	ctx.appendCode(indent, "switch %s.Variant {\n", varName)
+
+	if desc.SszTypeFlags&ssztypes.SszTypeFlagHasNoneVariant != 0 {
+		// The None option contributes a zero chunk as its data root:
+		// mix_in_selector(Bytes32(), 0).
+		ctx.appendCode(indent, "case 0:\n")
+		ctx.appendCode(indent, "\tif %s.Data != nil {\n", varName)
+		ctx.appendCode(indent, "\t\treturn %s\n", typePath.getErrorWith(errCodeUnionTypeMismatch))
+		ctx.appendCode(indent, "\t}\n")
+		ctx.appendCode(indent, "\thh.PutBytes(sszutils.ZeroBytes()[:32])\n")
+	}
 
 	variants := make([]int, 0, len(desc.UnionVariants))
 	for variant := range desc.UnionVariants {

--- a/codegen/gen_marshal.go
+++ b/codegen/gen_marshal.go
@@ -332,7 +332,7 @@ func (ctx *marshalContext) marshalType(desc *ssztypes.TypeDescriptor, varName st
 	case ssztypes.SszBitlistType, ssztypes.SszProgressiveBitlistType:
 		return ctx.marshalBitlist(desc, varName, typePath, indent)
 
-	case ssztypes.SszCompatibleUnionType:
+	case ssztypes.SszUnionType, ssztypes.SszCompatibleUnionType:
 		return ctx.marshalUnion(desc, varName, typePath, indent)
 
 	case ssztypes.SszCustomType:
@@ -926,6 +926,14 @@ func (ctx *marshalContext) marshalBitlist(desc *ssztypes.TypeDescriptor, varName
 func (ctx *marshalContext) marshalUnion(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int) error {
 	ctx.appendCode(indent, "dst = append(dst, %s.Variant)\n", varName)
 	ctx.appendCode(indent, "switch %s.Variant {\n", varName)
+
+	if desc.SszTypeFlags&ssztypes.SszTypeFlagHasNoneVariant != 0 {
+		// The None option carries no value and serializes as the bare selector.
+		ctx.appendCode(indent, "case 0:\n")
+		ctx.appendCode(indent, "\tif %s.Data != nil {\n", varName)
+		ctx.appendCode(indent, "\t\treturn nil, %s\n", typePath.getErrorWith(errCodeUnionTypeMismatch))
+		ctx.appendCode(indent, "\t}\n")
+	}
 
 	variants := make([]int, 0, len(desc.UnionVariants))
 	for variant := range desc.UnionVariants {

--- a/codegen/gen_size.go
+++ b/codegen/gen_size.go
@@ -635,6 +635,12 @@ func (ctx *sizeContext) sizeUnion(desc *ssztypes.TypeDescriptor, varName, sizeVa
 		}
 	}
 
+	// An unknown selector cannot be sized; report 0 like the mismatched-data
+	// branches above instead of returning a plausible-looking partial size for
+	// a value the marshalers reject.
+	ctx.appendCode(indent, "default:\n")
+	ctx.appendCode(indent, "\treturn 0\n")
+
 	ctx.appendCode(indent, "}\n")
 
 	return nil

--- a/codegen/gen_size.go
+++ b/codegen/gen_size.go
@@ -294,7 +294,7 @@ func (ctx *sizeContext) sizeType(desc *ssztypes.TypeDescriptor, varName, sizeVar
 	case ssztypes.SszListType, ssztypes.SszBitlistType, ssztypes.SszProgressiveListType, ssztypes.SszProgressiveBitlistType:
 		return ctx.sizeList(desc, varName, sizeVar, indent)
 
-	case ssztypes.SszCompatibleUnionType:
+	case ssztypes.SszUnionType, ssztypes.SszCompatibleUnionType:
 		return ctx.sizeUnion(desc, varName, sizeVar, indent)
 
 	case ssztypes.SszCustomType:
@@ -609,6 +609,11 @@ func (ctx *sizeContext) sizeUnion(desc *ssztypes.TypeDescriptor, varName, sizeVa
 
 	ctx.appendCode(indent, "%s += 1 // Union selector\n", sizeVar)
 	ctx.appendCode(indent, "switch %s.Variant {\n", varName)
+
+	if desc.SszTypeFlags&ssztypes.SszTypeFlagHasNoneVariant != 0 {
+		// The None option carries no value beyond the selector byte.
+		ctx.appendCode(indent, "case 0:\n")
+	}
 
 	variants := make([]int, 0, len(desc.UnionVariants))
 	for variant := range desc.UnionVariants {

--- a/codegen/gen_unmarshal.go
+++ b/codegen/gen_unmarshal.go
@@ -405,7 +405,7 @@ func (ctx *unmarshalContext) unmarshalType(desc *ssztypes.TypeDescriptor, varNam
 	case ssztypes.SszBitlistType, ssztypes.SszProgressiveBitlistType:
 		return ctx.unmarshalBitlist(desc, varName, typePath, indent)
 
-	case ssztypes.SszCompatibleUnionType:
+	case ssztypes.SszUnionType, ssztypes.SszCompatibleUnionType:
 		return ctx.unmarshalUnion(desc, varName, typePath, indent)
 
 	case ssztypes.SszCustomType:
@@ -1239,6 +1239,14 @@ func (ctx *unmarshalContext) unmarshalUnion(desc *ssztypes.TypeDescriptor, varNa
 	ctx.appendCode(indent, "selector := buf[0]\n")
 	ctx.appendCode(indent, "%s.Variant = selector\n", varName)
 	ctx.appendCode(indent, "switch selector {\n")
+
+	if desc.SszTypeFlags&ssztypes.SszTypeFlagHasNoneVariant != 0 {
+		// The None option carries no value, so its region is the bare selector byte.
+		ctx.appendCode(indent, "case 0:\n")
+		trailErr := typePath.getErrorWith("sszutils.ErrTrailingDataFn(len(buf) - 1)")
+		ctx.appendCode(indent, "\tif len(buf) > 1 {\n\t\treturn %s\n\t}\n", trailErr)
+		ctx.appendCode(indent, "\t%s.Data = nil\n", varName)
+	}
 
 	variants := make([]int, 0, len(desc.UnionVariants))
 	for variant := range desc.UnionVariants {

--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -262,14 +262,14 @@ func (cg *CodeGenerator) analyzeTypes() error {
 // validateTopLevelType rejects top-level types that cannot receive generated
 // methods. Both work fine as struct fields, but not as standalone -types
 // entries:
-//   - a CompatibleUnion / TypeWrapper: these are generic library types nameable
-//     only via a transparent alias, so a method receiver would resolve to the
-//     foreign generic type rather than a local named type.
+//   - a Union / CompatibleUnion / TypeWrapper: these are generic library types
+//     nameable only via a transparent alias, so a method receiver would resolve
+//     to the foreign generic type rather than a local named type.
 //   - a named pointer type (type T *U): methods cannot be declared on a type
 //     whose underlying type is a pointer.
 func validateTopLevelType(t *CodeGeneratorTypeOptions, desc *ssztypes.TypeDescriptor, typeName string) error {
-	if desc.SszType == ssztypes.SszCompatibleUnionType || desc.SszType == ssztypes.SszTypeWrapperType {
-		return fmt.Errorf("cannot generate SSZ methods for top-level %s: a CompatibleUnion/TypeWrapper is nameable only via a type alias and cannot receive methods; use it as a struct field instead", typeName)
+	if desc.SszType == ssztypes.SszUnionType || desc.SszType == ssztypes.SszCompatibleUnionType || desc.SszType == ssztypes.SszTypeWrapperType {
+		return fmt.Errorf("cannot generate SSZ methods for top-level %s: a Union/CompatibleUnion/TypeWrapper is nameable only via a type alias and cannot receive methods; use it as a struct field instead", typeName)
 	}
 
 	if t.ReflectType != nil {
@@ -302,7 +302,7 @@ func isShallowDelegatedDescriptor(desc *ssztypes.TypeDescriptor) bool {
 	case ssztypes.SszVectorType, ssztypes.SszListType, ssztypes.SszBitvectorType,
 		ssztypes.SszBitlistType, ssztypes.SszProgressiveListType, ssztypes.SszProgressiveBitlistType:
 		return desc.ElemDesc == nil
-	case ssztypes.SszCompatibleUnionType:
+	case ssztypes.SszUnionType, ssztypes.SszCompatibleUnionType:
 		return desc.UnionVariants == nil
 	case ssztypes.SszUnspecifiedType:
 		// The go/types parser gate returns shallow descriptors before type

--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -53,11 +53,17 @@ func (cg *CodeGenerator) analyzeTypes() error {
 	getTypeName := func(t *CodeGeneratorTypeOptions) (string, string, string) {
 		var typeName, typePkgPath, typePkgName string
 		if t.ReflectType != nil {
-			typeName = t.ReflectType.Name()
-			typePkgPath = t.ReflectType.PkgPath()
-			if typePkgPath == "" && t.ReflectType.Kind() == reflect.Ptr {
-				typePkgPath = t.ReflectType.Elem().PkgPath()
+			// An unnamed pointer type carries no name of its own; the named type is
+			// the element. Without the dereference every pointer-passed type would
+			// share the empty name, colliding in name-keyed bookkeeping (e.g. the
+			// duplicate-entry check) and producing nameless error messages. Named
+			// pointer types keep their own identity.
+			namedType := t.ReflectType
+			if namedType.Name() == "" && namedType.Kind() == reflect.Pointer {
+				namedType = namedType.Elem()
 			}
+			typeName = namedType.Name()
+			typePkgPath = namedType.PkgPath()
 			// Look up the actual package name from the import path
 			if typePkgPath != "" {
 				if pkg, err := build.Import(typePkgPath, "", build.FindOnly); err == nil {

--- a/codegen/parser.go
+++ b/codegen/parser.go
@@ -1301,7 +1301,7 @@ func (p *Parser) buildContainerDescriptor(desc *ssztypes.TypeDescriptor, dataStr
 	// field keeps its (strictly increasing) index; an untagged field takes the
 	// previous field's index + 1. With no tags this yields the default 0, 1, 2, ...
 	// sequence, so a progressive container never falls back to all-zero indices
-	// (a 1-bit active_fields bitvector for N field roots is illegal per EIP-7495).
+	// (a 1-bit active_fields bitvector for N field roots is illegal per EIP-8016).
 	if hasAnyIndexTag || desc.SszType == ssztypes.SszProgressiveContainerType {
 		nextIndex := uint16(0)
 		for i := range fields {
@@ -1592,7 +1592,7 @@ func (p *Parser) buildCompatibleUnionDescriptor(desc *ssztypes.TypeDescriptor, d
 	}
 
 	// An ssz-index tag assigns an explicit selector value, e.g. 1-based
-	// selectors for EIP-7495 conformant unions. Mixing tagged and untagged
+	// selectors for EIP-8016 conformant unions. Mixing tagged and untagged
 	// variants would silently renumber the untagged ones, so require
 	// all-or-none up front.
 	indexTagCount := 0
@@ -1605,17 +1605,27 @@ func (p *Parser) buildCompatibleUnionDescriptor(desc *ssztypes.TypeDescriptor, d
 		return fmt.Errorf("union descriptor mixes fields with and without ssz-index tags (all variants must carry one when any does)")
 	}
 
+	// EIP-8016 restricts union selectors to 1..127: 0 and the range above 127
+	// are reserved. Default numbering follows field order starting at 1, so the
+	// descriptor can hold at most 127 variants.
+	if schemaDescriptorStruct.NumFields() > 127 {
+		return fmt.Errorf("union descriptor has %d variants, but selectors are limited to 1..127", schemaDescriptorStruct.NumFields())
+	}
+
 	// Build union variants iterating over schema (determines SSZ layout)
 	variantInfo := make(map[uint8]*ssztypes.TypeDescriptor)
 
 	for i := 0; i < schemaDescriptorStruct.NumFields(); i++ {
 		schemaField := schemaDescriptorStruct.Field(i)
-		variantIndex := uint8(i) // Field order determines the default variant selector
+		variantIndex := uint8(i) + 1 // Field order determines the default variant selector, starting at 1
 
 		if indexStr := p.extractSszIndex(schemaDescriptorStruct.Tag(i)); indexStr != "" {
 			idx, err := strconv.ParseUint(indexStr, 10, 8)
 			if err != nil {
 				return fmt.Errorf("invalid ssz-index for union variant %s: %v", schemaField.Name(), indexStr)
+			}
+			if idx < 1 || idx > 127 {
+				return fmt.Errorf("union selector %d for field %s is outside the valid range 1..127", idx, schemaField.Name())
 			}
 			variantIndex = uint8(idx)
 		}

--- a/codegen/parser.go
+++ b/codegen/parser.go
@@ -686,6 +686,8 @@ func (p *Parser) buildTypeDescriptor(dataType, schemaType types.Type, typeHints 
 				sszType = ssztypes.SszBitlistType
 			case pkgPath == "github.com/pk910/dynamic-ssz" && typeName == "CompatibleUnion":
 				sszType = ssztypes.SszCompatibleUnionType
+			case pkgPath == "github.com/pk910/dynamic-ssz" && typeName == "Union":
+				sszType = ssztypes.SszUnionType
 			case pkgPath == "github.com/pk910/dynamic-ssz" && typeName == "TypeWrapper":
 				sszType = ssztypes.SszTypeWrapperType
 			}
@@ -904,6 +906,14 @@ func (p *Parser) buildTypeDescriptor(dataType, schemaType types.Type, typeHints 
 			return nil, fmt.Errorf("data CompatibleUnion must be a named type")
 		}
 		err := p.buildCompatibleUnionDescriptor(desc, dataNamedType, schemaNamedType)
+		if err != nil {
+			return nil, err
+		}
+	case ssztypes.SszUnionType:
+		if dataNamedType == nil {
+			return nil, fmt.Errorf("data Union must be a named type")
+		}
+		err := p.buildUnionDescriptor(desc, dataNamedType, schemaNamedType)
 		if err != nil {
 			return nil, err
 		}
@@ -1664,6 +1674,113 @@ func (p *Parser) buildCompatibleUnionDescriptor(desc *ssztypes.TypeDescriptor, d
 
 	if len(variantInfo) == 0 {
 		return fmt.Errorf("union descriptor struct has no fields")
+	}
+
+	desc.UnionVariants = variantInfo
+	desc.SszTypeFlags |= ssztypes.SszTypeFlagIsDynamic
+	desc.Size = 0
+
+	return nil
+}
+
+// isNoneMarkerType reports whether a descriptor field type is the classic
+// union None marker (dynssz.None).
+func (p *Parser) isNoneMarkerType(typ types.Type) bool {
+	named, ok := types.Unalias(typ).(*types.Named)
+	if !ok || named.Obj() == nil || named.Obj().Pkg() == nil {
+		return false
+	}
+	return named.Obj().Name() == "None" && named.Obj().Pkg().Path() == "github.com/pk910/dynamic-ssz"
+}
+
+// buildUnionDescriptor builds a descriptor for classic spec unions. Selectors
+// are the descriptor struct's 0-based field positions per the SSZ spec: the
+// None marker is only legal as the first field (making selector 0 the empty
+// option, with at least one further variant), selectors above 127 are
+// reserved, and positional numbering leaves no room for ssz-index tags.
+func (p *Parser) buildUnionDescriptor(desc *ssztypes.TypeDescriptor, dataNamed, schemaNamed *types.Named) error {
+	schemaTypeArgs := schemaNamed.TypeArgs()
+	if schemaTypeArgs == nil || schemaTypeArgs.Len() != 1 {
+		return fmt.Errorf("union must have exactly 1 type argument")
+	}
+
+	schemaDescriptorType := schemaTypeArgs.At(0)
+	schemaDescriptorStruct, ok := schemaDescriptorType.Underlying().(*types.Struct)
+	if !ok {
+		return fmt.Errorf("union descriptor must be a struct, got %T", schemaDescriptorType.Underlying())
+	}
+
+	isViewDescriptor := dataNamed != schemaNamed
+
+	var dataVariantMap map[string]types.Type
+	if isViewDescriptor {
+		dataTypeArgs := dataNamed.TypeArgs()
+		if dataTypeArgs == nil || dataTypeArgs.Len() != 1 {
+			return fmt.Errorf("data Union must have exactly 1 type argument")
+		}
+		dataDescriptorStruct, ok := dataTypeArgs.At(0).Underlying().(*types.Struct)
+		if !ok {
+			return fmt.Errorf("data Union descriptor must be a struct, got %T", dataTypeArgs.At(0).Underlying())
+		}
+		dataVariantMap = make(map[string]types.Type, dataDescriptorStruct.NumFields())
+		for i := 0; i < dataDescriptorStruct.NumFields(); i++ {
+			field := dataDescriptorStruct.Field(i)
+			dataVariantMap[field.Name()] = field.Type()
+		}
+	}
+
+	numFields := schemaDescriptorStruct.NumFields()
+	if numFields == 0 {
+		return fmt.Errorf("union descriptor struct has no fields")
+	}
+	// Selectors above 127 are reserved, so positions 0..127 bound the count.
+	if numFields > 128 {
+		return fmt.Errorf("union descriptor has %d variants, but selectors are limited to 0..127", numFields)
+	}
+
+	variantInfo := make(map[uint8]*ssztypes.TypeDescriptor, numFields)
+
+	for i := 0; i < numFields; i++ {
+		schemaField := schemaDescriptorStruct.Field(i)
+
+		if p.extractSszIndex(schemaDescriptorStruct.Tag(i)) != "" {
+			return fmt.Errorf("union selectors are positional; ssz-index tag on field %s is not allowed", schemaField.Name())
+		}
+
+		if p.isNoneMarkerType(schemaField.Type()) {
+			if i != 0 {
+				return fmt.Errorf("the None option is only legal as the first union variant (field %s is at position %d)", schemaField.Name(), i)
+			}
+			if numFields < 2 {
+				return fmt.Errorf("a union declaring None must offer at least one further variant")
+			}
+			desc.SszTypeFlags |= ssztypes.SszTypeFlagHasNoneVariant
+			continue
+		}
+
+		typeHints, sizeHints, maxSizeHints, err := p.parseFieldTags(schemaDescriptorStruct.Tag(i))
+		if err != nil {
+			return fmt.Errorf("failed to parse union variant field %s tags: %v", schemaField.Name(), err)
+		}
+
+		schemaVariantType := schemaField.Type()
+		var dataVariantType types.Type
+		if isViewDescriptor {
+			var ok bool
+			dataVariantType, ok = dataVariantMap[schemaField.Name()]
+			if !ok {
+				return fmt.Errorf("data union missing variant %q defined in schema", schemaField.Name())
+			}
+		} else {
+			dataVariantType = schemaVariantType
+		}
+
+		variantDesc, err := p.buildTypeDescriptor(dataVariantType, schemaVariantType, typeHints, sizeHints, maxSizeHints)
+		if err != nil {
+			return fmt.Errorf("failed to build union variant %d descriptor: %v", i, err)
+		}
+
+		variantInfo[uint8(i)] = variantDesc
 	}
 
 	desc.UnionVariants = variantInfo

--- a/codegen/parser.go
+++ b/codegen/parser.go
@@ -22,6 +22,7 @@ const (
 	typeNameString    = "string"
 	typeNameTime      = "Time"
 	pkgPathTime       = "time"
+	pkgPathDynssz     = "github.com/pk910/dynamic-ssz"
 )
 
 var (
@@ -684,11 +685,11 @@ func (p *Parser) buildTypeDescriptor(dataType, schemaType types.Type, typeHints 
 				sszType = ssztypes.SszBitlistType
 			case pkgPath == "github.com/OffchainLabs/go-bitfield" && typeName == "Bitlist":
 				sszType = ssztypes.SszBitlistType
-			case pkgPath == "github.com/pk910/dynamic-ssz" && typeName == "CompatibleUnion":
+			case pkgPath == pkgPathDynssz && typeName == "CompatibleUnion":
 				sszType = ssztypes.SszCompatibleUnionType
-			case pkgPath == "github.com/pk910/dynamic-ssz" && typeName == "Union":
+			case pkgPath == pkgPathDynssz && typeName == "Union":
 				sszType = ssztypes.SszUnionType
-			case pkgPath == "github.com/pk910/dynamic-ssz" && typeName == "TypeWrapper":
+			case pkgPath == pkgPathDynssz && typeName == "TypeWrapper":
 				sszType = ssztypes.SszTypeWrapperType
 			}
 		}
@@ -1690,7 +1691,7 @@ func (p *Parser) isNoneMarkerType(typ types.Type) bool {
 	if !ok || named.Obj() == nil || named.Obj().Pkg() == nil {
 		return false
 	}
-	return named.Obj().Name() == "None" && named.Obj().Pkg().Path() == "github.com/pk910/dynamic-ssz"
+	return named.Obj().Name() == "None" && named.Obj().Pkg().Path() == pkgPathDynssz
 }
 
 // buildUnionDescriptor builds a descriptor for classic spec unions. Selectors

--- a/codegen/parser_test.go
+++ b/codegen/parser_test.go
@@ -1773,8 +1773,8 @@ func TestBuildCompatibleUnionDescriptor(t *testing.T) {
 			t.Errorf("Expected 1 union variant, got %d", len(desc.UnionVariants))
 		}
 		// Variant should be a list type
-		if desc.UnionVariants[0].SszType != ssztypes.SszListType {
-			t.Errorf("Expected SszListType for variant 0, got %v", desc.UnionVariants[0].SszType)
+		if desc.UnionVariants[1].SszType != ssztypes.SszListType {
+			t.Errorf("Expected SszListType for variant 1, got %v", desc.UnionVariants[1].SszType)
 		}
 	})
 }
@@ -2862,5 +2862,42 @@ func TestZeroSizeSliceRejected(t *testing.T) {
 	}
 	if _, err := parser.buildTypeDescriptor(byteSlice, byteSlice, nil, []ssztypes.SszSizeHint{{Size: 0, Expr: "SPEC_X"}}, nil); err != nil {
 		t.Errorf("unexpected error for expression size hint: %v", err)
+	}
+}
+
+// Union selectors assigned via ssz-index must stay inside 1..127; the parser
+// rejects tags outside that range like the reflection type cache does.
+func TestParserUnionSelectorRangeEnforced(t *testing.T) {
+	newUnion := func(tag string) *types.Named {
+		pkg := types.NewPackage("github.com/pk910/dynamic-ssz", "dynssz")
+		typeParam := types.NewTypeParam(types.NewTypeName(token.NoPos, nil, "T", nil), types.NewInterfaceType(nil, nil))
+		unionObj := types.NewTypeName(token.NoPos, pkg, "CompatibleUnion", nil)
+		unionStruct := types.NewStruct([]*types.Var{
+			types.NewField(token.NoPos, nil, "Variant", types.Typ[types.Uint8], false),
+			types.NewField(token.NoPos, nil, "Data", types.NewInterfaceType(nil, nil), false),
+		}, []string{"", ""})
+		unionType := types.NewNamed(unionObj, unionStruct, nil)
+		unionType.SetTypeParams([]*types.TypeParam{typeParam})
+
+		descriptor := types.NewStruct([]*types.Var{
+			types.NewField(token.NoPos, nil, "F1", types.Typ[types.Uint32], false),
+		}, []string{tag})
+		inst, err := types.Instantiate(nil, unionType, []types.Type{descriptor}, false)
+		if err != nil {
+			t.Fatalf("instantiate: %v", err)
+		}
+		named, ok := inst.(*types.Named)
+		if !ok {
+			t.Fatalf("expected *types.Named, got %T", inst)
+		}
+		return named
+	}
+
+	for _, tag := range []string{`ssz-index:"0"`, `ssz-index:"128"`} {
+		named := newUnion(tag)
+		desc := &ssztypes.TypeDescriptor{SszType: ssztypes.SszCompatibleUnionType}
+		if err := NewParser().buildCompatibleUnionDescriptor(desc, named, named); err == nil {
+			t.Errorf("selector tag %s should be rejected", tag)
+		}
 	}
 }

--- a/codegen/parser_test.go
+++ b/codegen/parser_test.go
@@ -1779,6 +1779,126 @@ func TestBuildCompatibleUnionDescriptor(t *testing.T) {
 	})
 }
 
+func TestBuildUnionDescriptor(t *testing.T) {
+	parser := NewParser()
+
+	pkg := types.NewPackage("github.com/pk910/dynamic-ssz", "dynssz")
+
+	// The dynssz.None marker as a go/types named empty struct.
+	noneObj := types.NewTypeName(token.NoPos, pkg, "None", nil)
+	noneType := types.NewNamed(noneObj, types.NewStruct(nil, nil), nil)
+
+	// instantiateUnion builds dynssz.Union[descriptorStruct] as a go/types value.
+	instantiateUnion := func(t *testing.T, descriptorType types.Type) *types.Named {
+		t.Helper()
+		typeParam := types.NewTypeParam(types.NewTypeName(token.NoPos, nil, "T", nil), types.NewInterfaceType(nil, nil))
+		unionObj := types.NewTypeName(token.NoPos, pkg, "Union", nil)
+		variantField := types.NewVar(token.NoPos, nil, "Variant", types.Typ[types.Uint8])
+		dataField := types.NewVar(token.NoPos, nil, "Data", types.NewInterfaceType(nil, nil))
+		unionStruct := types.NewStruct([]*types.Var{variantField, dataField}, []string{"", ""})
+		unionType := types.NewNamed(unionObj, unionStruct, nil)
+		unionType.SetTypeParams([]*types.TypeParam{typeParam})
+		instantiated, err := types.Instantiate(nil, unionType, []types.Type{descriptorType}, false)
+		if err != nil {
+			t.Fatalf("Failed to instantiate Union: %v", err)
+		}
+		namedInst, ok := instantiated.(*types.Named)
+		if !ok {
+			t.Fatalf("Expected *types.Named, got %T", instantiated)
+		}
+		return namedInst
+	}
+
+	buildDesc := func(t *testing.T, fields []*types.Var, tags []string) (*ssztypes.TypeDescriptor, error) {
+		t.Helper()
+		namedInst := instantiateUnion(t, types.NewStruct(fields, tags))
+		desc := &ssztypes.TypeDescriptor{
+			SszType: ssztypes.SszUnionType,
+		}
+		return desc, parser.buildUnionDescriptor(desc, namedInst, namedInst)
+	}
+
+	t.Run("NoneFirstDeclaresEmptyOption", func(t *testing.T) {
+		desc, err := buildDesc(t, []*types.Var{
+			types.NewVar(token.NoPos, nil, "N", noneType),
+			types.NewVar(token.NoPos, nil, "F1", types.Typ[types.Uint32]),
+			types.NewVar(token.NoPos, nil, "F2", types.Typ[types.Uint64]),
+		}, []string{"", "", ""})
+		if err != nil {
+			t.Fatalf("Failed to build Union descriptor: %v", err)
+		}
+		if desc.SszTypeFlags&ssztypes.SszTypeFlagHasNoneVariant == 0 {
+			t.Error("Expected HasNoneVariant flag to be set")
+		}
+		if len(desc.UnionVariants) != 2 {
+			t.Errorf("Expected 2 union variants, got %d", len(desc.UnionVariants))
+		}
+		if _, ok := desc.UnionVariants[0]; ok {
+			t.Error("The None selector must not carry a variant descriptor")
+		}
+		if desc.UnionVariants[1].SszType != ssztypes.SszUint32Type {
+			t.Errorf("Expected SszUint32Type for variant 1, got %v", desc.UnionVariants[1].SszType)
+		}
+		if desc.SszTypeFlags&ssztypes.SszTypeFlagIsDynamic == 0 {
+			t.Error("Expected dynamic flag to be set")
+		}
+	})
+
+	t.Run("PositionalSelectorsWithoutNone", func(t *testing.T) {
+		desc, err := buildDesc(t, []*types.Var{
+			types.NewVar(token.NoPos, nil, "F1", types.Typ[types.Uint32]),
+			types.NewVar(token.NoPos, nil, "F2", types.Typ[types.Uint64]),
+		}, []string{"", ""})
+		if err != nil {
+			t.Fatalf("Failed to build Union descriptor: %v", err)
+		}
+		if desc.SszTypeFlags&ssztypes.SszTypeFlagHasNoneVariant != 0 {
+			t.Error("HasNoneVariant must not be set without a None marker")
+		}
+		if len(desc.UnionVariants) != 2 {
+			t.Errorf("Expected 2 union variants, got %d", len(desc.UnionVariants))
+		}
+		if desc.UnionVariants[0].SszType != ssztypes.SszUint32Type {
+			t.Errorf("Expected SszUint32Type for variant 0, got %v", desc.UnionVariants[0].SszType)
+		}
+	})
+
+	t.Run("NoneNotFirstRejected", func(t *testing.T) {
+		_, err := buildDesc(t, []*types.Var{
+			types.NewVar(token.NoPos, nil, "F1", types.Typ[types.Uint32]),
+			types.NewVar(token.NoPos, nil, "N", noneType),
+		}, []string{"", ""})
+		if err == nil || !strings.Contains(err.Error(), "None") {
+			t.Errorf("Expected None placement error, got: %v", err)
+		}
+	})
+
+	t.Run("LoneNoneRejected", func(t *testing.T) {
+		_, err := buildDesc(t, []*types.Var{
+			types.NewVar(token.NoPos, nil, "N", noneType),
+		}, []string{""})
+		if err == nil || !strings.Contains(err.Error(), "None") {
+			t.Errorf("Expected lone-None error, got: %v", err)
+		}
+	})
+
+	t.Run("SszIndexTagRejected", func(t *testing.T) {
+		_, err := buildDesc(t, []*types.Var{
+			types.NewVar(token.NoPos, nil, "F1", types.Typ[types.Uint32]),
+		}, []string{`ssz-index:"1"`})
+		if err == nil || !strings.Contains(err.Error(), "ssz-index") {
+			t.Errorf("Expected ssz-index rejection, got: %v", err)
+		}
+	})
+
+	t.Run("EmptyDescriptorRejected", func(t *testing.T) {
+		_, err := buildDesc(t, nil, nil)
+		if err == nil || !strings.Contains(err.Error(), "no fields") {
+			t.Errorf("Expected 'no fields' error, got: %v", err)
+		}
+	})
+}
+
 func TestBuildTypeWrapperDescriptor(t *testing.T) {
 	parser := NewParser()
 

--- a/codegen/tests/codegen_test.go
+++ b/codegen/tests/codegen_test.go
@@ -57,7 +57,7 @@ var testMatrix = []TestPayload{
 		Name:    "ProgressiveTypes",
 		Payload: ProgressiveTypes_Payload,
 		Specs:   map[string]any{},
-		Hash:    "317f412cd2d042f367c4f2fb6447828ef9524396428eb2ed0837524bcc70433c",
+		Hash:    "38a69cbd79a59c60505dac63c0330a57737f891a352cda1acd879cd778ca8cff",
 	},
 	{
 		// progressive container auto-detected from ssz-index tags alone
@@ -1211,11 +1211,11 @@ func TestCodegenPointerAndPaddingShapes(t *testing.T) {
 	bl := [][]byte{{0x03}, {0x05}}
 
 	uv := UnionSamePkgVariant{}
-	uv.U.Variant = 1
+	uv.U.Variant = 2
 	uv.U.Data = SimpleTypes1_C1{F1: 9}
 
 	wu := WrapUnionField{}
-	wu.W.Data.Variant = 0
+	wu.W.Data.Variant = 1
 	wu.W.Data.Data = uint32(42)
 
 	cases := []struct {
@@ -1330,5 +1330,30 @@ func TestCodegenExcludedFields(t *testing.T) {
 	}
 	if back.A != 1 || back.B != 2 || len(back.L) != 2 {
 		t.Errorf("included fields wrong after roundtrip: %+v", back)
+	}
+}
+
+// The generated sizer cannot return an error, so an unknown selector reports
+// size 0 (matching its mismatched-data convention) instead of a
+// plausible-looking partial size; the marshalers reject the value outright.
+func TestCodegenUnionInvalidSelectorSize(t *testing.T) {
+	ds := dynssz.NewDynSsz(nil)
+
+	v := UnionDynVariant{}
+	v.U.Variant = 99
+	v.U.Data = uint32(1)
+
+	size, err := ds.SizeSSZ(&v)
+	if err != nil {
+		t.Fatalf("size: %v", err)
+	}
+	// The whole value reports size 0: an un-sizable union aborts the sizer,
+	// matching the mismatched-data convention.
+	if size != 0 {
+		t.Errorf("expected size 0 for an un-sizable union, got %d", size)
+	}
+
+	if _, err := ds.MarshalSSZ(&v); err == nil {
+		t.Fatal("marshal should reject the invalid selector")
 	}
 }

--- a/codegen/tests/codegen_test.go
+++ b/codegen/tests/codegen_test.go
@@ -1108,6 +1108,94 @@ func TestCodegenUnionTaggedSelectors(t *testing.T) {
 	}
 }
 
+// Classic union wire semantics through the generated code: the None option
+// round-trips as the bare selector byte, trailing bytes after it and
+// out-of-range selectors are rejected, and a truncated union region fails
+// cleanly on both decode paths.
+func TestCodegenClassicUnionWireFormat(t *testing.T) {
+	ds := dynssz.NewDynSsz(nil)
+
+	testCodegenPayloadByReflection(t, ClassicUnionDynVariant_Payload, nil)
+
+	// The zero-valued union is the None option: its region is the bare
+	// selector byte 0. Layout: offsets (8) + U region + L region.
+	none := ClassicUnionDynVariant{L: []byte{7}}
+	enc, err := ds.MarshalSSZ(&none)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !bytes.Equal(enc, []byte{8, 0, 0, 0, 9, 0, 0, 0, 0, 7}) {
+		t.Fatalf("unexpected None encoding: %x", enc)
+	}
+
+	var back ClassicUnionDynVariant
+	if err := ds.UnmarshalSSZ(&back, enc); err != nil {
+		t.Fatalf("buffer unmarshal: %v", err)
+	}
+	if back.U.Variant != 0 || back.U.Data != nil || !bytes.Equal(back.L, []byte{7}) {
+		t.Fatalf("buffer None roundtrip mismatch: %+v", back)
+	}
+	var back2 ClassicUnionDynVariant
+	if err := ds.UnmarshalSSZReader(&back2, bytes.NewReader(enc), len(enc)); err != nil {
+		t.Fatalf("stream unmarshal: %v", err)
+	}
+	if back2.U.Variant != 0 || back2.U.Data != nil {
+		t.Fatalf("stream None roundtrip mismatch: %+v", back2)
+	}
+
+	reject := func(name string, in []byte) {
+		t.Run(name, func(t *testing.T) {
+			var a ClassicUnionDynVariant
+			if err := ds.UnmarshalSSZ(&a, in); err == nil {
+				t.Errorf("buffer UnmarshalSSZ accepted %x", in)
+			}
+			var b ClassicUnionDynVariant
+			if err := ds.UnmarshalSSZReader(&b, bytes.NewReader(in), len(in)); err == nil {
+				t.Errorf("stream UnmarshalSSZReader accepted %x", in)
+			}
+		})
+	}
+
+	// The None region must be exactly the selector byte.
+	reject("trailingAfterNone", []byte{8, 0, 0, 0, 10, 0, 0, 0, 0, 99, 7})
+	// A selector without a declared variant is rejected.
+	reject("outOfRangeSelector", []byte{8, 0, 0, 0, 9, 0, 0, 0, 9, 7})
+	// An empty union region has no selector byte; the stream decoder must not
+	// read it from the next region.
+	reject("emptyUnionRegion", []byte{8, 0, 0, 0, 8, 0, 0, 0, 7})
+}
+
+// A generated decoder must allocate a classic union's pointer variant before
+// writing through it; decoding valid bytes must round-trip rather than
+// nil-deref.
+func TestCodegenClassicUnionPtrVariant(t *testing.T) {
+	testCodegenPayloadByReflection(t, ClassicUnionPtrVariant_Payload, nil)
+
+	ds := dynssz.NewDynSsz(nil)
+	enc, err := ds.MarshalSSZ(&ClassicUnionPtrVariant_Payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var buf ClassicUnionPtrVariant
+	if err := ds.UnmarshalSSZ(&buf, enc); err != nil {
+		t.Fatalf("buffer unmarshal: %v", err)
+	}
+	uv, ok := buf.U.Data.(*uint64)
+	if !ok || uv == nil || *uv != ptrUnionVal {
+		t.Fatalf("buffer roundtrip mismatch: %+v", buf)
+	}
+
+	var strm ClassicUnionPtrVariant
+	if err := ds.UnmarshalSSZReader(&strm, bytes.NewReader(enc), len(enc)); err != nil {
+		t.Fatalf("stream unmarshal: %v", err)
+	}
+	sv, ok := strm.U.Data.(*uint64)
+	if !ok || sv == nil || *sv != ptrUnionVal {
+		t.Fatalf("stream roundtrip mismatch: %+v", strm)
+	}
+}
+
 // Top-level standalone named composite types: every generated method receives
 // the pointer receiver directly and must dereference it correctly on all
 // paths (marshal/unmarshal/size/hash, buffer and stream).
@@ -1224,9 +1312,17 @@ func TestCodegenPointerAndPaddingShapes(t *testing.T) {
 	uv.U.Variant = 2
 	uv.U.Data = SimpleTypes1_C1{F1: 9}
 
+	cuv := ClassicUnionSamePkgVariant{}
+	cuv.U.Variant = 1
+	cuv.U.Data = SimpleTypes1_C1{F1: 9}
+
 	wu := WrapUnionField{}
 	wu.W.Data.Variant = 1
 	wu.W.Data.Data = uint32(42)
+
+	wcu := WrapClassicUnionField{}
+	wcu.W.Data.Variant = 1
+	wcu.W.Data.Data = uint32(42)
 
 	cases := []struct {
 		name string
@@ -1235,6 +1331,7 @@ func TestCodegenPointerAndPaddingShapes(t *testing.T) {
 		{"TopVecOfVar", &TopVecOfVar{{1, 2}, {3}, {}}},
 		{"TopVecOfVar-underfill", &TopVecOfVar{{1, 2}}},
 		{"UnionSamePkgVariant", &uv},
+		{"ClassicUnionSamePkgVariant", &cuv},
 		{"PtrPrimitiveList", &PtrPrimitiveList{F: []*uint64{&u1, &u2}}},
 		{"FixedVecPtrStr", &FixedVecPtrStr{F: []*string{&s, &s}}},
 		{"FixedVecPtrStr-underfill", &FixedVecPtrStr{F: []*string{&s}}},
@@ -1242,6 +1339,7 @@ func TestCodegenPointerAndPaddingShapes(t *testing.T) {
 		{"FixedVecStr-underfill", &FixedVecStr{F: []string{"a"}}},
 		{"PtrDynCollectionField", &PtrDynCollectionField{F: &bl}},
 		{"WrapUnionField", &wu},
+		{"WrapClassicUnionField", &wcu},
 		{"PtrSvecOfList", &PtrSvecOfList{F: &[][]uint16{{1, 2}}}},
 		{"WrapPtrList", func() any { w := WrapPtrList{}; d := []uint16{5, 6}; w.W.Data = &d; return &w }()},
 	}
@@ -1278,6 +1376,14 @@ func TestCodegenRejectsUngeneratableTopLevelTypes(t *testing.T) {
 				B []byte `ssz-max:"8"`
 			}]](),
 			want: "CompatibleUnion/TypeWrapper",
+		},
+		{
+			name: "top-level classic union",
+			typ: reflect.TypeFor[dynssz.Union[struct {
+				A uint32
+				B []byte `ssz-max:"8"`
+			}]](),
+			want: "Union/CompatibleUnion/TypeWrapper",
 		},
 		{
 			name: "top-level wrapper",

--- a/codegen/tests/codegen_test.go
+++ b/codegen/tests/codegen_test.go
@@ -60,6 +60,15 @@ var testMatrix = []TestPayload{
 		Hash:    "38a69cbd79a59c60505dac63c0330a57737f891a352cda1acd879cd778ca8cff",
 	},
 	{
+		// classic spec unions: None selected (U1), a dynamic variant (U2) and
+		// a value-carrying selector 0 (U3). The mix_in_selector construction
+		// itself is pinned independently in TestUnionHashTreeRoot (root pkg).
+		Name:    "ClassicUnionTypes",
+		Payload: ClassicUnionTypes_Payload,
+		Specs:   map[string]any{},
+		Hash:    "87141e56fc9d1fa6b2cc3cfdd0283bcc77b744cf7d9b9bbbb5b309d0d5a67bef",
+	},
+	{
 		// progressive container auto-detected from ssz-index tags alone
 		Name:    "ProgIndexOnly",
 		Payload: ProgIndexOnly_Payload,

--- a/codegen/tests/codegen_test.go
+++ b/codegen/tests/codegen_test.go
@@ -12,6 +12,7 @@ import (
 	dynssz "github.com/pk910/dynamic-ssz"
 	"github.com/pk910/dynamic-ssz/codegen"
 	"github.com/pk910/dynamic-ssz/codegen/tests/views"
+	"github.com/pk910/dynamic-ssz/sszutils"
 )
 
 type TestPayload struct {
@@ -1345,6 +1346,9 @@ func TestCodegenExcludedFields(t *testing.T) {
 // The generated sizer cannot return an error, so an unknown selector reports
 // size 0 (matching its mismatched-data convention) instead of a
 // plausible-looking partial size; the marshalers reject the value outright.
+// Without generated code (this suite also runs before go generate), the
+// reflection sizer serves the call and reports the invalid selector as an
+// error instead.
 func TestCodegenUnionInvalidSelectorSize(t *testing.T) {
 	ds := dynssz.NewDynSsz(nil)
 
@@ -1353,13 +1357,17 @@ func TestCodegenUnionInvalidSelectorSize(t *testing.T) {
 	v.U.Data = uint32(1)
 
 	size, err := ds.SizeSSZ(&v)
-	if err != nil {
-		t.Fatalf("size: %v", err)
-	}
-	// The whole value reports size 0: an un-sizable union aborts the sizer,
-	// matching the mismatched-data convention.
-	if size != 0 {
-		t.Errorf("expected size 0 for an un-sizable union, got %d", size)
+	if _, hasGeneratedCode := any(&v).(sszutils.DynamicSizer); hasGeneratedCode {
+		if err != nil {
+			t.Fatalf("size: %v", err)
+		}
+		// The whole value reports size 0: an un-sizable union aborts the
+		// sizer, matching the mismatched-data convention.
+		if size != 0 {
+			t.Errorf("expected size 0 for an un-sizable union, got %d", size)
+		}
+	} else if err == nil {
+		t.Fatal("reflection sizing should reject the invalid selector")
 	}
 
 	if _, err := ds.MarshalSSZ(&v); err == nil {

--- a/codegen/tests/gen_ssz.yaml
+++ b/codegen/tests/gen_ssz.yaml
@@ -113,6 +113,10 @@ types:
     output: gen_divergence.go
   - name: PtrUnionVariant
     output: gen_divergence.go
+  - name: ClassicUnionDynVariant
+    output: gen_divergence.go
+  - name: ClassicUnionPtrVariant
+    output: gen_divergence.go
   - name: TopLevelBitlist
     output: gen_toplevel.go
   - name: TopLevelProgBitlist
@@ -133,6 +137,8 @@ types:
     output: gen_compilecorrectness.go
   - name: UnionSamePkgVariant
     output: gen_compilecorrectness.go
+  - name: ClassicUnionSamePkgVariant
+    output: gen_compilecorrectness.go
   - name: PtrPrimitiveList
     output: gen_compilecorrectness.go
   - name: FixedVecPtrStr
@@ -144,6 +150,8 @@ types:
   - name: PtrDynCollectionField
     output: gen_compilecorrectness.go
   - name: WrapUnionField
+    output: gen_compilecorrectness.go
+  - name: WrapClassicUnionField
     output: gen_compilecorrectness.go
   - name: ExcludedFields
     output: gen_compilecorrectness.go

--- a/codegen/tests/gen_ssz.yaml
+++ b/codegen/tests/gen_ssz.yaml
@@ -58,6 +58,8 @@ types:
   - name: VecOfList
     output: gen_listoflist.go
 
+  - name: ClassicUnionTypes
+    output: gen_progressive.go
   - name: ProgressiveTypes
     output: gen_progressive.go
   - name: ProgIndexOnly

--- a/codegen/tests/types.go
+++ b/codegen/tests/types.go
@@ -456,6 +456,46 @@ var ProgressiveTypes_Payload = ProgressiveTypes{
 	},
 }
 
+// ClassicUnionTypes exercises classic spec unions (dynssz.Union) through the
+// generated code: a None-declaring union with the empty option selected (U1),
+// the same union type with its dynamic variant selected (U2), and a union
+// without None whose selector 0 carries a value (U3).
+type ClassicUnionTypes struct {
+	U1 dynssz.Union[struct {
+		N  dynssz.None
+		F1 uint32
+		F2 []uint8 `ssz-max:"16"`
+	}]
+	U2 dynssz.Union[struct {
+		N  dynssz.None
+		F1 uint32
+		F2 []uint8 `ssz-max:"16"`
+	}]
+	U3 dynssz.Union[struct {
+		F1 uint64
+		F2 [2][]uint16 `ssz-size:"2,5"`
+	}]
+}
+
+var ClassicUnionTypes_Payload = ClassicUnionTypes{
+	// U1 stays zero-valued: Variant 0 with nil Data is the None option.
+	U2: dynssz.Union[struct {
+		N  dynssz.None
+		F1 uint32
+		F2 []uint8 `ssz-max:"16"`
+	}]{
+		Variant: 2,
+		Data:    []uint8{1, 2, 3},
+	},
+	U3: dynssz.Union[struct {
+		F1 uint64
+		F2 [2][]uint16 `ssz-size:"2,5"`
+	}]{
+		Variant: 0,
+		Data:    uint64(0x1122334455667788),
+	},
+}
+
 type CustomTypes1 struct {
 	F1 CustomType1 `ssz-type:"custom"`
 }

--- a/codegen/tests/types.go
+++ b/codegen/tests/types.go
@@ -451,7 +451,7 @@ var ProgressiveTypes_Payload = ProgressiveTypes{
 		F2 [2][]uint8 `ssz-size:"2,5"`
 		F3 [4]*SimpleTypesWithSpecs_C1
 	}]{
-		Variant: 0,
+		Variant: 1,
 		Data:    uint32(0x12345678),
 	},
 }
@@ -1113,7 +1113,7 @@ var ViewTypes4_Payload = ViewTypes4_Base{
 		F1 uint32
 		F2 uint64
 	}]{
-		Variant: 0,
+		Variant: 1,
 		Data:    uint32(0x12345678),
 	},
 	W1: dynssz.TypeWrapper[struct {
@@ -1156,7 +1156,7 @@ var CoverageTypes4_Payload = CoverageTypes4{
 		F2 uint64
 		F3 []uint16 `ssz-size:"4"`
 	}]{
-		Variant: 0,
+		Variant: 1,
 		Data:    uint32(0x12345678),
 	},
 	U1V1: dynssz.CompatibleUnion[struct {
@@ -1164,7 +1164,7 @@ var CoverageTypes4_Payload = CoverageTypes4{
 		F2 uint64
 		F3 []uint16 `ssz-size:"4"`
 	}]{
-		Variant: 1,
+		Variant: 2,
 		Data:    uint64(0xdeadbeef),
 	},
 	U1V2: dynssz.CompatibleUnion[struct {
@@ -1172,7 +1172,7 @@ var CoverageTypes4_Payload = CoverageTypes4{
 		F2 uint64
 		F3 []uint16 `ssz-size:"4"`
 	}]{
-		Variant: 2,
+		Variant: 3,
 		Data:    []uint16{1, 2, 3, 4},
 	},
 	Opt3: &covU16,
@@ -1362,12 +1362,12 @@ var UnionDynVariant_Payload = UnionDynVariant{
 	U: dynssz.CompatibleUnion[struct {
 		F1 uint32
 		F2 []byte `ssz-max:"16"`
-	}]{Variant: 1, Data: []byte{1, 2, 3}},
+	}]{Variant: 2, Data: []byte{1, 2, 3}},
 	L: []byte{1, 4, 5},
 }
 
 // UnionTaggedSelectors assigns explicit 1-based selector values via ssz-index
-// tags on the union variant fields (EIP-7495 conformant numbering).
+// tags on the union variant fields (EIP-8016 conformant numbering).
 type UnionTaggedSelectors struct {
 	U dynssz.CompatibleUnion[struct {
 		F1 uint32 `ssz-index:"1"`
@@ -1437,7 +1437,7 @@ var ptrUnionVal = uint64(0xdeadbeef)
 
 var PtrUnionVariant_Payload = func() PtrUnionVariant {
 	p := PtrUnionVariant{}
-	p.U.Variant = 1
+	p.U.Variant = 2
 	p.U.Data = &ptrUnionVal
 	p.W.Data = &ptrUnionVal
 	return p

--- a/codegen/tests/types.go
+++ b/codegen/tests/types.go
@@ -1406,6 +1406,44 @@ var UnionDynVariant_Payload = UnionDynVariant{
 	L: []byte{1, 4, 5},
 }
 
+// ClassicUnionDynVariant has a classic union (None declared first) with a
+// variable-size variant followed by another dynamic field: the None region
+// must be exactly the bare selector byte, and a truncated union region must
+// fail cleanly on the stream path.
+type ClassicUnionDynVariant struct {
+	U dynssz.Union[struct {
+		N  dynssz.None
+		F1 uint32
+		F2 []byte `ssz-max:"16"`
+	}]
+	L []byte `ssz-max:"16"`
+}
+
+var ClassicUnionDynVariant_Payload = ClassicUnionDynVariant{
+	U: dynssz.Union[struct {
+		N  dynssz.None
+		F1 uint32
+		F2 []byte `ssz-max:"16"`
+	}]{Variant: 2, Data: []byte{1, 2, 3}},
+	L: []byte{1, 4, 5},
+}
+
+// ClassicUnionPtrVariant covers a classic union with a pointer variant — the
+// generated decoder must allocate the pointer before writing through it.
+type ClassicUnionPtrVariant struct {
+	U dynssz.Union[struct {
+		V1 uint64
+		V2 *uint64
+	}]
+}
+
+var ClassicUnionPtrVariant_Payload = func() ClassicUnionPtrVariant {
+	p := ClassicUnionPtrVariant{}
+	p.U.Variant = 1
+	p.U.Data = &ptrUnionVal
+	return p
+}()
+
 // UnionTaggedSelectors assigns explicit 1-based selector values via ssz-index
 // tags on the union variant fields (EIP-8016 conformant numbering).
 type UnionTaggedSelectors struct {
@@ -1500,6 +1538,15 @@ type UnionSamePkgVariant struct {
 	}]
 }
 
+// ClassicUnionSamePkgVariant uses a same-package named type as a classic
+// union variant.
+type ClassicUnionSamePkgVariant struct {
+	U dynssz.Union[struct {
+		V1 uint64
+		V2 SimpleTypes1_C1
+	}]
+}
+
 // PtrPrimitiveList is a list of pointer-to-primitive; the bulk uint64
 // fast-path must not fire for pointer elements.
 type PtrPrimitiveList struct {
@@ -1535,6 +1582,20 @@ type WrapUnionField struct {
 	}, dynssz.CompatibleUnion[struct {
 		A uint32
 		B []byte `ssz-max:"4"`
+	}]] `ssz-type:"wrapper"`
+}
+
+// WrapClassicUnionField wraps a classic Union; the streaming size closure
+// must not collide with its parameter name.
+type WrapClassicUnionField struct {
+	W dynssz.TypeWrapper[struct {
+		Data dynssz.Union[struct {
+			N dynssz.None
+			A uint32
+		}]
+	}, dynssz.Union[struct {
+		N dynssz.None
+		A uint32
 	}]] `ssz-type:"wrapper"`
 }
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -414,7 +414,7 @@ See [Type Wrapper](type-wrapper.md) for usage details.
 
 ### CompatibleUnion[T]
 
-Generic union type for variant values (EIP-7495).
+Generic union type for variant values (EIP-8016).
 
 ```go
 type CompatibleUnion[T any] struct {
@@ -424,7 +424,7 @@ type CompatibleUnion[T any] struct {
 ```
 
 **Type Parameters**:
-- `T` - Descriptor struct defining union variants as fields (field order = variant index)
+- `T` - Descriptor struct defining union variants as fields. Selectors follow field order starting at 1 (EIP-8016 allows 1..127); `ssz-index` tags assign them explicitly.
 
 **Constructor**:
 ```go
@@ -439,7 +439,7 @@ type PayloadUnion = dynssz.CompatibleUnion[struct {
 }]
 
 payload := PayloadUnion{
-    Variant: 0,
+    Variant: 1,
     Data: ExecutionPayload{...},
 }
 ```

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -410,6 +410,55 @@ func (w *TypeWrapper[D, T]) GetDescriptorType() reflect.Type
 
 See [Type Wrapper](type-wrapper.md) for usage details.
 
+## Union API
+
+### Union[T]
+
+Generic classic SSZ union type (`Union[type_0, type_1, ...]` from the SSZ specification).
+
+```go
+type Union[T any] struct {
+    Variant uint8
+    Data    interface{}
+}
+```
+
+**Type Parameters**:
+- `T` - Descriptor struct defining union variants as fields. Selectors are the 0-based field positions; `ssz-index` tags are not allowed and selectors above 127 are reserved.
+
+**Constructor**:
+```go
+func NewUnion[T any](variantIndex uint8, data interface{}) (*Union[T], error)
+```
+
+**Usage**:
+```go
+type PayloadUnion = dynssz.Union[struct {
+    Legacy ExecutionPayload // selector 0
+    Full   FullPayload      // selector 1
+}]
+
+payload := PayloadUnion{
+    Variant: 1,
+    Data: FullPayload{...},
+}
+```
+
+### None
+
+Marker type declaring the empty option of a classic union. Declared as the first descriptor field, it makes selector 0 the None variant (`{Variant: 0, Data: nil}`, serialized as the single byte `0x00`):
+
+```go
+type None struct{}
+```
+
+```go
+type MaybePayload = dynssz.Union[struct {
+    None dynssz.None      // selector 0: no value
+    Full ExecutionPayload // selector 1
+}]
+```
+
 ## Compatible Union API
 
 ### CompatibleUnion[T]

--- a/docs/code-generator.md
+++ b/docs/code-generator.md
@@ -552,7 +552,7 @@ See [SSZ Annotations](ssz-annotations.md#type-annotations-with-sszutilsannotatet
 - Large integers: byte arrays or uint64 arrays with `ssz-type:"uint256"`
 - Bitfields
 - Progressive types
-- Unions: `CompatibleUnion[T]`
+- Unions: `Union[T]` (classic spec) and `CompatibleUnion[T]` (EIP-8016)
 - Type wrappers: `TypeWrapper[D, T]`
 
 ### Annotations

--- a/docs/ssz-annotations.md
+++ b/docs/ssz-annotations.md
@@ -195,7 +195,9 @@ Explicitly specifies the SSZ type for a field. When omitted, the type is auto-de
 
 **Collection types**: `container`, `list`, `vector`, `bitlist`, `bitvector`
 
-**Progressive types** (EIP-7916/7495): `progressive-list`, `progressive-bitlist`, `progressive-container`, `compatible-union` (or `union`)
+**Union types**: `union` (classic spec union via `dynssz.Union[T]`, 0-based positional selectors)
+
+**Progressive types** (EIP-7916/7495): `progressive-list`, `progressive-bitlist`, `progressive-container`, `compatible-union` (EIP-8016 via `dynssz.CompatibleUnion[T]`)
 
 **Pointer encoding**: `optional-list` — encodes a pointer as canonical `List[T, 1]`
 

--- a/docs/supported-types.md
+++ b/docs/supported-types.md
@@ -284,10 +284,11 @@ Type-safe variant types using struct descriptor:
 ```go
 import dynssz "github.com/pk910/dynamic-ssz"
 
-// Define union using struct descriptor (field order = variant index)
+// Define union using a struct descriptor. Selectors follow field order
+// starting at 1 (EIP-8016 allows 1..127); ssz-index tags assign them explicitly.
 type PayloadUnion = dynssz.CompatibleUnion[struct {
-    ExecutionPayload            // Variant 0
-    ExecutionPayloadWithBlobs   // Variant 1
+    ExecutionPayload            // Variant 1
+    ExecutionPayloadWithBlobs   // Variant 2
 }]
 
 // Use in container
@@ -300,7 +301,7 @@ type BeaconBlock struct {
 block := BeaconBlock{
     Slot: 123,
     Payload: PayloadUnion{
-        Variant: 0,  // Use ExecutionPayload
+        Variant: 1,  // Use ExecutionPayload
         Data: ExecutionPayload{...},
     },
 }

--- a/docs/supported-types.md
+++ b/docs/supported-types.md
@@ -234,6 +234,48 @@ Encoding:
 
 The hash tree root matches `List[T, 1]` exactly.
 
+## Union Types
+
+Classic SSZ unions (`Union[type_0, type_1, ...]` from the SSZ specification) are expressed with the generic `dynssz.Union[T]` helper. The descriptor struct `T` lists the variants in order; selectors are the 0-based field positions:
+
+```go
+import dynssz "github.com/pk910/dynamic-ssz"
+
+// Selector = descriptor field position (0-based).
+type PayloadUnion = dynssz.Union[struct {
+    Legacy ExecutionPayload    // selector 0
+    Full   FullPayload         // selector 1
+}]
+
+type Block struct {
+    Slot    uint64
+    Payload PayloadUnion
+}
+```
+
+Declaring `dynssz.None` as the **first** descriptor field makes selector 0 the empty option (`Union[None, type_1, ...]`):
+
+```go
+type MaybePayload = dynssz.Union[struct {
+    None dynssz.None         // selector 0: no value
+    Full ExecutionPayload    // selector 1
+}]
+
+// The zero value {Variant: 0, Data: nil} is the None option.
+// It serializes as the single byte 0x00 and hashes as
+// mix_in_selector(Bytes32(), 0).
+```
+
+Spec rules enforced at descriptor build:
+
+- Selectors are positional; `ssz-index` tags are not allowed
+- `None` is only legal as the first field, and a union declaring it must offer at least one further variant
+- At most 128 variants (selectors above 127 are reserved)
+
+Serialization is `selector byte || serialize(value)`; the hash tree root is `mix_in_selector(hash_tree_root(value), selector)`. Variant fields may carry the usual `ssz-size`/`ssz-max`/`ssz-type` tags.
+
+For the EIP-8016 `CompatibleUnion` flavor (1-based selectors, no None, compatible merkleization), see [Compatible Unions](#compatible-unions-m4).
+
 ## Progressive Types (EIP-7916 & EIP-7495)
 
 ### Progressive Lists (M1)

--- a/dynssz_test.go
+++ b/dynssz_test.go
@@ -2059,12 +2059,12 @@ func TestRecursiveTypeWithUnion(t *testing.T) {
 		U: CompatibleUnion[struct {
 			V1 uint32
 			V2 uint64
-		}]{Variant: 1, Data: uint64(7)},
+		}]{Variant: 2, Data: uint64(7)},
 		Children: []*recUnionNode{
 			{U: CompatibleUnion[struct {
 				V1 uint32
 				V2 uint64
-			}]{Variant: 0, Data: uint32(3)}},
+			}]{Variant: 1, Data: uint32(3)}},
 		},
 	}
 
@@ -2637,7 +2637,7 @@ func TestUnionMarshalErrorPaths(t *testing.T) {
 		u := &CompatibleUnion[struct {
 			V0 uint32
 			V1 [16]byte
-		}]{Variant: 0, Data: "wrong type"}
+		}]{Variant: 1, Data: "wrong type"}
 		var sb bytes.Buffer
 		if err := ds.MarshalSSZWriter(u, &sb); err == nil {
 			t.Fatal("expected error for wrong-typed data")
@@ -2647,7 +2647,7 @@ func TestUnionMarshalErrorPaths(t *testing.T) {
 	t.Run("variantMarshalError", func(t *testing.T) {
 		u := &CompatibleUnion[struct {
 			V0 []byte `ssz-type:"bitlist" ssz-max:"16"`
-		}]{Variant: 0, Data: []byte{0xff, 0x00}}
+		}]{Variant: 1, Data: []byte{0xff, 0x00}}
 		var sb bytes.Buffer
 		if err := ds.MarshalSSZWriter(u, &sb); err == nil {
 			t.Fatal("expected error from union variant bitlist")
@@ -2659,7 +2659,7 @@ func TestUnionHTRVariantError(t *testing.T) {
 	ds := NewDynSsz(nil)
 	u := &CompatibleUnion[struct {
 		V0 []byte `ssz-type:"bitlist" ssz-max:"16"`
-	}]{Variant: 0, Data: []byte{0xff, 0x00}}
+	}]{Variant: 1, Data: []byte{0xff, 0x00}}
 	if _, err := ds.HashTreeRoot(u); err == nil {
 		t.Fatal("expected HTR error from union variant bitlist")
 	}

--- a/examples/progressive-merkleization/main.go
+++ b/examples/progressive-merkleization/main.go
@@ -7,7 +7,7 @@
 // - M1: ProgressiveList (EIP-7916)
 // - M2: ProgressiveBitlist (EIP-7916)
 // - M3: ProgressiveContainer (EIP-7495)
-// - M4: CompatibleUnion (EIP-7495)
+// - M4: CompatibleUnion (EIP-8016)
 
 package main
 
@@ -153,14 +153,14 @@ func main() {
 		Timestamp     uint64       `ssz-index:"55"`
 	}
 
-	// Create execution payload without blobs (variant 0)
+	// Create execution payload without blobs (variant 1)
 	basicPayload := ExecutionPayload{
 		ParentHash:   [32]byte{11, 12, 13, 14, 15},
 		FeeRecipient: [20]byte{21, 22, 23, 24, 25},
 		GasLimit:     15000000,
 	}
 
-	// Create execution payload with blobs (variant 1)
+	// Create execution payload with blobs (variant 2)
 	blobPayload := ExecutionPayloadWithBlobs{
 		ParentHash:   [32]byte{31, 32, 33, 34, 35},
 		FeeRecipient: [20]byte{41, 42, 43, 44, 45},
@@ -177,7 +177,7 @@ func main() {
 		ProposerIndex: 11111,
 		ParentRoot:    [32]byte{51, 52, 53, 54, 55},
 		StateRoot:     [32]byte{61, 62, 63, 64, 65},
-		ExecutionData: PayloadUnion{Variant: 0, Data: basicPayload},
+		ExecutionData: PayloadUnion{Variant: 1, Data: basicPayload},
 		Timestamp:     1234567890,
 	}
 
@@ -186,7 +186,7 @@ func main() {
 		ProposerIndex: 22222,
 		ParentRoot:    [32]byte{71, 72, 73, 74, 75},
 		StateRoot:     [32]byte{81, 82, 83, 84, 85},
-		ExecutionData: PayloadUnion{Variant: 1, Data: blobPayload},
+		ExecutionData: PayloadUnion{Variant: 2, Data: blobPayload},
 		Timestamp:     1234567891,
 	}
 
@@ -212,14 +212,14 @@ func main() {
 		log.Fatal("Failed to compute blob block root:", err)
 	}
 
-	fmt.Printf("   - Block with Basic Payload (variant 0): %d bytes, root: %x\n", len(basicBlockEncoded), basicBlockRoot)
-	fmt.Printf("   - Block with Blob Payload (variant 1): %d bytes, root: %x\n", len(blobBlockEncoded), blobBlockRoot)
+	fmt.Printf("   - Block with Basic Payload (variant 1): %d bytes, root: %x\n", len(basicBlockEncoded), basicBlockRoot)
+	fmt.Printf("   - Block with Blob Payload (variant 2): %d bytes, root: %x\n", len(blobBlockEncoded), blobBlockRoot)
 	fmt.Printf("   - Union embedded in progressive container with ssz-index:\"28\"\n")
 	fmt.Printf("   - Type-safe variants with automatic selector assignment\n")
 
 	// Demonstrate union serialization details
-	union1 := PayloadUnion{Variant: 0, Data: basicPayload}
-	union2 := PayloadUnion{Variant: 1, Data: blobPayload}
+	union1 := PayloadUnion{Variant: 1, Data: basicPayload}
+	union2 := PayloadUnion{Variant: 2, Data: blobPayload}
 
 	unionData1, _ := ds.MarshalSSZ(&union1)
 	unionData2, _ := ds.MarshalSSZ(&union2)

--- a/reflection/common_internal_test.go
+++ b/reflection/common_internal_test.go
@@ -5,11 +5,62 @@
 package reflection
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
 	"github.com/pk910/dynamic-ssz/ssztypes"
+	"github.com/pk910/dynamic-ssz/sszutils"
 )
+
+// The public marshal entry points size a value before encoding it, so
+// marshalUnion's own validation errors are shadowed by the equivalent checks in
+// the sizing pass. These tests drive marshalUnion directly to pin its guards.
+func TestMarshalUnionValidationErrors(t *testing.T) {
+	type unionValue struct {
+		Variant uint8
+		Data    interface{}
+	}
+
+	ctx := newCtx()
+	td := &ssztypes.TypeDescriptor{
+		SszType:      ssztypes.SszUnionType,
+		Kind:         reflect.Struct,
+		SszTypeFlags: ssztypes.SszTypeFlagIsDynamic | ssztypes.SszTypeFlagHasNoneVariant,
+		UnionVariants: map[uint8]*ssztypes.TypeDescriptor{
+			1: {
+				SszType: ssztypes.SszUint32Type,
+				Kind:    reflect.Uint32,
+				Type:    reflect.TypeOf(uint32(0)),
+				Size:    4,
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		value   unionValue
+		wantErr error
+	}{
+		{"noneWithData", unionValue{Variant: 0, Data: uint32(1)}, sszutils.ErrInvalidValueRange},
+		{"invalidVariant", unionValue{Variant: 9, Data: uint32(1)}, sszutils.ErrInvalidValueRange},
+		{"nilData", unionValue{Variant: 1, Data: nil}, sszutils.ErrInvalidValueRange},
+		{"typeMismatch", unionValue{Variant: 1, Data: "not a uint32"}, sszutils.ErrInvalidValueRange},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			enc := sszutils.NewBufferEncoder(nil)
+			err := ctx.marshalUnion(td, reflect.ValueOf(tt.value), enc, 0)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("expected %v, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
 
 func TestGetPtrWithPointerValue(t *testing.T) {
 	x := 42

--- a/reflection/common_test.go
+++ b/reflection/common_test.go
@@ -351,9 +351,9 @@ var commonTestMatrix = []struct {
 		}{0x1337, dynssz.CompatibleUnion[struct {
 			Field1 uint32
 			Field2 [2]uint8
-		}]{Variant: 0, Data: uint32(0x12345678)}, 0x4242},
-		fromHex("0x37130800000042420078563412"),
-		fromHex("0x631276fc281634b5224241dd547762be15e2f54e361c6bdc8f921a4d5125e954"),
+		}]{Variant: 1, Data: uint32(0x12345678)}, 0x4242},
+		fromHex("0x37130800000042420178563412"),
+		fromHex("0x545fedc025d1b21b79e65cfec615bb165a559fa5e4ff762e2de5e731e2a242c3"),
 	},
 	{
 		"compatible_union_2",
@@ -367,9 +367,9 @@ var commonTestMatrix = []struct {
 		}{0x1337, dynssz.CompatibleUnion[struct {
 			Field1 []uint32
 			Field2 [2]uint8
-		}]{Variant: 1, Data: [2]uint8{0x78, 0x56}}, 0x4242},
-		fromHex("0x3713080000004242017856"),
-		fromHex("0xa667d80855a0a42d447357c8dc753ce188ed7d30daceee9bb7ecc592d729bbeb"),
+		}]{Variant: 2, Data: [2]uint8{0x78, 0x56}}, 0x4242},
+		fromHex("0x3713080000004242027856"),
+		fromHex("0xdfabf548c6c052a47da50414d016d89fb1247a7d31f9cb0586f13c5572a8a21e"),
 	},
 	{
 		"complex_struct15",

--- a/reflection/marshal.go
+++ b/reflection/marshal.go
@@ -108,6 +108,11 @@ func (ctx *ReflectionCtx) marshalType(sourceType *ssztypes.TypeDescriptor, sourc
 		if err != nil {
 			return err
 		}
+	case ssztypes.SszUnionType:
+		err = ctx.marshalUnion(sourceType, sourceValue, encoder, idt)
+		if err != nil {
+			return err
+		}
 
 	// primitive types
 	case ssztypes.SszBoolType:
@@ -801,6 +806,54 @@ func (ctx *ReflectionCtx) marshalCompatibleUnion(sourceType *ssztypes.TypeDescri
 	encoder.EncodeUint8(variant)
 
 	// Marshal the data using the variant's type descriptor
+	err := ctx.marshalType(variantDesc, dataField.Elem(), encoder, idt+2)
+	if err != nil {
+		return sszutils.ErrorWithPathf(err, "[v:%d]", variant)
+	}
+
+	return nil
+}
+
+// marshalUnion encodes classic spec unions into SSZ-encoded data.
+//
+// The encoding is: selector.to_bytes(1, "little") + serialize(value.data).
+// Selectors are the 0-based descriptor field positions; a union declaring the
+// None option serializes it as the single selector byte 0.
+//
+// Parameters:
+//   - sourceType: The TypeDescriptor containing union metadata and variant descriptors
+//   - sourceValue: The reflect.Value of the Union to encode
+//   - encoder: The encoder instance used to write SSZ-encoded data
+//   - idt: Indentation level for verbose logging
+//
+// Returns:
+//   - error: An error if encoding fails
+func (ctx *ReflectionCtx) marshalUnion(sourceType *ssztypes.TypeDescriptor, sourceValue reflect.Value, encoder sszutils.Encoder, idt int) error {
+	variant := uint8(sourceValue.Field(0).Uint())
+	dataField := sourceValue.Field(1)
+
+	if variant == 0 && sourceType.SszTypeFlags&ssztypes.SszTypeFlagHasNoneVariant != 0 {
+		// The None option carries no value and serializes as the bare selector.
+		if !dataField.IsNil() {
+			return sszutils.ErrUnionTypeMismatchFn()
+		}
+		encoder.EncodeUint8(0)
+		return nil
+	}
+
+	variantDesc, ok := sourceType.UnionVariants[variant]
+	if !ok {
+		return sszutils.ErrInvalidUnionVariantFn()
+	}
+	if dataField.IsNil() {
+		return sszutils.ErrInvalidUnionVariantFn()
+	}
+	if dataField.Elem().Type() != variantDesc.Type {
+		return sszutils.ErrUnionTypeMismatchFn()
+	}
+
+	encoder.EncodeUint8(variant)
+
 	err := ctx.marshalType(variantDesc, dataField.Elem(), encoder, idt+2)
 	if err != nil {
 		return sszutils.ErrorWithPathf(err, "[v:%d]", variant)

--- a/reflection/marshal.go
+++ b/reflection/marshal.go
@@ -761,10 +761,9 @@ func (ctx *ReflectionCtx) marshalBitlist(sourceType *ssztypes.TypeDescriptor, so
 
 // marshalCompatibleUnion encodes CompatibleUnion values into SSZ-encoded data.
 //
-// According to the spec:
-//   - The encoding is: selector.to_bytes(1, "little") + serialize(value.data)
-//   - The selector index is based at 0 if a ProgressiveContainer type option is present
-//   - Otherwise, it is based at 1
+// The encoding is: selector.to_bytes(1, "little") + serialize(value.data).
+// Selectors are in 1..127 (EIP-8016): field order assigns them starting at 1,
+// or ssz-index tags assign them explicitly.
 //
 // Parameters:
 //   - sourceType: The TypeDescriptor containing union metadata and variant descriptors

--- a/reflection/marshal_test.go
+++ b/reflection/marshal_test.go
@@ -960,7 +960,7 @@ func TestSizeSSZCompatibleUnion(t *testing.T) {
 	input := struct {
 		Field TestUnion
 	}{
-		TestUnion{Variant: 0, Data: uint32(42)},
+		TestUnion{Variant: 1, Data: uint32(42)},
 	}
 
 	size, err := dynssz.SizeSSZ(input)
@@ -1746,13 +1746,13 @@ func TestMarshalUnionMarshalTypeError(t *testing.T) {
 	}
 
 	unionDesc := typeDesc.ContainerDesc.Fields[1].Type
-	variantDesc := unionDesc.UnionVariants[0]
+	variantDesc := unionDesc.UnionVariants[1]
 	variantDesc.SszType = ssztypes.SszCustomType
 	variantDesc.SszCompatFlags = 0
 
 	input := Container{
 		Field0: 0x1234,
-		Field1: TestUnion{Variant: 0, Data: UnionVariant{Field1: 42}},
+		Field1: TestUnion{Variant: 1, Data: UnionVariant{Field1: 42}},
 	}
 	_, err = dynssz.MarshalSSZTo(input, make([]byte, 0, 100))
 	if err == nil {
@@ -1997,7 +1997,7 @@ func TestMarshalDirectValidationErrors(t *testing.T) {
 			U U
 		}
 		enc := sszutils.NewBufferEncoder(make([]byte, 0, 64))
-		err := ctx.MarshalSSZ(fieldDesc(C{}), reflect.ValueOf(U{Variant: 0, Data: nil}), enc)
+		err := ctx.MarshalSSZ(fieldDesc(C{}), reflect.ValueOf(U{Variant: 1, Data: nil}), enc)
 		if err == nil {
 			t.Fatal("expected nil data error")
 		}
@@ -2012,7 +2012,7 @@ func TestMarshalDirectValidationErrors(t *testing.T) {
 			U U
 		}
 		enc := sszutils.NewBufferEncoder(make([]byte, 0, 64))
-		err := ctx.MarshalSSZ(fieldDesc(C{}), reflect.ValueOf(U{Variant: 0, Data: "wrong"}), enc)
+		err := ctx.MarshalSSZ(fieldDesc(C{}), reflect.ValueOf(U{Variant: 1, Data: "wrong"}), enc)
 		if err == nil {
 			t.Fatal("expected type mismatch error")
 		}

--- a/reflection/sszsize.go
+++ b/reflection/sszsize.go
@@ -202,6 +202,38 @@ func (ctx *ReflectionCtx) getSszValueSize(targetType *ssztypes.TypeDescriptor, t
 			// (see marshalBitlist), so account for that extra byte here as well
 			staticSize = 1
 		}
+	case ssztypes.SszUnionType:
+		// Union: 1 byte for selector + size of the data; the None option is the
+		// bare selector byte.
+		variant := uint8(targetValue.Field(0).Uint())
+		dataField := targetValue.Field(1)
+
+		if variant == 0 && targetType.SszTypeFlags&ssztypes.SszTypeFlagHasNoneVariant != 0 {
+			if !dataField.IsNil() {
+				return 0, sszutils.ErrUnionTypeMismatchFn()
+			}
+			staticSize = 1
+			break
+		}
+
+		variantDesc, ok := targetType.UnionVariants[variant]
+		if !ok {
+			return 0, sszutils.ErrInvalidUnionVariantFn()
+		}
+		if dataField.IsNil() {
+			return 0, sszutils.ErrInvalidUnionVariantFn()
+		}
+		if dataField.Elem().Type() != variantDesc.Type {
+			return 0, sszutils.ErrUnionTypeMismatchFn()
+		}
+
+		dataSize, err := ctx.getSszValueSize(variantDesc, dataField.Elem())
+		if err != nil {
+			return 0, sszutils.ErrorWithPathf(err, "[v:%d]", variant)
+		}
+
+		staticSize = 1 + dataSize
+
 	case ssztypes.SszCompatibleUnionType:
 		// CompatibleUnion: 1 byte for selector + size of the data
 		variant := uint8(targetValue.Field(0).Uint())

--- a/reflection/sszsize_test.go
+++ b/reflection/sszsize_test.go
@@ -321,7 +321,7 @@ func TestSizeSSZErrors(t *testing.T) {
 			name: "invalid_dynamic_type_in_union",
 			input: CompatibleUnion[struct {
 				V1 InvalidDynamicType
-			}]{Variant: 0, Data: InvalidDynamicType{}},
+			}]{Variant: 1, Data: InvalidDynamicType{}},
 			expectedErr: "unknown type",
 		},
 		{

--- a/reflection/treeroot.go
+++ b/reflection/treeroot.go
@@ -494,7 +494,7 @@ func (ctx *ReflectionCtx) buildRootFromCompatibleUnion(sourceType *ssztypes.Type
 		return sszutils.ErrInvalidUnionVariantFn()
 	}
 
-	// Hash only the data, not the selector
+	// Hash the data root first; the selector is merkleized in below.
 	if dataField.IsNil() {
 		return sszutils.ErrInvalidUnionVariantFn()
 	}

--- a/reflection/treeroot.go
+++ b/reflection/treeroot.go
@@ -173,6 +173,11 @@ func (ctx *ReflectionCtx) buildRootFromType(sourceType *ssztypes.TypeDescriptor,
 		if err != nil {
 			return err
 		}
+	case ssztypes.SszUnionType:
+		err := ctx.buildRootFromUnion(sourceType, sourceValue, hh, idt)
+		if err != nil {
+			return err
+		}
 
 	case ssztypes.SszBoolType:
 		if pack {
@@ -514,6 +519,58 @@ func (ctx *ReflectionCtx) buildRootFromCompatibleUnion(sourceType *ssztypes.Type
 	hh.PutUint8(variant)
 
 	// merkleize
+	hh.Merkleize(hashIndex)
+
+	return nil
+}
+
+// buildRootFromUnion computes the hash tree root for classic spec unions.
+//
+// The root is mix_in_selector(hash_tree_root(value.data), selector) with
+// 0-based positional selectors; the None option contributes a zero chunk as
+// its data root: mix_in_selector(Bytes32(), 0).
+//
+// Parameters:
+//   - sourceType: The TypeDescriptor containing union metadata and variant descriptors
+//   - sourceValue: The reflect.Value of the Union to hash
+//   - hh: The Hasher instance for hash computation
+//   - idt: Indentation level for verbose logging
+//
+// Returns:
+//   - error: An error if hashing fails
+func (ctx *ReflectionCtx) buildRootFromUnion(sourceType *ssztypes.TypeDescriptor, sourceValue reflect.Value, hh sszutils.HashWalker, idt int) error {
+	variant := uint8(sourceValue.Field(0).Uint())
+	dataField := sourceValue.Field(1)
+
+	hashIndex := hh.StartTree(sszutils.TreeTypeNone)
+
+	if variant == 0 && sourceType.SszTypeFlags&ssztypes.SszTypeFlagHasNoneVariant != 0 {
+		if !dataField.IsNil() {
+			return sszutils.ErrUnionTypeMismatchFn()
+		}
+		hh.PutBytes(sszutils.ZeroBytes()[:32])
+		hh.PutUint8(0)
+		hh.Merkleize(hashIndex)
+		return nil
+	}
+
+	variantDesc, ok := sourceType.UnionVariants[variant]
+	if !ok {
+		return sszutils.ErrInvalidUnionVariantFn()
+	}
+	if dataField.IsNil() {
+		return sszutils.ErrInvalidUnionVariantFn()
+	}
+	if dataField.Elem().Type() != variantDesc.Type {
+		return sszutils.ErrUnionTypeMismatchFn()
+	}
+
+	err := ctx.buildRootFromType(variantDesc, dataField.Elem(), hh, false, idt+2)
+	if err != nil {
+		return sszutils.ErrorWithPathf(err, "[v:%d]", variant)
+	}
+
+	hh.PutUint8(variant)
 	hh.Merkleize(hashIndex)
 
 	return nil

--- a/reflection/treeroot.go
+++ b/reflection/treeroot.go
@@ -471,9 +471,8 @@ func (ctx *ReflectionCtx) buildRootFromProgressiveContainer(sourceType *ssztypes
 
 // buildRootFromCompatibleUnion computes the hash tree root for CompatibleUnion values.
 //
-// According to the spec:
-// - hash_tree_root(value.data) if value is of compatible union type
-// - The selector is only used for serialization, it is not mixed in when Merkleizing
+// The root is mix_in_selector(hash_tree_root(value.data), selector): the
+// variant's data root merkleized with the selector value.
 //
 // Parameters:
 //   - sourceType: The TypeDescriptor containing union metadata and variant descriptors

--- a/reflection/treeroot_test.go
+++ b/reflection/treeroot_test.go
@@ -1868,13 +1868,13 @@ func TestCompatibleUnionBuildRootError(t *testing.T) {
 	}
 
 	unionDesc := typeDesc.ContainerDesc.Fields[1].Type
-	variantDesc := unionDesc.UnionVariants[0]
+	variantDesc := unionDesc.UnionVariants[1]
 	variantDesc.SszType = ssztypes.SszCustomType
 	variantDesc.SszCompatFlags = 0
 
 	input := Container{
 		Field0: 0x1234,
-		Field1: TestUnion{Variant: 0, Data: UnionVariant{Field1: 42}},
+		Field1: TestUnion{Variant: 1, Data: UnionVariant{Field1: 42}},
 	}
 	_, err = dynssz.HashTreeRoot(input)
 	if err == nil {

--- a/reflection/treeroot_test.go
+++ b/reflection/treeroot_test.go
@@ -1089,7 +1089,7 @@ func TestCompatibleUnionHashErrors(t *testing.T) {
 			Field1 TestUnion
 		}{
 			0x1234,
-			TestUnion{Variant: 0, Data: nil}, // Data is nil
+			TestUnion{Variant: 1, Data: nil}, // Data is nil
 		}
 		_, err := dynssz.HashTreeRoot(input)
 		if err == nil {
@@ -1107,7 +1107,7 @@ func TestCompatibleUnionHashErrors(t *testing.T) {
 			Field1 TestUnion
 		}{
 			0x1234,
-			TestUnion{Variant: 0, Data: complex64(1 + 2i)},
+			TestUnion{Variant: 1, Data: complex64(1 + 2i)},
 		}
 		_, err := dynssz.HashTreeRoot(input)
 		if err == nil {

--- a/reflection/unmarshal.go
+++ b/reflection/unmarshal.go
@@ -198,6 +198,11 @@ func (ctx *ReflectionCtx) unmarshalType(targetType *ssztypes.TypeDescriptor, tar
 		if err != nil {
 			return err
 		}
+	case ssztypes.SszUnionType:
+		err = ctx.unmarshalUnion(targetType, targetValue, decoder, idt)
+		if err != nil {
+			return err
+		}
 
 	// primitive types
 	case ssztypes.SszBoolType:
@@ -1139,6 +1144,56 @@ func (ctx *ReflectionCtx) unmarshalCompatibleUnion(targetType *ssztypes.TypeDesc
 
 	// We know CompatibleUnion has exactly 2 fields: Variant (uint8) and Data (interface{})
 	// Field 0 is Variant, Field 1 is Data
+	targetValue.Field(0).SetUint(uint64(variant))
+	targetValue.Field(1).Set(variantValue)
+
+	return nil
+}
+
+// unmarshalUnion decodes SSZ-encoded data into a classic spec union.
+//
+// The encoding is: selector.to_bytes(1, "little") + serialize(value.data).
+// Selectors are the 0-based descriptor field positions. Selector 0 of a union
+// declaring the None option carries no value, so its region is the bare
+// selector byte (trailing bytes surface through the surrounding
+// exact-consumption checks).
+//
+// Parameters:
+//   - targetType: The TypeDescriptor containing union metadata and variant descriptors
+//   - targetValue: The reflect.Value of the Union to populate
+//   - decoder: The decoder instance used to read SSZ-encoded data
+//   - idt: Indentation level for verbose logging
+//
+// Returns:
+//   - error: An error if decoding fails
+func (ctx *ReflectionCtx) unmarshalUnion(targetType *ssztypes.TypeDescriptor, targetValue reflect.Value, decoder sszutils.Decoder, idt int) error {
+	if decoder.GetLength() < 1 {
+		return sszutils.ErrUnionSelectorEOFFn()
+	}
+
+	variant, err := decoder.DecodeUint8()
+	if err != nil {
+		return err
+	}
+
+	if variant == 0 && targetType.SszTypeFlags&ssztypes.SszTypeFlagHasNoneVariant != 0 {
+		targetValue.Field(0).SetUint(0)
+		targetValue.Field(1).Set(reflect.Zero(targetValue.Field(1).Type()))
+		return nil
+	}
+
+	variantDesc, ok := targetType.UnionVariants[variant]
+	if !ok {
+		return sszutils.ErrInvalidUnionVariantFn()
+	}
+
+	variantValue := reflect.New(variantDesc.Type).Elem()
+
+	err = ctx.unmarshalType(variantDesc, variantValue, decoder, idt+2)
+	if err != nil {
+		return sszutils.ErrorWithPathf(err, "[v:%d]", variant)
+	}
+
 	targetValue.Field(0).SetUint(uint64(variant))
 	targetValue.Field(1).Set(variantValue)
 

--- a/reflection/unmarshal.go
+++ b/reflection/unmarshal.go
@@ -1099,10 +1099,9 @@ func (ctx *ReflectionCtx) unmarshalBitlist(targetType *ssztypes.TypeDescriptor, 
 
 // unmarshalCompatibleUnion decodes SSZ-encoded data into a CompatibleUnion.
 //
-// According to the spec:
-//   - The encoding is: selector.to_bytes(1, "little") + serialize(value.data)
-//   - The selector index is based at 0 if a ProgressiveContainer type option is present
-//   - Otherwise, it is based at 1
+// The encoding is: selector.to_bytes(1, "little") + serialize(value.data).
+// Selectors are in 1..127 (EIP-8016): field order assigns them starting at 1,
+// or ssz-index tags assign them explicitly.
 //
 // Parameters:
 //   - targetType: The TypeDescriptor containing union metadata and variant descriptors

--- a/reflection/unmarshal_test.go
+++ b/reflection/unmarshal_test.go
@@ -503,7 +503,7 @@ func TestUnmarshalErrors(t *testing.T) {
 				A uint32
 				B uint64
 			}]),
-			data:        []byte{0x00},
+			data:        []byte{0x01},
 			expectedErr: "unexpected end of SSZ",
 		},
 		{

--- a/ssztypes/descriptor.go
+++ b/ssztypes/descriptor.go
@@ -27,6 +27,7 @@ const (
 	SszTypeFlagHasSizeExpr                            // Whether this type or any of its nested types uses a dynamic expression to calculate the size or max size
 	SszTypeFlagHasMaxExpr                             // Whether this type or any of its nested types uses a dynamic expression to calculate the max size
 	SszTypeFlagHasBitSize                             // Whether the type has a bit size tag
+	SszTypeFlagHasNoneVariant                         // Whether a classic union declares the None option at selector 0
 )
 
 // SszCompatFlag is a flag indicating whether a type implements a specific SSZ compatibility interface

--- a/ssztypes/ssztags.go
+++ b/ssztypes/ssztags.go
@@ -40,6 +40,7 @@ const (
 	SszVectorType
 	SszBitlistType
 	SszBitvectorType
+	SszUnionType
 	SszProgressiveListType
 	SszProgressiveBitlistType
 	SszProgressiveContainerType
@@ -110,8 +111,10 @@ func ParseSszType(typeStr string) (SszType, error) {
 		return SszProgressiveBitlistType, nil
 	case "progressive-container":
 		return SszProgressiveContainerType, nil
-	case "compatible-union", "union":
+	case "compatible-union":
 		return SszCompatibleUnionType, nil
+	case "union":
+		return SszUnionType, nil
 
 	// extended types (not supported by SSZ spec)
 	case "int8":

--- a/ssztypes/typecache.go
+++ b/ssztypes/typecache.go
@@ -763,6 +763,11 @@ func (tc *TypeCache) buildTypeDescriptor(desc *TypeDescriptor, runtimeType, sche
 		if err != nil {
 			return nil, err
 		}
+	case SszUnionType:
+		err := tc.buildUnionDescriptor(desc, runtimeType, schemaType)
+		if err != nil {
+			return nil, err
+		}
 	case SszCustomType:
 		// A custom type serializes entirely through its own methods, so its Go
 		// structure is never traversed and no child descriptors are built. It is
@@ -1474,6 +1479,70 @@ func (tc *TypeCache) buildCompatibleUnionDescriptor(desc *TypeDescriptor, runtim
 	}
 
 	// Build type descriptors for each variant using schema for layout, runtime for data
+	for variantIndex, schemaInfo := range schemaVariantInfo {
+		var runtimeVariantType reflect.Type
+		if isViewDescriptor {
+			var ok bool
+			runtimeVariantType, ok = runtimeVariantMap[schemaInfo.Name]
+			if !ok {
+				return sszutils.NewSszErrorf(sszutils.ErrTypeMismatch, "runtime union missing variant %q defined in schema", schemaInfo.Name)
+			}
+		} else {
+			runtimeVariantType = schemaInfo.Type
+		}
+
+		variantDesc, err := tc.getTypeDescriptor(runtimeVariantType, schemaInfo.Type, schemaInfo.SizeHints, schemaInfo.MaxSizeHints, schemaInfo.TypeHints)
+		if err != nil {
+			return sszutils.ErrorWithPathf(err, "(variant:%d)", variantIndex)
+		}
+
+		desc.UnionVariants[variantIndex] = variantDesc
+	}
+
+	return nil
+}
+
+// buildUnionDescriptor builds a descriptor for classic spec unions with
+// runtime/schema pairing. Selectors are the descriptor struct's 0-based field
+// positions; a None marker declared first makes selector 0 the empty option
+// (recorded via SszTypeFlagHasNoneVariant, with no variant entry).
+func (tc *TypeCache) buildUnionDescriptor(desc *TypeDescriptor, runtimeType, schemaType reflect.Type) error {
+	// A union is always dynamic size (1 selector byte + variable data).
+	desc.Size = 0
+	desc.SszTypeFlags |= SszTypeFlagIsDynamic
+
+	schemaDescriptorType, err := tc.extractGenericTypeParameter(schemaType)
+	if err != nil {
+		return err
+	}
+
+	schemaVariantInfo, hasNone, err := extractClassicUnionDescriptorInfo(schemaDescriptorType, tc.specs)
+	if err != nil {
+		return sszutils.ErrorWithPath(err, "(union)")
+	}
+	if hasNone {
+		desc.SszTypeFlags |= SszTypeFlagHasNoneVariant
+	}
+
+	isViewDescriptor := runtimeType != schemaType
+
+	var runtimeVariantMap map[string]reflect.Type
+	if isViewDescriptor {
+		runtimeDescriptorType, err := tc.extractGenericTypeParameter(runtimeType)
+		if err != nil {
+			return sszutils.ErrorWithPath(err, "(union)")
+		}
+		runtimeVariantInfo, _, err := extractClassicUnionDescriptorInfo(runtimeDescriptorType, tc.specs)
+		if err != nil {
+			return sszutils.ErrorWithPath(err, "(union)")
+		}
+		runtimeVariantMap = make(map[string]reflect.Type, len(runtimeVariantInfo))
+		for _, info := range runtimeVariantInfo {
+			runtimeVariantMap[info.Name] = info.Type
+		}
+	}
+
+	desc.UnionVariants = make(map[uint8]*TypeDescriptor, len(schemaVariantInfo))
 	for variantIndex, schemaInfo := range schemaVariantInfo {
 		var runtimeVariantType reflect.Type
 		if isViewDescriptor {

--- a/ssztypes/typecache_test.go
+++ b/ssztypes/typecache_test.go
@@ -3538,12 +3538,12 @@ func TestTypeCache_CompatibleUnionDescriptor(t *testing.T) {
 			t.Fatalf("expected 2 union variants, got %d", len(desc.UnionVariants))
 		}
 		// Variant 0 should be uint32
-		if desc.UnionVariants[0].SszType != SszUint32Type {
-			t.Errorf("variant 0: expected SszUint32Type, got %v", desc.UnionVariants[0].SszType)
+		if desc.UnionVariants[1].SszType != SszUint32Type {
+			t.Errorf("variant 1: expected SszUint32Type, got %v", desc.UnionVariants[1].SszType)
 		}
 		// Variant 1 should be uint64
-		if desc.UnionVariants[1].SszType != SszUint64Type {
-			t.Errorf("variant 1: expected SszUint64Type, got %v", desc.UnionVariants[1].SszType)
+		if desc.UnionVariants[2].SszType != SszUint64Type {
+			t.Errorf("variant 2: expected SszUint64Type, got %v", desc.UnionVariants[2].SszType)
 		}
 	})
 }
@@ -3586,8 +3586,8 @@ func TestTypeCache_CompatibleUnionViewDescriptor(t *testing.T) {
 	if len(desc.UnionVariants) != 1 {
 		t.Fatalf("expected 1 union variant from schema, got %d", len(desc.UnionVariants))
 	}
-	if desc.UnionVariants[0].SszType != SszUint64Type {
-		t.Errorf("variant 0: expected SszUint64Type, got %v", desc.UnionVariants[0].SszType)
+	if desc.UnionVariants[1].SszType != SszUint64Type {
+		t.Errorf("variant 1: expected SszUint64Type, got %v", desc.UnionVariants[1].SszType)
 	}
 }
 

--- a/ssztypes/typecache_test.go
+++ b/ssztypes/typecache_test.go
@@ -1883,7 +1883,7 @@ func TestParseSszType(t *testing.T) {
 		{"progressive-bitlist", SszProgressiveBitlistType},
 		{"progressive-container", SszProgressiveContainerType},
 		{"compatible-union", SszCompatibleUnionType},
-		{"union", SszCompatibleUnionType},
+		{"union", SszUnionType},
 
 		// extended types
 		{"int8", SszInt8Type},

--- a/ssztypes/union.go
+++ b/ssztypes/union.go
@@ -100,3 +100,77 @@ func extractUnionDescriptorInfo(descriptorType reflect.Type, ds sszutils.Dynamic
 
 	return variantInfo, nil
 }
+
+// isNoneMarkerType reports whether a descriptor field type is the classic
+// union None marker (dynssz.None), detected by identity like the well-known
+// generic types.
+func isNoneMarkerType(t reflect.Type) bool {
+	return t.Kind() == reflect.Struct && t.NumField() == 0 &&
+		t.Name() == "None" && t.PkgPath() == dynsszPkgPath
+}
+
+// extractClassicUnionDescriptorInfo extracts variant information from a
+// classic union descriptor type. Selectors are the 0-based field positions per
+// the SSZ spec: the None marker is only legal as the first field (making
+// selector 0 the empty option, with at least one further variant), selectors
+// above 127 are reserved, and positional numbering leaves no room for
+// ssz-index tags. The returned map holds no entry for the None selector.
+func extractClassicUnionDescriptorInfo(descriptorType reflect.Type, ds sszutils.DynamicSpecs) (map[uint8]unionVariantInfo, bool, error) {
+	if descriptorType.Kind() != reflect.Struct {
+		return nil, false, sszutils.NewSszErrorf(sszutils.ErrTypeMismatch, "union descriptor must be a struct, got %v", descriptorType.Kind())
+	}
+
+	numFields := descriptorType.NumField()
+	if numFields == 0 {
+		return nil, false, sszutils.NewSszError(sszutils.ErrInvalidConstraint, "union descriptor struct has no fields")
+	}
+	// Selectors above 127 are reserved, so positions 0..127 bound the count.
+	if numFields > 128 {
+		return nil, false, sszutils.NewSszErrorf(sszutils.ErrInvalidConstraint, "union descriptor has %d variants, but selectors are limited to 0..127", numFields)
+	}
+
+	hasNone := false
+	variantInfo := make(map[uint8]unionVariantInfo, numFields)
+
+	for i := 0; i < numFields; i++ {
+		field := descriptorType.Field(i)
+
+		if _, tagged := field.Tag.Lookup("ssz-index"); tagged {
+			return nil, false, sszutils.NewSszErrorf(sszutils.ErrInvalidConstraint, "union selectors are positional; ssz-index tag on field %s is not allowed", field.Name)
+		}
+
+		if isNoneMarkerType(field.Type) {
+			if i != 0 {
+				return nil, false, sszutils.NewSszErrorf(sszutils.ErrInvalidConstraint, "the None option is only legal as the first union variant (field %s is at position %d)", field.Name, i)
+			}
+			if numFields < 2 {
+				return nil, false, sszutils.NewSszError(sszutils.ErrInvalidConstraint, "a union declaring None must offer at least one further variant")
+			}
+			hasNone = true
+			continue
+		}
+
+		sizeHints, err := getSszSizeTag(ds, &field)
+		if err != nil {
+			return nil, false, err
+		}
+		maxSizeHints, err := getSszMaxSizeTag(ds, &field)
+		if err != nil {
+			return nil, false, err
+		}
+		typeHints, err := getSszTypeTag(&field)
+		if err != nil {
+			return nil, false, err
+		}
+
+		variantInfo[uint8(i)] = unionVariantInfo{
+			Name:         field.Name,
+			Type:         field.Type,
+			SizeHints:    sizeHints,
+			MaxSizeHints: maxSizeHints,
+			TypeHints:    typeHints,
+		}
+	}
+
+	return variantInfo, hasNone, nil
+}

--- a/ssztypes/union.go
+++ b/ssztypes/union.go
@@ -27,7 +27,7 @@ func extractUnionDescriptorInfo(descriptorType reflect.Type, ds sszutils.Dynamic
 	}
 
 	// An ssz-index tag assigns an explicit selector value, e.g. 1-based
-	// selectors for EIP-7495 conformant unions. Mixing tagged and untagged
+	// selectors for EIP-8016 conformant unions. Mixing tagged and untagged
 	// variants would silently renumber the untagged ones, so require
 	// all-or-none up front.
 	indexTagCount := 0
@@ -41,17 +41,27 @@ func extractUnionDescriptorInfo(descriptorType reflect.Type, ds sszutils.Dynamic
 		return nil, sszutils.NewSszError(sszutils.ErrInvalidConstraint, "union descriptor mixes fields with and without ssz-index tags (all variants must carry one when any does)")
 	}
 
+	// EIP-8016 restricts union selectors to 1..127: 0 and the range above 127
+	// are reserved. Default numbering follows field order starting at 1, so the
+	// descriptor can hold at most 127 variants.
+	if descriptorType.NumField() > 127 {
+		return nil, sszutils.NewSszErrorf(sszutils.ErrInvalidConstraint, "union descriptor has %d variants, but selectors are limited to 1..127", descriptorType.NumField())
+	}
+
 	variantInfo := make(map[uint8]unionVariantInfo)
 
 	for i := 0; i < descriptorType.NumField(); i++ {
 		field := descriptorType.Field(i)
-		variantIndex := uint8(i) // Field order determines the default variant selector
+		variantIndex := uint8(i) + 1 // Field order determines the default variant selector, starting at 1
 
 		sszIndex, err := getSszIndexTag(&field)
 		if err != nil {
 			return nil, err
 		}
 		if sszIndex != nil {
+			if *sszIndex < 1 || *sszIndex > 127 {
+				return nil, sszutils.NewSszErrorf(sszutils.ErrInvalidConstraint, "union selector %d for field %s is outside the valid range 1..127", *sszIndex, field.Name)
+			}
 			variantIndex = uint8(*sszIndex)
 		}
 

--- a/ssztypes/union_test.go
+++ b/ssztypes/union_test.go
@@ -5,6 +5,7 @@
 package ssztypes
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -39,11 +40,11 @@ func TestExtractUnionDescriptorInfo(t *testing.T) {
 				}
 
 				// Check that both variants exist
-				if _, ok := info[0]; !ok {
-					t.Error("variant 0 not found")
-				}
 				if _, ok := info[1]; !ok {
 					t.Error("variant 1 not found")
+				}
+				if _, ok := info[2]; !ok {
+					t.Error("variant 2 not found")
 				}
 			},
 		},
@@ -58,8 +59,8 @@ func TestExtractUnionDescriptorInfo(t *testing.T) {
 			validateInfo: func(t *testing.T, info map[uint8]unionVariantInfo) {
 				t.Helper()
 
-				if _, ok := info[0]; !ok {
-					t.Error("variant 0 not found")
+				if _, ok := info[1]; !ok {
+					t.Error("variant 1 not found")
 				}
 			},
 		},
@@ -144,10 +145,10 @@ func TestCompatibleUnionVariantIndexing(t *testing.T) {
 		t.Fatalf("failed to extract union info: %v", err)
 	}
 
-	// Verify that indices 0-3 are present
-	for i := uint8(0); i < 4; i++ {
+	// Verify that selectors 1-4 are present
+	for i := uint8(1); i <= 4; i++ {
 		if _, ok := info[i]; !ok {
-			t.Errorf("expected variant at index %d", i)
+			t.Errorf("expected variant at selector %d", i)
 		}
 	}
 
@@ -160,7 +161,7 @@ func TestCompatibleUnionVariantIndexing(t *testing.T) {
 	}
 
 	for i, expectedKind := range expectedKinds {
-		variant := info[uint8(i)]
+		variant := info[uint8(i)+1]
 		if variant.Type.Kind() != reflect.Struct {
 			t.Errorf("variant %d should be struct", i)
 			continue
@@ -210,4 +211,21 @@ func TestUnionEdgeCases(t *testing.T) {
 			}
 		}
 	})
+}
+
+// A union descriptor cannot hold more than 127 variants: default numbering
+// would run past the EIP-8016 selector range.
+func TestExtractUnionDescriptorTooManyVariants(t *testing.T) {
+	fields := make([]reflect.StructField, 128)
+	for i := range fields {
+		fields[i] = reflect.StructField{
+			Name: fmt.Sprintf("V%d", i),
+			Type: reflect.TypeOf(uint32(0)),
+		}
+	}
+	descriptorType := reflect.StructOf(fields)
+
+	if _, err := extractUnionDescriptorInfo(descriptorType, &dummyDynamicSpecs{}); err == nil {
+		t.Fatal("descriptor with 128 variants should be rejected")
+	}
 }

--- a/ssztypes/union_test.go
+++ b/ssztypes/union_test.go
@@ -229,3 +229,51 @@ func TestExtractUnionDescriptorTooManyVariants(t *testing.T) {
 		t.Fatal("descriptor with 128 variants should be rejected")
 	}
 }
+
+// Classic union descriptor edge cases not reachable through the public API
+// golden tests: the variant count cap and per-field tag parse failures.
+func TestExtractClassicUnionDescriptorInfo(t *testing.T) {
+	ds := &dummyDynamicSpecs{}
+
+	t.Run("tooManyVariants", func(t *testing.T) {
+		// 129 fields: even with a leading None marker the remaining positions
+		// would exceed selector 127
+		fields := make([]reflect.StructField, 129)
+		for i := range fields {
+			fields[i] = reflect.StructField{
+				Name: fmt.Sprintf("V%d", i),
+				Type: reflect.TypeOf(uint32(0)),
+			}
+		}
+		if _, _, err := extractClassicUnionDescriptorInfo(reflect.StructOf(fields), ds); err == nil {
+			t.Fatal("descriptor with 129 variants should be rejected")
+		}
+	})
+
+	t.Run("invalidSszSize", func(t *testing.T) {
+		descriptorType := reflect.TypeOf(struct {
+			Data []uint8 `ssz-size:"invalid"`
+		}{})
+		if _, _, err := extractClassicUnionDescriptorInfo(descriptorType, ds); err == nil || !strings.Contains(err.Error(), "ssz-size") {
+			t.Fatalf("expected ssz-size parse error, got: %v", err)
+		}
+	})
+
+	t.Run("invalidSszMax", func(t *testing.T) {
+		descriptorType := reflect.TypeOf(struct {
+			Data []uint8 `ssz-max:"invalid"`
+		}{})
+		if _, _, err := extractClassicUnionDescriptorInfo(descriptorType, ds); err == nil || !strings.Contains(err.Error(), "ssz-max") {
+			t.Fatalf("expected ssz-max parse error, got: %v", err)
+		}
+	})
+
+	t.Run("invalidSszType", func(t *testing.T) {
+		descriptorType := reflect.TypeOf(struct {
+			Data []uint8 `ssz-type:"invalid"`
+		}{})
+		if _, _, err := extractClassicUnionDescriptorInfo(descriptorType, ds); err == nil || !strings.Contains(err.Error(), "ssz-type") {
+			t.Fatalf("expected ssz-type parse error, got: %v", err)
+		}
+	})
+}

--- a/ssztypes/wellknown.go
+++ b/ssztypes/wellknown.go
@@ -6,6 +6,10 @@ package ssztypes
 
 import "strings"
 
+// dynsszPkgPath is the import path of the root dynamic-ssz package, home of
+// the generic helper types (Union, CompatibleUnion, TypeWrapper, None).
+const dynsszPkgPath = "github.com/pk910/dynamic-ssz"
+
 // wellKnownExternalTypes is a map of external types that are known to be supported by SSZ
 var wellKnownExternalTypes = map[string]SszType{
 	"time.Time":                      SszUint64Type,
@@ -21,9 +25,12 @@ func getWellKnownExternalType(pkgPath, name string) SszType {
 		return t
 	}
 
-	if pkgPath == "github.com/pk910/dynamic-ssz" {
+	if pkgPath == dynsszPkgPath {
 		if strings.HasPrefix(name, "CompatibleUnion[") {
 			return SszCompatibleUnionType
+		}
+		if strings.HasPrefix(name, "Union[") {
+			return SszUnionType
 		}
 		if strings.HasPrefix(name, "TypeWrapper[") {
 			return SszTypeWrapperType

--- a/union.go
+++ b/union.go
@@ -58,3 +58,51 @@ func (u *CompatibleUnion[T]) GetDescriptorType() reflect.Type {
 	var zero *T
 	return reflect.TypeOf(zero).Elem()
 }
+
+// None marks the empty option of a classic SSZ Union. Declared as the FIRST
+// field of a Union descriptor struct, it makes selector 0 the None variant:
+//
+//	type MaybePayload = dynssz.Union[struct {
+//	    None dynssz.None // selector 0: no value
+//	    Full ExecutionPayload
+//	}]
+//
+// A None-valued union serializes as the single byte 0x00 and hashes as
+// mix_in_selector(Bytes32(), 0). The SSZ spec only allows None as the first
+// option, and a union declaring it must offer at least one other variant.
+type None struct{}
+
+// Union represents a classic SSZ union: an ordered set of variants addressed
+// by 0-based positional selectors, following the consensus-spec Union rules.
+// T is a descriptor struct whose fields define the variants in order; it is
+// never instantiated and only provides type information. Selectors above 127
+// are reserved by the spec and rejected.
+//
+// The union stores the active selector and the value. A union whose descriptor
+// declares dynssz.None as its first field represents the empty option as
+// {Variant: 0, Data: nil}.
+//
+// Unlike CompatibleUnion, variants share no merkleization constraints and the
+// selector is assigned by position alone (ssz-index tags are not allowed).
+type Union[T any] struct {
+	Variant uint8
+	Data    interface{}
+}
+
+// NewUnion creates a new Union with the specified variant selector and data.
+// Selectors are the 0-based positions of the descriptor struct's fields; when
+// the descriptor declares dynssz.None first, selector 0 with nil data is the
+// empty option.
+func NewUnion[T any](variantIndex uint8, data interface{}) (*Union[T], error) {
+	return &Union[T]{
+		Variant: variantIndex,
+		Data:    data,
+	}, nil
+}
+
+// GetDescriptorType returns the reflect.Type of the descriptor struct T.
+// This allows external code to access the descriptor type information.
+func (u *Union[T]) GetDescriptorType() reflect.Type {
+	var zero *T
+	return reflect.TypeOf(zero).Elem()
+}

--- a/union.go
+++ b/union.go
@@ -31,7 +31,7 @@ import (
 //	block := BlockWithPayload{
 //	    Slot: 123,
 //	    ExecutionData: UnionExecutionPayload{
-//	        Variant: 0,
+//	        Variant: 1,
 //	        Data: ExecutionPayload{
 //	            ...
 //	        },
@@ -42,8 +42,9 @@ type CompatibleUnion[T any] struct {
 	Data    interface{}
 }
 
-// NewCompatibleUnion creates a new CompatibleUnion with the specified variant type and data.
-// The variantIndex corresponds to the field index in the descriptor struct T.
+// NewCompatibleUnion creates a new CompatibleUnion with the specified variant selector and data.
+// Selectors follow the descriptor struct's field order starting at 1, or the
+// fields' ssz-index tags when present (valid range 1..127 per EIP-8016).
 func NewCompatibleUnion[T any](variantIndex uint8, data interface{}) (*CompatibleUnion[T], error) {
 	return &CompatibleUnion[T]{
 		Variant: variantIndex,

--- a/union_test.go
+++ b/union_test.go
@@ -519,6 +519,14 @@ func TestUnionDataTypeMismatch(t *testing.T) {
 	dynBad.U.Variant = 1 // expects []uint64
 	dynBad.U.Data = uint32(42)
 	check("size-dynvariant", func() error { _, e := ds.MarshalSSZ(dynBad); return e })
+
+	// A valid selector with nil data exercises the size- and HTR-path nil
+	// guards directly (the zero value stops earlier at the unassigned
+	// selector 0).
+	nilData := &T{}
+	nilData.U.Variant = 1
+	check("size-nildata", func() error { _, e := ds.MarshalSSZ(nilData); return e })
+	check("htr-nildata", func() error { _, e := ds.HashTreeRoot(nilData); return e })
 }
 
 // Union variant fields may carry ssz-index tags to assign explicit selector

--- a/union_test.go
+++ b/union_test.go
@@ -41,7 +41,7 @@ func TestNewCompatibleUnion(t *testing.T) {
 	}{
 		{
 			name:         "create union with first variant",
-			variantIndex: 0,
+			variantIndex: 1,
 			data: ExecutionPayload{
 				BlockHash: []byte{1, 2, 3},
 				StateRoot: []byte{4, 5, 6},
@@ -50,7 +50,7 @@ func TestNewCompatibleUnion(t *testing.T) {
 		},
 		{
 			name:         "create union with second variant",
-			variantIndex: 1,
+			variantIndex: 2,
 			data: ExecutionPayloadWithBlobs{
 				BlockHash: []byte{1, 2, 3},
 				StateRoot: []byte{4, 5, 6},
@@ -60,7 +60,7 @@ func TestNewCompatibleUnion(t *testing.T) {
 		},
 		{
 			name:         "create union with nil data",
-			variantIndex: 0,
+			variantIndex: 1,
 			data:         nil,
 			expectError:  false,
 		},
@@ -179,7 +179,7 @@ func TestCompatibleUnionGetDescriptorType(t *testing.T) {
 	}
 
 	union := &CompatibleUnion[TestUnionDescriptor]{
-		Variant: 0,
+		Variant: 1,
 		Data:    TestVariantA{FieldA: 42},
 	}
 
@@ -226,12 +226,12 @@ func TestCompatibleUnionWithComplexTypes(t *testing.T) {
 			BaseFee:   []byte{1, 2, 3},
 		}
 
-		union, err := NewCompatibleUnion[PayloadUnion](0, baseData)
+		union, err := NewCompatibleUnion[PayloadUnion](1, baseData)
 		if err != nil {
 			t.Fatalf("failed to create union: %v", err)
 		}
 
-		if union.Variant != 0 {
+		if union.Variant != 1 {
 			t.Error("variant mismatch")
 		}
 
@@ -256,9 +256,9 @@ func TestCompatibleUnionWithComplexTypes(t *testing.T) {
 			index uint8
 			data  interface{}
 		}{
-			{0, []byte{1, 2, 3, 4, 5}},
-			{1, []uint64{10, 20, 30}},
-			{2, []string{"hello", "world"}},
+			{1, []byte{1, 2, 3, 4, 5}},
+			{2, []uint64{10, 20, 30}},
+			{3, []string{"hello", "world"}},
 		}
 
 		for _, v := range variants {
@@ -287,13 +287,13 @@ func TestCompatibleUnionEdgeCases(t *testing.T) {
 			}
 		}
 
-		union, err := NewCompatibleUnion[SingleVariantUnion](0, struct{ Data string }{Data: "test"})
+		union, err := NewCompatibleUnion[SingleVariantUnion](1, struct{ Data string }{Data: "test"})
 		if err != nil {
 			t.Fatalf("failed to create union: %v", err)
 		}
 
-		if union.Variant != 0 {
-			t.Error("variant should be 0 for single variant union")
+		if union.Variant != 1 {
+			t.Error("variant should be 1 for single variant union")
 		}
 	})
 
@@ -304,17 +304,17 @@ func TestCompatibleUnionEdgeCases(t *testing.T) {
 		}
 
 		// Start with TypeA
-		union, err := NewCompatibleUnion[SwitchableUnion](0, struct{ A int }{A: 42})
+		union, err := NewCompatibleUnion[SwitchableUnion](1, struct{ A int }{A: 42})
 		if err != nil {
 			t.Fatalf("failed to create union: %v", err)
 		}
 
 		// Switch to TypeB
-		union.Variant = 1
+		union.Variant = 2
 		union.Data = struct{ B string }{B: "switched"}
 
-		if union.Variant != 1 {
-			t.Error("variant should be updated to 1")
+		if union.Variant != 2 {
+			t.Error("variant should be updated to 2")
 		}
 
 		if data, ok := union.Data.(struct{ B string }); ok {
@@ -332,8 +332,8 @@ func TestCompatibleUnionEdgeCases(t *testing.T) {
 			B struct{ Field string }
 		}
 
-		union1 := &CompatibleUnion[CachedUnion]{Variant: 0}
-		union2 := &CompatibleUnion[CachedUnion]{Variant: 1}
+		union1 := &CompatibleUnion[CachedUnion]{Variant: 1}
+		union2 := &CompatibleUnion[CachedUnion]{Variant: 2}
 
 		type1 := union1.GetDescriptorType()
 		type2 := union2.GetDescriptorType()
@@ -492,16 +492,16 @@ func TestUnionDataTypeMismatch(t *testing.T) {
 		}
 	}
 
-	// variant 0 expects uint32, Data is a string
+	// the first variant expects uint32, Data is a string
 	bad := &T{}
-	bad.U.Variant = 0
+	bad.U.Variant = 1
 	bad.U.Data = "not a uint32"
 	check("marshal", func() error { _, e := ds.MarshalSSZ(bad); return e })
 	check("htr", func() error { _, e := ds.HashTreeRoot(bad); return e })
 
-	// variant 1 expects [16]byte, Data is uint32
+	// the second variant expects [16]byte, Data is uint32
 	bad2 := &T{}
-	bad2.U.Variant = 1
+	bad2.U.Variant = 2
 	bad2.U.Data = uint32(42)
 	check("marshal2", func() error { _, e := ds.MarshalSSZ(bad2); return e })
 	check("htr2", func() error { _, e := ds.HashTreeRoot(bad2); return e })
@@ -515,13 +515,13 @@ func TestUnionDataTypeMismatch(t *testing.T) {
 		}]
 	}
 	dynBad := &D{}
-	dynBad.U.Variant = 0 // expects []uint64
+	dynBad.U.Variant = 1 // expects []uint64
 	dynBad.U.Data = uint32(42)
 	check("size-dynvariant", func() error { _, e := ds.MarshalSSZ(dynBad); return e })
 }
 
 // Union variant fields may carry ssz-index tags to assign explicit selector
-// values (e.g. 1-based selectors for EIP-7495 conformance).
+// values (e.g. 1-based selectors for EIP-8016 conformance).
 func TestCompatibleUnionExplicitSelectors(t *testing.T) {
 	type tagged struct {
 		U CompatibleUnion[struct {
@@ -585,4 +585,75 @@ func TestCompatibleUnionSelectorValidation(t *testing.T) {
 	if _, err := ds2.MarshalSSZ(&mixed{}); err == nil || !strings.Contains(err.Error(), "ssz-index") {
 		t.Errorf("expected mixed ssz-index error, got: %v", err)
 	}
+}
+
+// Default selectors follow field order starting at 1 per EIP-8016: the first
+// variant serializes with selector byte 0x01, never the reserved 0x00.
+func TestCompatibleUnionDefaultSelectorsStartAtOne(t *testing.T) {
+	type T struct {
+		U CompatibleUnion[struct {
+			F1 uint32
+			F2 uint64
+		}]
+	}
+	ds := NewDynSsz(nil)
+
+	v := T{}
+	v.U.Variant = 1
+	v.U.Data = uint32(7)
+
+	enc, err := ds.MarshalSSZ(&v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// offset (4) + selector byte + uint32 payload
+	if len(enc) != 9 || enc[4] != 1 {
+		t.Fatalf("first variant should serialize with selector 1, got: %x", enc)
+	}
+
+	// The reserved selector 0 is not a valid variant.
+	v.U.Variant = 0
+	if _, err := ds.MarshalSSZ(&v); err == nil {
+		t.Fatal("selector 0 should be invalid")
+	}
+
+	// Decoding a reserved selector fails.
+	bad := append([]byte{4, 0, 0, 0, 0}, 7, 0, 0, 0)
+	var dst T
+	if err := ds.UnmarshalSSZ(&dst, bad); err == nil {
+		t.Fatal("decoding selector 0 should fail")
+	}
+}
+
+// Explicit ssz-index selectors outside 1..127 are rejected at descriptor build.
+func TestCompatibleUnionSelectorRangeEnforced(t *testing.T) {
+	ds := NewDynSsz(nil)
+
+	t.Run("zero", func(t *testing.T) {
+		type T struct {
+			U CompatibleUnion[struct {
+				F1 uint32 `ssz-index:"0"`
+			}]
+		}
+		v := T{}
+		v.U.Variant = 0
+		v.U.Data = uint32(1)
+		if _, err := ds.MarshalSSZ(&v); err == nil {
+			t.Fatal("ssz-index 0 should be rejected")
+		}
+	})
+
+	t.Run("above127", func(t *testing.T) {
+		type T struct {
+			U CompatibleUnion[struct {
+				F1 uint32 `ssz-index:"128"`
+			}]
+		}
+		v := T{}
+		v.U.Variant = 128
+		v.U.Data = uint32(1)
+		if _, err := ds.MarshalSSZ(&v); err == nil {
+			t.Fatal("ssz-index 128 should be rejected")
+		}
+	})
 }

--- a/union_test.go
+++ b/union_test.go
@@ -6,6 +6,7 @@ package dynssz
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"errors"
 	"reflect"
 	"strings"
@@ -623,6 +624,477 @@ func TestCompatibleUnionDefaultSelectorsStartAtOne(t *testing.T) {
 	if err := ds.UnmarshalSSZ(&dst, bad); err == nil {
 		t.Fatal("decoding selector 0 should fail")
 	}
+}
+
+// Classic spec unions use 0-based positional selectors; a None marker declared
+// first makes selector 0 the empty option serializing as the single byte 0x00.
+func TestUnionNoneWireFormat(t *testing.T) {
+	type T struct {
+		U Union[struct {
+			N  None
+			F1 uint32
+		}]
+	}
+	ds := NewDynSsz(nil)
+
+	v := T{} // zero value: Variant 0, Data nil = None
+	enc, err := ds.MarshalSSZ(&v)
+	if err != nil {
+		t.Fatalf("marshal None: %v", err)
+	}
+	// offset (4) + bare selector byte 0
+	if !bytes.Equal(enc, []byte{4, 0, 0, 0, 0}) {
+		t.Fatalf("None must serialize as the bare selector byte, got: %x", enc)
+	}
+
+	var back T
+	if err = ds.UnmarshalSSZ(&back, enc); err != nil {
+		t.Fatalf("unmarshal None: %v", err)
+	}
+	if back.U.Variant != 0 || back.U.Data != nil {
+		t.Fatalf("None roundtrip mismatch: %+v", back.U)
+	}
+
+	// A concrete variant encodes as selector + serialized value.
+	v.U.Variant = 1
+	v.U.Data = uint32(7)
+	enc, err = ds.MarshalSSZ(&v)
+	if err != nil {
+		t.Fatalf("marshal variant: %v", err)
+	}
+	if !bytes.Equal(enc, []byte{4, 0, 0, 0, 1, 7, 0, 0, 0}) {
+		t.Fatalf("unexpected variant encoding: %x", enc)
+	}
+	back = T{}
+	if err = ds.UnmarshalSSZ(&back, enc); err != nil {
+		t.Fatalf("unmarshal variant: %v", err)
+	}
+	if back.U.Variant != 1 || back.U.Data != uint32(7) {
+		t.Fatalf("variant roundtrip mismatch: %+v", back.U)
+	}
+
+	// None with attached data is a type mismatch.
+	v.U.Variant = 0
+	v.U.Data = uint32(7)
+	if _, err := ds.MarshalSSZ(&v); err == nil {
+		t.Fatal("None with non-nil data should be rejected")
+	}
+
+	// Bytes trailing the bare None selector are rejected.
+	var b2 T
+	if err := ds.UnmarshalSSZ(&b2, []byte{4, 0, 0, 0, 0, 99}); err == nil {
+		t.Fatal("trailing bytes after None selector should be rejected")
+	}
+
+	// A selector without a declared variant is rejected.
+	if err := ds.UnmarshalSSZ(&b2, []byte{4, 0, 0, 0, 9}); err == nil {
+		t.Fatal("out-of-range selector should be rejected")
+	}
+
+	// An empty union region has no selector byte.
+	if err := ds.UnmarshalSSZ(&b2, []byte{4, 0, 0, 0}); err == nil {
+		t.Fatal("empty union region should be rejected")
+	}
+}
+
+// Without a None marker the first descriptor field is selector 0 and carries
+// a value like any other variant.
+func TestUnionWithoutNone(t *testing.T) {
+	type T struct {
+		U Union[struct {
+			F1 uint32
+			F2 []uint8 `ssz-max:"16"`
+		}]
+	}
+	ds := NewDynSsz(nil)
+
+	v := T{}
+	v.U.Variant = 0
+	v.U.Data = uint32(7)
+	enc, err := ds.MarshalSSZ(&v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !bytes.Equal(enc, []byte{4, 0, 0, 0, 0, 7, 0, 0, 0}) {
+		t.Fatalf("unexpected encoding: %x", enc)
+	}
+	var back T
+	if err = ds.UnmarshalSSZ(&back, enc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back.U.Variant != 0 || back.U.Data != uint32(7) {
+		t.Fatalf("roundtrip mismatch: %+v", back.U)
+	}
+
+	// A dynamic variant roundtrips through the offset machinery.
+	v.U.Variant = 1
+	v.U.Data = []uint8{1, 2, 3}
+	enc, err = ds.MarshalSSZ(&v)
+	if err != nil {
+		t.Fatalf("marshal dynamic variant: %v", err)
+	}
+	if !bytes.Equal(enc, []byte{4, 0, 0, 0, 1, 1, 2, 3}) {
+		t.Fatalf("unexpected dynamic variant encoding: %x", enc)
+	}
+	back = T{}
+	if err = ds.UnmarshalSSZ(&back, enc); err != nil {
+		t.Fatalf("unmarshal dynamic variant: %v", err)
+	}
+	if back.U.Variant != 1 || !reflect.DeepEqual(back.U.Data, []uint8{1, 2, 3}) {
+		t.Fatalf("dynamic variant roundtrip mismatch: %+v", back.U)
+	}
+
+	// Selector 0 holds a real variant here, so nil data is invalid.
+	v.U.Variant = 0
+	v.U.Data = nil
+	if _, err := ds.MarshalSSZ(&v); err == nil {
+		t.Fatal("nil data for a value-carrying selector should be rejected")
+	}
+}
+
+// The union root is mix_in_selector(hash_tree_root(value), selector); the None
+// option contributes a zero chunk as its data root.
+func TestUnionHashTreeRoot(t *testing.T) {
+	type T = Union[struct {
+		N  None
+		F1 uint32
+	}]
+	ds := NewDynSsz(nil)
+
+	mixin := func(dataRoot [32]byte, selector uint8) [32]byte {
+		var buf [64]byte
+		copy(buf[:32], dataRoot[:])
+		buf[32] = selector
+		return sha256.Sum256(buf[:])
+	}
+
+	// None: mix_in_selector(Bytes32(), 0)
+	root, err := ds.HashTreeRoot(&T{})
+	if err != nil {
+		t.Fatalf("HTR None: %v", err)
+	}
+	if want := mixin([32]byte{}, 0); root != want {
+		t.Fatalf("None root mismatch: got %x, want %x", root, want)
+	}
+
+	// uint32 variant: mix_in_selector(chunk(7), 1)
+	root, err = ds.HashTreeRoot(&T{Variant: 1, Data: uint32(7)})
+	if err != nil {
+		t.Fatalf("HTR variant: %v", err)
+	}
+	var dataChunk [32]byte
+	dataChunk[0] = 7
+	if want := mixin(dataChunk, 1); root != want {
+		t.Fatalf("variant root mismatch: got %x, want %x", root, want)
+	}
+}
+
+func TestNewUnion(t *testing.T) {
+	type D = struct {
+		N  None
+		F1 uint32
+	}
+
+	u, err := NewUnion[D](1, uint32(7))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if u.Variant != 1 || u.Data != uint32(7) {
+		t.Fatalf("unexpected union value: %+v", u)
+	}
+}
+
+// Classic union marshal error paths require reaching marshalUnion without a
+// prior size pass, which happens via MarshalSSZTo with a preallocated buffer.
+func TestUnionStreamMarshalErrorPaths(t *testing.T) {
+	type D = struct {
+		N  None
+		F1 uint32
+		F2 []byte `ssz-type:"bitlist" ssz-max:"16"`
+	}
+	ds := NewDynSsz(nil)
+
+	expectErr := func(t *testing.T, u *Union[D]) {
+		t.Helper()
+		if _, err := ds.MarshalSSZTo(u, make([]byte, 0, 100)); err == nil {
+			t.Fatal("expected error")
+		}
+	}
+
+	t.Run("noneWithData", func(t *testing.T) {
+		expectErr(t, &Union[D]{Variant: 0, Data: uint32(1)})
+	})
+	t.Run("invalidVariant", func(t *testing.T) {
+		expectErr(t, &Union[D]{Variant: 9, Data: uint32(1)})
+	})
+	t.Run("nilData", func(t *testing.T) {
+		expectErr(t, &Union[D]{Variant: 1, Data: nil})
+	})
+	t.Run("typeMismatch", func(t *testing.T) {
+		expectErr(t, &Union[D]{Variant: 1, Data: "not a uint32"})
+	})
+	t.Run("variantMarshalError", func(t *testing.T) {
+		// the bitlist variant is missing its termination bit
+		expectErr(t, &Union[D]{Variant: 2, Data: []byte{0xff, 0x00}})
+	})
+
+	t.Run("streamRoundtrip", func(t *testing.T) {
+		var sb bytes.Buffer
+		if err := ds.MarshalSSZWriter(&Union[D]{Variant: 1, Data: uint32(7)}, &sb); err != nil {
+			t.Fatalf("stream marshal: %v", err)
+		}
+		if !bytes.Equal(sb.Bytes(), []byte{1, 7, 0, 0, 0}) {
+			t.Fatalf("unexpected stream encoding: %x", sb.Bytes())
+		}
+	})
+}
+
+// Classic union hash tree root error paths.
+func TestUnionHTRErrorPaths(t *testing.T) {
+	type D = struct {
+		N  None
+		F1 uint32
+		F2 []byte `ssz-type:"bitlist" ssz-max:"16"`
+	}
+	ds := NewDynSsz(nil)
+
+	expectErr := func(t *testing.T, u *Union[D]) {
+		t.Helper()
+		if _, err := ds.HashTreeRoot(u); err == nil {
+			t.Fatal("expected error")
+		}
+	}
+
+	t.Run("noneWithData", func(t *testing.T) {
+		expectErr(t, &Union[D]{Variant: 0, Data: uint32(1)})
+	})
+	t.Run("invalidVariant", func(t *testing.T) {
+		expectErr(t, &Union[D]{Variant: 9, Data: uint32(1)})
+	})
+	t.Run("nilData", func(t *testing.T) {
+		expectErr(t, &Union[D]{Variant: 1, Data: nil})
+	})
+	t.Run("typeMismatch", func(t *testing.T) {
+		expectErr(t, &Union[D]{Variant: 1, Data: "not a uint32"})
+	})
+	t.Run("variantHTRError", func(t *testing.T) {
+		// the bitlist variant is missing its termination bit
+		expectErr(t, &Union[D]{Variant: 2, Data: []byte{0xff, 0x00}})
+	})
+}
+
+// Classic union size path errors: a buffer marshal of a nested union sizes the
+// value first, so these surface from the sizing pass.
+func TestUnionSizeErrorPaths(t *testing.T) {
+	ds := NewDynSsz(nil)
+
+	t.Run("invalidVariant", func(t *testing.T) {
+		type T struct {
+			U Union[struct {
+				F1 uint32
+			}]
+		}
+		v := T{}
+		v.U.Variant = 9
+		v.U.Data = uint32(1)
+		if _, err := ds.MarshalSSZ(&v); err == nil {
+			t.Fatal("expected error for invalid variant")
+		}
+	})
+
+	t.Run("typeMismatch", func(t *testing.T) {
+		type T struct {
+			U Union[struct {
+				F1 uint32
+			}]
+		}
+		v := T{}
+		v.U.Variant = 0
+		v.U.Data = "not a uint32"
+		if _, err := ds.MarshalSSZ(&v); err == nil {
+			t.Fatal("expected error for wrong-typed data")
+		}
+	})
+
+	t.Run("variantSizeError", func(t *testing.T) {
+		// the selected variant is a zero-valued CompatibleUnion, which cannot
+		// be sized (selector 0 is unassigned there)
+		type T struct {
+			U Union[struct {
+				F1 CompatibleUnion[struct {
+					A uint32
+				}]
+			}]
+		}
+		v := T{}
+		v.U.Variant = 0
+		v.U.Data = CompatibleUnion[struct {
+			A uint32
+		}]{}
+		if _, err := ds.MarshalSSZ(&v); err == nil {
+			t.Fatal("expected error from variant sizing")
+		}
+	})
+}
+
+// Classic union unmarshal error paths beyond the wire-format golden tests.
+func TestUnionUnmarshalErrorPaths(t *testing.T) {
+	ds := NewDynSsz(nil)
+
+	type T struct {
+		U Union[struct {
+			N  None
+			F1 uint32
+		}]
+	}
+
+	t.Run("selectorReadError", func(t *testing.T) {
+		// The declared size promises a union region, but the stream ends before
+		// the selector byte can be read.
+		var dst T
+		if err := ds.UnmarshalSSZReader(&dst, bytes.NewReader([]byte{4, 0, 0, 0}), 5); err == nil {
+			t.Fatal("expected error for truncated selector stream")
+		}
+	})
+
+	t.Run("variantDataError", func(t *testing.T) {
+		// selector 1 expects 4 bytes of uint32 data, only 2 are present
+		var dst T
+		if err := ds.UnmarshalSSZ(&dst, []byte{4, 0, 0, 0, 1, 7, 0}); err == nil {
+			t.Fatal("expected error for truncated variant data")
+		}
+	})
+}
+
+// Classic unions support view descriptors: the schema union defines the SSZ
+// layout while the runtime union holds the data, matched by variant name.
+func TestUnionViewDescriptor(t *testing.T) {
+	ds := NewDynSsz(nil)
+	tc := ds.GetTypeCache()
+
+	type runtimeDesc = struct {
+		N  None
+		F1 uint32
+		F2 uint64
+	}
+	type viewDesc = struct {
+		N  None
+		F1 uint32
+	}
+
+	t.Run("viewSubset", func(t *testing.T) {
+		desc, err := tc.GetTypeDescriptorWithSchema(
+			reflect.TypeOf(Union[runtimeDesc]{}),
+			reflect.TypeOf(Union[viewDesc]{}),
+			nil, nil, nil,
+		)
+		if err != nil {
+			t.Fatalf("view descriptor build failed: %v", err)
+		}
+		if len(desc.UnionVariants) != 1 {
+			t.Fatalf("expected 1 variant in view, got %d", len(desc.UnionVariants))
+		}
+	})
+
+	t.Run("missingRuntimeVariant", func(t *testing.T) {
+		type otherDesc = struct {
+			N  None
+			F9 uint16
+		}
+		_, err := tc.GetTypeDescriptorWithSchema(
+			reflect.TypeOf(Union[runtimeDesc]{}),
+			reflect.TypeOf(Union[otherDesc]{}),
+			nil, nil, nil,
+		)
+		if err == nil || !strings.Contains(err.Error(), "missing variant") {
+			t.Fatalf("expected missing-variant error, got: %v", err)
+		}
+	})
+
+	t.Run("nonGenericRuntime", func(t *testing.T) {
+		_, err := tc.GetTypeDescriptorWithSchema(
+			reflect.TypeOf(struct{ Variant uint8 }{}),
+			reflect.TypeOf(Union[viewDesc]{}),
+			nil, nil, nil,
+		)
+		if err == nil {
+			t.Fatal("expected error for non-generic runtime type")
+		}
+	})
+
+	t.Run("nonStructRuntimeDescriptor", func(t *testing.T) {
+		_, err := tc.GetTypeDescriptorWithSchema(
+			reflect.TypeOf(Union[uint64]{}),
+			reflect.TypeOf(Union[viewDesc]{}),
+			nil, nil, nil,
+		)
+		if err == nil {
+			t.Fatal("expected error for non-struct runtime descriptor")
+		}
+	})
+}
+
+// The None marker is only legal as the first descriptor field, needs at least
+// one further variant, and positional selectors leave no room for ssz-index.
+func TestUnionDescriptorValidation(t *testing.T) {
+	ds := NewDynSsz(nil)
+
+	t.Run("noneNotFirst", func(t *testing.T) {
+		type T struct {
+			U Union[struct {
+				F1 uint32
+				N  None
+			}]
+		}
+		if _, err := ds.MarshalSSZ(&T{}); err == nil || !strings.Contains(err.Error(), "None") {
+			t.Errorf("expected None placement error, got: %v", err)
+		}
+	})
+
+	t.Run("onlyNone", func(t *testing.T) {
+		type T struct {
+			U Union[struct {
+				N None
+			}]
+		}
+		if _, err := ds.MarshalSSZ(&T{}); err == nil || !strings.Contains(err.Error(), "None") {
+			t.Errorf("expected lone-None error, got: %v", err)
+		}
+	})
+
+	t.Run("sszIndexTag", func(t *testing.T) {
+		type T struct {
+			U Union[struct {
+				F1 uint32 `ssz-index:"1"`
+			}]
+		}
+		v := T{}
+		v.U.Variant = 1
+		v.U.Data = uint32(1)
+		if _, err := ds.MarshalSSZ(&v); err == nil || !strings.Contains(err.Error(), "ssz-index") {
+			t.Errorf("expected ssz-index rejection, got: %v", err)
+		}
+	})
+
+	t.Run("emptyDescriptor", func(t *testing.T) {
+		type T struct {
+			U Union[struct{}]
+		}
+		if _, err := ds.MarshalSSZ(&T{}); err == nil {
+			t.Error("expected error for descriptor without fields")
+		}
+	})
+
+	t.Run("unsupportedVariantType", func(t *testing.T) {
+		type T struct {
+			U Union[struct {
+				F1 chan int
+			}]
+		}
+		if _, err := ds.MarshalSSZ(&T{}); err == nil {
+			t.Error("expected error for unsupported variant type")
+		}
+	})
 }
 
 // Explicit ssz-index selectors outside 1..127 are rejected at descriptor build.


### PR DESCRIPTION
Fixes all union behaviour in one pass: conforms the existing `CompatibleUnion` to [EIP-8016](https://eips.ethereum.org/EIPS/eip-8016) selector rules and adds full support for classic spec unions ([`Union[type_0, type_1, ...]`](https://github.com/ethereum/consensus-specs/blob/master/ssz/simple-serialize.md)) as a new `dynssz.Union[T]` helper.

## CompatibleUnion: EIP-8016 conformance

- Default selectors now follow field order **starting at 1** (previously 0-based); explicit `ssz-index` tags may assign selectors in the valid range **1..127**. Selector 0 and values above 127 are rejected at descriptor build.
- Mixing tagged and untagged variant fields is rejected (silent renumbering hazard), as are duplicate selectors.
- The generated union sizer returns 0 for unknown selectors and mismatched data instead of a plausible-looking partial size.
- The progressive-merkleization example is migrated to 1-based selectors.

> ⚠️ Breaking for descriptors relying on the old 0-based default numbering: the first variant now serializes with selector byte `0x01`.

## New: classic spec Union (`dynssz.Union[T]`)

`Union[T]` mirrors the `CompatibleUnion[T]` API (Variant selector + Data value) but implements classic spec semantics:

- **0-based positional selectors** — the descriptor struct's fields define the variants in declaration order; `ssz-index` tags are not allowed.
- **None option** — declaring `dynssz.None` as the *first* descriptor field makes selector 0 the empty option (`{Variant: 0, Data: nil}`). Per spec it is only legal first and requires at least one further variant. A None-valued union serializes as the single byte `0x00` (trailing bytes rejected on decode) and hashes as `mix_in_selector(Bytes32(), 0)`.
- **Wire/HTR** — `selector.to_bytes(1, "little") + serialize(value)`; root is `mix_in_selector(hash_tree_root(value), selector)`.
- **Selector cap** — at most 128 options; selectors above 127 are reserved by the spec and rejected.
- The `ssz-type:"union"` tag now maps to classic Union semantics; `"compatible-union"` keeps the EIP-8016 behaviour.

```go
// Union[None, ExecutionPayload]
type MaybePayload = dynssz.Union[struct {
    None dynssz.None        // selector 0: no value
    Full ExecutionPayload   // selector 1
}]

// Union[ExecutionPayload, FullPayload] (no None)
type PayloadUnion = dynssz.Union[struct {
    Legacy ExecutionPayload // selector 0
    Full   FullPayload      // selector 1
}]
```

Both engines implement the new type end to end: the reflection marshal/unmarshal/size/hashroot paths and all six code generators (buffer + streaming codecs, sizer, hasher), including view descriptor support and rejection of top-level `Union` generation consistent with `CompatibleUnion`/`TypeWrapper`.

## Also included

- `getTypeName` in the codegen generator dereferences unnamed pointer types, so `-types` entries passed as pointers no longer collide as duplicate empty names (named pointer types still rejected with a clear error).
- Docs updated: supported types, API reference, annotations, code generator, README.

## Testing

- Wire & HTR golden tests (None single-byte encoding, `mix_in_selector` verified against an independent raw-SHA256 construction) plus roundtrips for static and dynamic variants.
- Error-path coverage across marshal, stream marshal, size, HTR, and unmarshal (buffer + reader): invalid/out-of-range selectors, None with attached data, nil data, wrong-typed data, trailing bytes, truncated streams.
- Descriptor validation tests in both engines (reflection typecache + go/types parser): None placement, lone None, `ssz-index` rejection, empty/oversized descriptors, malformed tags, view descriptors.
- Codegen end-to-end: `ClassicUnionTypes` in the differential test matrix (generated code vs reflection, golden root pinned).
- **100% statement coverage** on all new union code outside the codegen emitters; full suite, `-race`, and lint green.
