### PR TITLE
Add examples: chain-specs, streaming, merkle-proofs, fork-views

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -14,12 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.25.11', 1.26.x]
         example:
           - basic
           - versioned-blocks
           - custom-types
           - progressive-merkleization
+          - chain-specs
+          - streaming
+          - merkle-proofs
+          - fork-views
 
     steps:
     - name: Checkout code
@@ -28,13 +31,13 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
-        go-version: ${{ matrix.go-version }}
+        go-version: '1.26.x'
 
     - name: Cache Go modules
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ matrix.go-version }}-examples-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-1.26.x-examples-${{ hashFiles('**/go.sum') }}
 
     - name: Download main module dependencies
       run: go mod download

--- a/README.md
+++ b/README.md
@@ -160,9 +160,13 @@ The library includes comprehensive testing infrastructure:
 Check out the [examples](examples/) directory for standalone, CI-tested example projects:
 
 - [basic](examples/basic/) — simple encoding/decoding with Ethereum consensus types
+- [chain-specs](examples/chain-specs/) — preset-aware serialization: load a chain config and serialize the same types under mainnet, minimal, or custom devnet presets
 - [codegen](examples/codegen/) — code generation setup with a programmatic generator
 - [custom-types](examples/custom-types/) — custom specifications and dynamic expressions
+- [fork-views](examples/fork-views/) — one fork-agnostic type with per-fork SSZ schemas via views, plus view-only code generation
+- [merkle-proofs](examples/merkle-proofs/) — Merkle tree construction, generalized-index proofs into nested lists, multiproofs and standalone verification
 - [progressive-merkleization](examples/progressive-merkleization/) — progressive lists, bitlists, and containers (EIP-7916/EIP-7495)
+- [streaming](examples/streaming/) — stream SSZ to/from files and network connections without buffering the full payload
 - [versioned-blocks](examples/versioned-blocks/) — handling Ethereum fork-versioned block structures
 
 ## Contributing

--- a/examples/chain-specs/README.md
+++ b/examples/chain-specs/README.md
@@ -1,0 +1,59 @@
+# Chain Specs Example
+
+One binary, any preset: serialize the same Go types correctly under the
+mainnet preset, the minimal preset, or any custom devnet configuration.
+
+This is the core problem dynamic-ssz solves in production. Statically
+generated SSZ code bakes preset constants (vector lengths, list limits) into
+the generated methods, so anything but mainnet serializes and merkleizes to
+the wrong bytes and wrong hash tree roots. Devnet tooling, beacon API
+clients, and genesis generators instead load the chain config at runtime —
+from a `config.yaml` or the beacon node's `/eth/v1/config/spec` endpoint —
+and pass it to `dynssz.NewDynSsz`.
+
+## Run
+
+```bash
+go run .
+```
+
+## What it shows
+
+1. **Config loading** — a beacon-chain config YAML is parsed into the
+   `map[string]any` spec format `dynssz.NewDynSsz` expects (integers →
+   `uint64`, `0x...` strings → `[]byte`).
+
+2. **The dual-tag convention** used on Ethereum consensus types:
+
+   ```go
+   BlockRoots  [][32]byte `ssz-size:"8192,32" dynssz-size:"SLOTS_PER_HISTORICAL_ROOT,32"`
+   Validators  []Validator `ssz-max:"1099511627776" dynssz-max:"VALIDATOR_REGISTRY_LIMIT"`
+   ```
+
+   The `ssz-*` tag carries the mainnet fallback (used when no spec value is
+   provided), the `dynssz-*` tag carries the expression resolved against the
+   runtime spec map.
+
+3. **Spec expressions** — `dynssz-size`/`dynssz-max` support arithmetic:
+
+   ```go
+   SyncCommitteeBits []byte   `ssz-size:"64" dynssz-size:"SYNC_COMMITTEE_SIZE/8" ssz-type:"bitvector"`
+   ProposerLookahead []uint64 `ssz-size:"64" dynssz-size:"(MIN_SEED_LOOKAHEAD+1)*SLOTS_PER_EPOCH"`
+   ```
+
+4. **Fallback equivalence** — `NewDynSsz(nil)` encodes byte-identically to
+   the mainnet-spec instance, so mainnet users pay no spec-resolution cost.
+
+5. **Mismatch detection** — decoding minimal-preset bytes with a
+   mainnet-preset instance fails with a size error instead of producing
+   silently corrupt data.
+
+## Choosing an instance strategy
+
+| Pattern | When |
+|---|---|
+| `NewDynSsz(specs)` per spec set | multiple networks in one process |
+| `SetGlobalSpecs` + `GetGlobalDynSsz()` | one network per process; types with generated `MarshalSSZ()`/`HashTreeRoot()` facades route through the global instance |
+| `NewDynSsz(nil)` singleton | mainnet-only tools that just want dynamic-ssz's streaming/proof features |
+
+Instances cache type descriptors — create them once and reuse them.

--- a/examples/chain-specs/go.mod
+++ b/examples/chain-specs/go.mod
@@ -1,0 +1,16 @@
+module chain-specs-example
+
+go 1.25.8
+
+require (
+	github.com/goccy/go-yaml v1.18.0
+	github.com/pk910/dynamic-ssz v1.3.2
+)
+
+require (
+	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/pk910/hashtree-bindings v0.2.5 // indirect
+	golang.org/x/sys v0.30.0 // indirect
+)
+
+replace github.com/pk910/dynamic-ssz => ../../

--- a/examples/chain-specs/go.sum
+++ b/examples/chain-specs/go.sum
@@ -1,0 +1,8 @@
+github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
+github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
+github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
+github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
+github.com/pk910/hashtree-bindings v0.2.5 h1:zwONqRIgw40yGEOnGXBORvQVYaXtdZE3bS1ZJohc2/s=
+github.com/pk910/hashtree-bindings v0.2.5/go.mod h1:zrWt88783JmhBfcgni6kkIMYRdXTZi/FL//OyI5T/l4=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/examples/chain-specs/main.go
+++ b/examples/chain-specs/main.go
@@ -1,0 +1,273 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+
+// Package main demonstrates preset-aware SSZ serialization: one binary that
+// produces spec-correct SSZ for mainnet, minimal, or any custom devnet preset.
+//
+// This is the core problem dynamic-ssz solves in production. Statically
+// generated SSZ code bakes preset constants (vector lengths, list limits) into
+// the generated methods, so a minimal-preset beacon state serializes and
+// merkleizes to the wrong bytes/roots. Tools that must support devnets
+// therefore load the chain config at runtime and pass it to dynssz.NewDynSsz.
+//
+// The example mirrors that workflow:
+//  1. Load a beacon-chain config YAML into a spec map.
+//  2. Annotate types with dual tags: ssz-size/ssz-max carry the mainnet
+//     fallback, dynssz-size/dynssz-max carry the spec expression.
+//  3. Serialize the same type under both presets and compare.
+package main
+
+import (
+	_ "embed"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+	dynssz "github.com/pk910/dynamic-ssz"
+)
+
+//go:embed specs/mainnet.yaml
+var mainnetConfig []byte
+
+//go:embed specs/minimal.yaml
+var minimalConfig []byte
+
+// Checkpoint is a simplified epoch checkpoint.
+type Checkpoint struct {
+	Epoch uint64
+	Root  [32]byte
+}
+
+// Validator mirrors the consensus-spec validator container (shortened).
+type Validator struct {
+	Pubkey                [48]byte
+	WithdrawalCredentials [32]byte
+	EffectiveBalance      uint64
+	Slashed               bool
+	ActivationEpoch       uint64
+	ExitEpoch             uint64
+}
+
+// SyncAggregate has a bitvector whose length is preset-dependent:
+// SYNC_COMMITTEE_SIZE is 512 on mainnet (64 bytes) but 32 on minimal (4 bytes).
+type SyncAggregate struct {
+	SyncCommitteeBits      []byte `ssz-size:"64" dynssz-size:"SYNC_COMMITTEE_SIZE/8" ssz-type:"bitvector"`
+	SyncCommitteeSignature [96]byte
+}
+
+// BeaconStateSnapshot is a reduced beacon-state-like container showing the
+// dual-tag convention used for Ethereum consensus types:
+// the ssz-* tag holds the mainnet value (used when no specs are provided or a
+// spec value is missing), the dynssz-* tag holds the expression resolved
+// against the runtime spec map. Expressions support +, -, *, / and
+// parentheses, e.g. "(MIN_SEED_LOOKAHEAD+1)*SLOTS_PER_EPOCH".
+type BeaconStateSnapshot struct {
+	GenesisTime         uint64
+	Slot                uint64
+	FinalizedCheckpoint Checkpoint
+	BlockRoots          [][32]byte   `ssz-size:"8192,32" dynssz-size:"SLOTS_PER_HISTORICAL_ROOT,32"`
+	RandaoMixes         [][32]byte   `ssz-size:"65536,32" dynssz-size:"EPOCHS_PER_HISTORICAL_VECTOR,32"`
+	Validators          []Validator  `ssz-max:"1099511627776" dynssz-max:"VALIDATOR_REGISTRY_LIMIT"`
+	Balances            []uint64     `ssz-max:"1099511627776" dynssz-max:"VALIDATOR_REGISTRY_LIMIT"`
+	ETH1DataVotes       []Checkpoint `ssz-max:"2048" dynssz-max:"EPOCHS_PER_ETH1_VOTING_PERIOD*SLOTS_PER_EPOCH"`
+	LatestSyncAggregate SyncAggregate
+	ProposerLookahead   []uint64 `ssz-size:"64" dynssz-size:"(MIN_SEED_LOOKAHEAD+1)*SLOTS_PER_EPOCH"`
+}
+
+func main() {
+	fmt.Println("Chain Specs Example — one binary, any preset")
+	fmt.Println("=============================================")
+
+	mainnetSpecs, err := loadSpecs(mainnetConfig)
+	if err != nil {
+		log.Fatal("Failed to load mainnet specs: ", err)
+	}
+
+	minimalSpecs, err := loadSpecs(minimalConfig)
+	if err != nil {
+		log.Fatal("Failed to load minimal specs: ", err)
+	}
+
+	// One DynSsz instance per spec set. Instances cache type descriptors, so
+	// create them once and reuse them — either one per network, or a single
+	// process-wide instance (see dynssz.SetGlobalSpecs / GetGlobalDynSsz).
+	mainnetSsz := dynssz.NewDynSsz(mainnetSpecs)
+	minimalSsz := dynssz.NewDynSsz(minimalSpecs)
+
+	fmt.Println("\n1. Serialize the same type under both presets:")
+
+	mainnetState := buildState(mainnetSpecs)
+	mainnetBytes, err := mainnetSsz.MarshalSSZ(mainnetState)
+	if err != nil {
+		log.Fatal("Failed to marshal mainnet state: ", err)
+	}
+
+	mainnetRoot, err := mainnetSsz.HashTreeRoot(mainnetState)
+	if err != nil {
+		log.Fatal("Failed to hash mainnet state: ", err)
+	}
+
+	fmt.Printf("  mainnet: %8d bytes, root 0x%x\n", len(mainnetBytes), mainnetRoot[:8])
+
+	minimalState := buildState(minimalSpecs)
+	minimalBytes, err := minimalSsz.MarshalSSZ(minimalState)
+	if err != nil {
+		log.Fatal("Failed to marshal minimal state: ", err)
+	}
+
+	minimalRoot, err := minimalSsz.HashTreeRoot(minimalState)
+	if err != nil {
+		log.Fatal("Failed to hash minimal state: ", err)
+	}
+
+	fmt.Printf("  minimal: %8d bytes, root 0x%x\n", len(minimalBytes), minimalRoot[:8])
+	fmt.Println("  The vectors shrink from 8192/65536 entries to 64/64 — same Go type,")
+	fmt.Println("  completely different wire layout and hash tree root.")
+
+	fmt.Println("\n2. The ssz-* tags are the mainnet fallback:")
+
+	// With no specs at all, the static ssz-size/ssz-max values apply — which
+	// are exactly the mainnet preset. The encoding matches the mainnet
+	// instance byte for byte, so mainnet users pay no spec-resolution cost.
+	staticSsz := dynssz.NewDynSsz(nil)
+
+	staticBytes, err := staticSsz.MarshalSSZ(mainnetState)
+	if err != nil {
+		log.Fatal("Failed to marshal with static fallback: ", err)
+	}
+
+	fmt.Printf("  NewDynSsz(nil) encoding matches mainnet encoding: %v\n", string(staticBytes) == string(mainnetBytes))
+
+	fmt.Println("\n3. Preset mismatches are detected, not silently mis-decoded:")
+
+	var wrongPreset BeaconStateSnapshot
+	if err := mainnetSsz.UnmarshalSSZ(&wrongPreset, minimalBytes); err != nil {
+		fmt.Printf("  decoding minimal bytes with the mainnet instance fails: %v\n", firstLine(err.Error()))
+	} else {
+		log.Fatal("expected preset mismatch to fail decoding")
+	}
+
+	var roundTrip BeaconStateSnapshot
+	if err := minimalSsz.UnmarshalSSZ(&roundTrip, minimalBytes); err != nil {
+		log.Fatal("Failed to unmarshal minimal state: ", err)
+	}
+
+	fmt.Printf("  decoding with the minimal instance succeeds: %d validators, %d-byte sync bits\n",
+		len(roundTrip.Validators), len(roundTrip.LatestSyncAggregate.SyncCommitteeBits))
+
+	fmt.Println("\n4. Spec expressions resolved at runtime:")
+	fmt.Printf("  SYNC_COMMITTEE_SIZE/8:               mainnet %3d bytes, minimal %2d bytes\n",
+		len(mainnetState.LatestSyncAggregate.SyncCommitteeBits), len(minimalState.LatestSyncAggregate.SyncCommitteeBits))
+	fmt.Printf("  (MIN_SEED_LOOKAHEAD+1)*SLOTS_PER_EPOCH: mainnet %3d slots, minimal %2d slots\n",
+		len(mainnetState.ProposerLookahead), len(minimalState.ProposerLookahead))
+}
+
+// buildState creates a state whose preset-dependent fields are sized from the
+// loaded spec map — the same values dynssz resolves the tag expressions
+// against, so the constructed value always matches what the tags expect.
+func buildState(specs map[string]any) *BeaconStateSnapshot {
+	slotsPerEpoch := specUint(specs, "SLOTS_PER_EPOCH")
+	minSeedLookahead := specUint(specs, "MIN_SEED_LOOKAHEAD")
+
+	state := &BeaconStateSnapshot{
+		GenesisTime: 1606824023,
+		Slot:        123456,
+		FinalizedCheckpoint: Checkpoint{
+			Epoch: 3858,
+			Root:  [32]byte{0x01},
+		},
+		BlockRoots:        make([][32]byte, specUint(specs, "SLOTS_PER_HISTORICAL_ROOT")),
+		RandaoMixes:       make([][32]byte, specUint(specs, "EPOCHS_PER_HISTORICAL_VECTOR")),
+		ProposerLookahead: make([]uint64, (minSeedLookahead+1)*slotsPerEpoch),
+	}
+
+	state.LatestSyncAggregate.SyncCommitteeBits = make([]byte, specUint(specs, "SYNC_COMMITTEE_SIZE")/8)
+
+	validatorCount := 128
+	state.Validators = make([]Validator, 0, validatorCount)
+	state.Balances = make([]uint64, 0, validatorCount)
+
+	for i := 0; i < validatorCount; i++ {
+		validator := Validator{
+			EffectiveBalance: 32_000_000_000,
+			ActivationEpoch:  0,
+			ExitEpoch:        ^uint64(0),
+		}
+		validator.Pubkey[0] = byte(i)
+
+		state.Validators = append(state.Validators, validator)
+		state.Balances = append(state.Balances, 32_000_000_000+uint64(i))
+	}
+
+	return state
+}
+
+// loadSpecs parses a beacon-chain config YAML into the spec map format dynssz
+// expects: integers become uint64, 0x-prefixed strings become []byte,
+// everything else stays a string.
+func loadSpecs(configYaml []byte) (map[string]any, error) {
+	var raw map[string]any
+	if err := yaml.Unmarshal(configYaml, &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse config yaml: %w", err)
+	}
+
+	specs := make(map[string]any, len(raw))
+
+	for name, value := range raw {
+		switch typedValue := value.(type) {
+		case int:
+			specs[name] = uint64(typedValue)
+		case int64:
+			specs[name] = uint64(typedValue)
+		case uint64:
+			specs[name] = typedValue
+		case string:
+			if strings.HasPrefix(typedValue, "0x") {
+				specs[name] = hexToBytes(typedValue)
+			} else if parsed, err := strconv.ParseUint(typedValue, 10, 64); err == nil {
+				specs[name] = parsed
+			} else {
+				specs[name] = typedValue
+			}
+		default:
+			specs[name] = value
+		}
+	}
+
+	return specs, nil
+}
+
+func specUint(specs map[string]any, name string) uint64 {
+	value, ok := specs[name].(uint64)
+	if !ok {
+		log.Fatalf("spec value %s missing or not a uint64", name)
+	}
+
+	return value
+}
+
+func hexToBytes(hexString string) []byte {
+	hexString = strings.TrimPrefix(hexString, "0x")
+
+	result := make([]byte, len(hexString)/2)
+	for i := 0; i < len(result); i++ {
+		parsed, err := strconv.ParseUint(hexString[i*2:i*2+2], 16, 8)
+		if err != nil {
+			log.Fatalf("invalid hex value %q: %v", hexString, err)
+		}
+
+		result[i] = byte(parsed)
+	}
+
+	return result
+}
+
+func firstLine(message string) string {
+	if idx := strings.IndexByte(message, '\n'); idx >= 0 {
+		return message[:idx]
+	}
+
+	return message
+}

--- a/examples/chain-specs/specs/mainnet.yaml
+++ b/examples/chain-specs/specs/mainnet.yaml
@@ -1,0 +1,12 @@
+# Subset of the Ethereum mainnet preset / config values used by this example.
+# Real tools load the full config from the beacon node's /eth/v1/config/spec
+# endpoint or a devnet config.yaml.
+PRESET_BASE: mainnet
+SLOTS_PER_EPOCH: 32
+SLOTS_PER_HISTORICAL_ROOT: 8192
+EPOCHS_PER_HISTORICAL_VECTOR: 65536
+EPOCHS_PER_ETH1_VOTING_PERIOD: 64
+VALIDATOR_REGISTRY_LIMIT: 1099511627776
+SYNC_COMMITTEE_SIZE: 512
+MIN_SEED_LOOKAHEAD: 1
+GENESIS_FORK_VERSION: 0x00000000

--- a/examples/chain-specs/specs/minimal.yaml
+++ b/examples/chain-specs/specs/minimal.yaml
@@ -1,0 +1,12 @@
+# Subset of the Ethereum minimal preset values used by this example.
+# The minimal preset is what many devnets and the spec tests run on — the
+# same Go types must serialize with completely different layouts here.
+PRESET_BASE: minimal
+SLOTS_PER_EPOCH: 8
+SLOTS_PER_HISTORICAL_ROOT: 64
+EPOCHS_PER_HISTORICAL_VECTOR: 64
+EPOCHS_PER_ETH1_VOTING_PERIOD: 4
+VALIDATOR_REGISTRY_LIMIT: 1099511627776
+SYNC_COMMITTEE_SIZE: 32
+MIN_SEED_LOOKAHEAD: 1
+GENESIS_FORK_VERSION: 0x00000001

--- a/examples/fork-views/README.md
+++ b/examples/fork-views/README.md
@@ -1,0 +1,57 @@
+# Fork Views Example
+
+Serialize one runtime type with different per-fork SSZ schemas — no per-fork
+type explosion.
+
+Ethereum containers evolve across hard forks: fields get added, layouts
+change. With views, a single fork-agnostic "data type" holds the union of all
+fields, per-fork "view types" define the wire schemas, and a `Version` field
+selects the view at runtime. This is how fork-agnostic beacon and builder-API
+types are handled in production.
+
+## Run
+
+```bash
+go run .
+```
+
+## What it shows
+
+1. **Data type vs view types** — `BuilderBid` (the data type) carries all
+   fields across forks plus a non-serialized `Version` selector. Each view
+   type (`BuilderBidBellatrixView`, ...) is a schema-only struct: never
+   instantiated, matched to the data type's fields by name, nested structs
+   resolved through their own view types.
+
+2. **`WithViewDescriptor`** — the same object marshals, unmarshals and
+   hashes under any view:
+
+   ```go
+   data, err := ds.MarshalSSZ(bid, dynssz.WithViewDescriptor((*BuilderBidDenebView)(nil)))
+   ```
+
+3. **Version dispatch** — a `viewFor(version)` switch mapping the fork to a
+   view descriptor, bridging the data type's `Version` field to the right
+   schema.
+
+4. **`ValidateType` at startup** — verify every view matches the data type
+   once, instead of discovering a mismatch mid-request.
+
+5. **Views compose with dynamic specs** — the deneb view's
+   `dynssz-max:"MAX_BLOB_COMMITMENTS_PER_BLOCK"` resolves against the
+   instance's spec map, so the same view enforces different limits per
+   network.
+
+## Code generation
+
+Reflection handles views out of the box. For hot paths, `generate.yaml` in
+this directory shows the view-only codegen config: it emits per-view codecs
+plus dispatchers on the data type, which the runtime picks up automatically —
+same API, faster.
+
+```bash
+go run github.com/pk910/dynamic-ssz/dynssz-gen@latest -config generate.yaml
+```
+
+See [docs/views.md](../../docs/views.md) and
+[docs/code-generator-config.md](../../docs/code-generator-config.md).

--- a/examples/fork-views/generate.yaml
+++ b/examples/fork-views/generate.yaml
@@ -1,0 +1,21 @@
+# Optional: generate static view codecs instead of using runtime reflection.
+#
+#   go run github.com/pk910/dynamic-ssz/dynssz-gen@latest -config generate.yaml
+#
+# (or add `tool github.com/pk910/dynamic-ssz/dynssz-gen` to go.mod and run
+# `go tool dynssz-gen -config generate.yaml`)
+#
+# view-only mode emits per-view codecs plus MarshalSSZDynView /
+# UnmarshalSSZDynView / SizeSSZDynView / HashTreeRootWithDynView dispatchers
+# on the data type — no base (view-less) methods. The runtime instance picks
+# the generated code up automatically; ds.MarshalSSZ(bid, WithViewDescriptor(...))
+# keeps working unchanged, just faster.
+package: .
+types:
+  - name: BuilderBid
+    output: builderbid_ssz.go
+    view-only: true
+    views:
+      - BuilderBidBellatrixView
+      - BuilderBidCapellaView
+      - BuilderBidDenebView

--- a/examples/fork-views/go.mod
+++ b/examples/fork-views/go.mod
@@ -1,0 +1,16 @@
+module fork-views-example
+
+go 1.25.8
+
+require (
+	github.com/holiman/uint256 v1.3.2
+	github.com/pk910/dynamic-ssz v1.3.2
+)
+
+require (
+	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/pk910/hashtree-bindings v0.2.5 // indirect
+	golang.org/x/sys v0.47.0 // indirect
+)
+
+replace github.com/pk910/dynamic-ssz => ../../

--- a/examples/fork-views/go.sum
+++ b/examples/fork-views/go.sum
@@ -1,0 +1,8 @@
+github.com/holiman/uint256 v1.3.2 h1:a9EgMPSC1AAaj1SZL5zIQD3WbwTuHrMGOerLjGmM/TA=
+github.com/holiman/uint256 v1.3.2/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
+github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
+github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
+github.com/pk910/hashtree-bindings v0.2.5 h1:zwONqRIgw40yGEOnGXBORvQVYaXtdZE3bS1ZJohc2/s=
+github.com/pk910/hashtree-bindings v0.2.5/go.mod h1:zrWt88783JmhBfcgni6kkIMYRdXTZi/FL//OyI5T/l4=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/examples/fork-views/main.go
+++ b/examples/fork-views/main.go
@@ -1,0 +1,263 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+
+// Package main demonstrates SSZ views: one runtime type serialized with
+// different per-fork schemas.
+//
+// Ethereum containers evolve across hard forks — fields get added, layouts
+// change — but handler code doesn't want a per-fork type explosion. With
+// views, a single "data type" holds the union of all fields, and lightweight
+// per-fork "view types" define the SSZ schema (field set, order and tags).
+// A Version field on the data type selects the view at runtime.
+package main
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+
+	"github.com/holiman/uint256"
+	dynssz "github.com/pk910/dynamic-ssz"
+)
+
+// DataVersion identifies the fork a bid belongs to.
+type DataVersion uint8
+
+const (
+	DataVersionBellatrix DataVersion = iota
+	DataVersionCapella
+	DataVersionDeneb
+)
+
+func (v DataVersion) String() string {
+	switch v {
+	case DataVersionBellatrix:
+		return "bellatrix"
+	case DataVersionCapella:
+		return "capella"
+	case DataVersionDeneb:
+		return "deneb"
+	default:
+		return fmt.Sprintf("unknown(%d)", uint8(v))
+	}
+}
+
+// ExecutionHeader is the data type for a simplified execution payload
+// header: it carries the union of all fields across forks. Which fields end
+// up on the wire is decided by the view, not by this struct.
+type ExecutionHeader struct {
+	ParentHash   [32]byte
+	FeeRecipient [20]byte
+	StateRoot    [32]byte
+	BlockNumber  uint64
+	GasLimit     uint64
+	GasUsed      uint64
+	Timestamp    uint64
+	BaseFee      *uint256.Int
+	// Capella+
+	WithdrawalsRoot [32]byte
+	// Deneb+
+	BlobGasUsed   uint64
+	ExcessBlobGas uint64
+}
+
+// BuilderBid is the fork-agnostic data type, modeled on the builder-API bid
+// containers. Version selects the wire schema; it appears in no view and is
+// therefore never serialized.
+type BuilderBid struct {
+	Version DataVersion
+	Header  *ExecutionHeader
+	Value   *uint256.Int
+	Pubkey  [48]byte
+	// Deneb+
+	BlobCommitments [][48]byte
+}
+
+// The view types below define one SSZ schema each. Only their type
+// information is used — they are never instantiated. Fields are matched to
+// the data type by name; nested structs get their own view types.
+
+// ExecutionHeaderBellatrixView is the pre-withdrawals header schema.
+type ExecutionHeaderBellatrixView struct {
+	ParentHash   [32]byte
+	FeeRecipient [20]byte
+	StateRoot    [32]byte
+	BlockNumber  uint64
+	GasLimit     uint64
+	GasUsed      uint64
+	Timestamp    uint64
+	BaseFee      *uint256.Int `ssz-type:"uint256"`
+}
+
+// ExecutionHeaderCapellaView adds the withdrawals root.
+type ExecutionHeaderCapellaView struct {
+	ParentHash      [32]byte
+	FeeRecipient    [20]byte
+	StateRoot       [32]byte
+	BlockNumber     uint64
+	GasLimit        uint64
+	GasUsed         uint64
+	Timestamp       uint64
+	BaseFee         *uint256.Int `ssz-type:"uint256"`
+	WithdrawalsRoot [32]byte
+}
+
+// ExecutionHeaderDenebView adds the blob gas fields.
+type ExecutionHeaderDenebView struct {
+	ParentHash      [32]byte
+	FeeRecipient    [20]byte
+	StateRoot       [32]byte
+	BlockNumber     uint64
+	GasLimit        uint64
+	GasUsed         uint64
+	Timestamp       uint64
+	BaseFee         *uint256.Int `ssz-type:"uint256"`
+	WithdrawalsRoot [32]byte
+	BlobGasUsed     uint64
+	ExcessBlobGas   uint64
+}
+
+// BuilderBidBellatrixView is the bellatrix bid schema.
+type BuilderBidBellatrixView struct {
+	Header *ExecutionHeaderBellatrixView
+	Value  *uint256.Int `ssz-type:"uint256"`
+	Pubkey [48]byte
+}
+
+// BuilderBidCapellaView is the capella bid schema.
+type BuilderBidCapellaView struct {
+	Header *ExecutionHeaderCapellaView
+	Value  *uint256.Int `ssz-type:"uint256"`
+	Pubkey [48]byte
+}
+
+// BuilderBidDenebView adds blob commitments, with a preset-dependent limit.
+type BuilderBidDenebView struct {
+	Header          *ExecutionHeaderDenebView
+	BlobCommitments [][48]byte   `ssz-max:"4096" dynssz-max:"MAX_BLOB_COMMITMENTS_PER_BLOCK"`
+	Value           *uint256.Int `ssz-type:"uint256"`
+	Pubkey          [48]byte
+}
+
+// viewFor returns the view descriptor for a fork version — the dispatch
+// pattern used with fork-agnostic types, keyed off the data type's Version
+// field.
+func viewFor(version DataVersion) (any, error) {
+	switch version {
+	case DataVersionBellatrix:
+		return (*BuilderBidBellatrixView)(nil), nil
+	case DataVersionCapella:
+		return (*BuilderBidCapellaView)(nil), nil
+	case DataVersionDeneb:
+		return (*BuilderBidDenebView)(nil), nil
+	default:
+		return nil, fmt.Errorf("no view for version %s", version)
+	}
+}
+
+func main() {
+	fmt.Println("Fork Views Example — one type, one schema per fork")
+	fmt.Println("===================================================")
+
+	ds := dynssz.NewDynSsz(nil)
+
+	// Validate every view against the data type once at startup — a cheap
+	// check that catches schema drift before it corrupts wire data.
+	for _, version := range []DataVersion{DataVersionBellatrix, DataVersionCapella, DataVersionDeneb} {
+		view, err := viewFor(version)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if err := ds.ValidateType(reflect.TypeOf((*BuilderBid)(nil)), dynssz.WithViewDescriptor(view)); err != nil {
+			log.Fatalf("view for %s does not match BuilderBid: %v", version, err)
+		}
+	}
+
+	fmt.Println("\nAll views validated against the data type.")
+
+	// One bid, fully populated. The same object serializes under all three
+	// fork schemas.
+	bid := &BuilderBid{
+		Header: &ExecutionHeader{
+			BlockNumber:   19_000_000,
+			GasLimit:      30_000_000,
+			GasUsed:       12_345_678,
+			Timestamp:     1700000000,
+			BaseFee:       uint256.NewInt(7_500_000_000),
+			BlobGasUsed:   131072,
+			ExcessBlobGas: 393216,
+		},
+		Value:           uint256.NewInt(123_456_789_000_000_000),
+		BlobCommitments: make([][48]byte, 3),
+	}
+	bid.Header.ParentHash[0] = 0xaa
+	bid.Header.WithdrawalsRoot[0] = 0xbb
+	bid.Pubkey[0] = 0xcc
+
+	fmt.Println("\n1. Marshal the same object under each fork schema:")
+
+	encoded := make(map[DataVersion][]byte, 3)
+
+	for _, version := range []DataVersion{DataVersionBellatrix, DataVersionCapella, DataVersionDeneb} {
+		view, err := viewFor(version)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		data, err := ds.MarshalSSZ(bid, dynssz.WithViewDescriptor(view))
+		if err != nil {
+			log.Fatalf("failed to marshal %s bid: %v", version, err)
+		}
+
+		root, err := ds.HashTreeRoot(bid, dynssz.WithViewDescriptor(view))
+		if err != nil {
+			log.Fatalf("failed to hash %s bid: %v", version, err)
+		}
+
+		encoded[version] = data
+
+		fmt.Printf("  %-9s: %4d bytes, root 0x%x\n", version, len(data), root[:8])
+	}
+
+	fmt.Println("  Fields absent from a view (WithdrawalsRoot on bellatrix, blob data")
+	fmt.Println("  before deneb) simply don't reach the wire — no per-fork structs needed.")
+
+	// 2. Version-dispatched decoding: pick the view from the version that
+	// arrived out of band (API header, stored version column, fork schedule).
+	fmt.Println("\n2. Unmarshal with the version-selected view:")
+
+	for _, version := range []DataVersion{DataVersionBellatrix, DataVersionDeneb} {
+		view, err := viewFor(version)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		decoded := &BuilderBid{Version: version}
+		if err := ds.UnmarshalSSZ(decoded, encoded[version], dynssz.WithViewDescriptor(view)); err != nil {
+			log.Fatalf("failed to unmarshal %s bid: %v", version, err)
+		}
+
+		fmt.Printf("  %-9s: block %d, value %s wei, %d blob commitments, withdrawals root 0x%x...\n",
+			version, decoded.Header.BlockNumber, decoded.Value, len(decoded.BlobCommitments),
+			decoded.Header.WithdrawalsRoot[:2])
+	}
+
+	fmt.Println("  The bellatrix decode leaves WithdrawalsRoot and BlobCommitments at their")
+	fmt.Println("  zero values — those fields are not part of its schema.")
+
+	fmt.Println("\n3. Views compose with dynamic specs:")
+
+	// The deneb view carries dynssz-max:"MAX_BLOB_COMMITMENTS_PER_BLOCK", so
+	// the same view resolves different limits per network.
+	devnetSsz := dynssz.NewDynSsz(map[string]any{
+		"MAX_BLOB_COMMITMENTS_PER_BLOCK": uint64(2),
+	})
+
+	_, err := devnetSsz.MarshalSSZ(bid, dynssz.WithViewDescriptor((*BuilderBidDenebView)(nil)))
+	if err != nil {
+		fmt.Printf("  3 commitments rejected on a devnet with MAX_BLOB_COMMITMENTS_PER_BLOCK=2:\n    %v\n", err)
+	} else {
+		log.Fatal("expected the devnet limit to reject 3 blob commitments")
+	}
+}

--- a/examples/merkle-proofs/README.md
+++ b/examples/merkle-proofs/README.md
@@ -1,0 +1,53 @@
+# Merkle Proofs Example
+
+Build Merkle trees from SSZ structures, prove individual fields — including
+elements deep inside lists — and verify the proofs standalone.
+
+This is the pattern used to prove validator and withdrawal data out of the
+beacon state for on-chain verification: build the tree with
+`GetTree` + `Prove`, and submit the resulting sibling-hash chains to a
+contract that verifies them against a known state root.
+
+## Run
+
+```bash
+go run .
+```
+
+## What it shows
+
+1. **`GetTree`** — build the complete Merkle tree once; its root hash equals
+   `HashTreeRoot`. Reuse the tree for every proof (rebuilding per proof is
+   the expensive mistake).
+2. **`tree.Show(depth)`** — inspect the tree layout to discover generalized
+   indices.
+3. **Generalized-index arithmetic** — walking from the root to a validator
+   inside the `Validators` list:
+
+   ```go
+   gid := uint64(1)                                // root
+   gid = gid*stateChunkCeil + validatorsFieldIndex // container field (8 fields → ceil 8)
+   gid *= 2                                        // list data subtree (length mix-in is the right child)
+   gid = gid*validatorsLimit + validatorIndex      // element within the limit-sized subtree
+   ```
+
+4. **Leaf sanity check** — before trusting a proof, compare its leaf against
+   the field's own `HashTreeRoot`. Always do this for proofs that get
+   submitted on-chain.
+5. **`ProveMulti` / `VerifyMultiproof`** — prove several fields with shared
+   sibling hashes; three single proofs would carry 9 hashes here, the
+   multiproof carries 3.
+6. **Standalone `VerifyProof`** — verification needs only the root and the
+   proof. The tree itself can be dropped immediately (a full mainnet state
+   tree is the memory hot spot — release it as soon as the proofs exist).
+
+## Notes
+
+- Generalized indices depend on the container layout: with 8 fields the
+  container merkleizes into 8 chunks, so field *i* sits at index `8+i`.
+  Adding a 9th field would double the chunk ceiling to 16.
+- Progressive containers (`ssz-index` tags) produce different tree shapes and
+  therefore different indices — use `tree.Show()` to discover them. See
+  [docs/merkle-proofs.md](../../docs/merkle-proofs.md).
+- For preset-dependent types, pass the chain specs to `NewDynSsz` — list
+  limits change the subtree depth and with it every generalized index below.

--- a/examples/merkle-proofs/go.mod
+++ b/examples/merkle-proofs/go.mod
@@ -1,0 +1,13 @@
+module merkle-proofs-example
+
+go 1.25.8
+
+require github.com/pk910/dynamic-ssz v1.3.2
+
+require (
+	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/pk910/hashtree-bindings v0.2.5 // indirect
+	golang.org/x/sys v0.30.0 // indirect
+)
+
+replace github.com/pk910/dynamic-ssz => ../../

--- a/examples/merkle-proofs/go.sum
+++ b/examples/merkle-proofs/go.sum
@@ -1,0 +1,6 @@
+github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
+github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
+github.com/pk910/hashtree-bindings v0.2.5 h1:zwONqRIgw40yGEOnGXBORvQVYaXtdZE3bS1ZJohc2/s=
+github.com/pk910/hashtree-bindings v0.2.5/go.mod h1:zrWt88783JmhBfcgni6kkIMYRdXTZi/FL//OyI5T/l4=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/examples/merkle-proofs/main.go
+++ b/examples/merkle-proofs/main.go
@@ -1,0 +1,234 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+
+// Package main demonstrates Merkle tree construction and proof generation
+// with dynamic-ssz's treeproof package.
+//
+// This is the pattern used to prove validator data out of the beacon state
+// for on-chain verification: build the state tree once with GetTree, derive
+// generalized indices for the fields to prove, generate proofs with
+// Prove/ProveMulti, and sanity-check each proof leaf against the field's own
+// hash tree root before trusting it.
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+
+	dynssz "github.com/pk910/dynamic-ssz"
+	"github.com/pk910/dynamic-ssz/treeproof"
+)
+
+// BeaconBlockHeader mirrors the consensus-spec block header container.
+type BeaconBlockHeader struct {
+	Slot          uint64
+	ProposerIndex uint64
+	ParentRoot    [32]byte
+	StateRoot     [32]byte
+	BodyRoot      [32]byte
+}
+
+// Validator mirrors the consensus-spec validator container (shortened).
+type Validator struct {
+	Pubkey                [48]byte
+	WithdrawalCredentials [32]byte
+	EffectiveBalance      uint64
+	Slashed               bool
+	ActivationEpoch       uint64
+	ExitEpoch             uint64
+}
+
+// Checkpoint is a simplified epoch checkpoint.
+type Checkpoint struct {
+	Epoch uint64
+	Root  [32]byte
+}
+
+// Generalized-index layout constants for BeaconState. With 8 fields the
+// container merkleizes into 8 chunks, so field i sits at generalized index
+// 8+i. The real beacon state works the same way with 2^5..2^6 fields
+// depending on the fork.
+const (
+	stateChunkCeil       = 8    // next power of two >= field count
+	slotFieldIndex       = 1    // BeaconState.Slot
+	validatorsFieldIndex = 5    // BeaconState.Validators
+	validatorsLimit      = 1024 // must match the ssz-max tag
+)
+
+// BeaconState is a reduced beacon-state-like container: exactly 8 fields, so
+// the generalized-index math stays easy to follow.
+type BeaconState struct {
+	GenesisTime         uint64
+	Slot                uint64
+	LatestBlockHeader   BeaconBlockHeader
+	BlockRoots          [][32]byte  `ssz-size:"64,32"`
+	StateRoots          [][32]byte  `ssz-size:"64,32"`
+	Validators          []Validator `ssz-max:"1024"`
+	Balances            []uint64    `ssz-max:"1024"`
+	FinalizedCheckpoint Checkpoint
+}
+
+func main() {
+	fmt.Println("Merkle Proofs Example — prove fields out of an SSZ structure")
+	fmt.Println("=============================================================")
+
+	ds := dynssz.NewDynSsz(nil)
+	state := buildState(100)
+
+	// Build the complete Merkle tree once, then generate as many proofs from
+	// it as needed. Rebuilding the tree per proof is the expensive mistake.
+	tree, err := ds.GetTree(state)
+	if err != nil {
+		log.Fatal("Failed to build tree: ", err)
+	}
+
+	stateRoot, err := ds.HashTreeRoot(state)
+	if err != nil {
+		log.Fatal("Failed to hash state: ", err)
+	}
+
+	fmt.Printf("\nstate root:     0x%x\n", stateRoot)
+	fmt.Printf("tree root hash: 0x%x (identical)\n", tree.Hash())
+
+	// The tree structure determines the generalized indices. Show the top
+	// levels — the 8 field subtrees sit at indices 8..15.
+	fmt.Println("\n1. Tree structure (top 3 levels):")
+	tree.Show(3)
+
+	// 2. Prove a simple field: Slot is field 1, so its leaf lives at
+	// generalized index 8+1 = 9.
+	fmt.Println("\n2. Prove the Slot field (generalized index 9):")
+
+	slotProof, err := tree.Prove(stateChunkCeil + slotFieldIndex)
+	if err != nil {
+		log.Fatal("Failed to prove slot: ", err)
+	}
+
+	fmt.Printf("  leaf (little-endian slot): 0x%x\n", slotProof.Leaf[:8])
+	fmt.Printf("  sibling hashes: %d\n", len(slotProof.Hashes))
+
+	valid, err := treeproof.VerifyProof(tree.Hash(), slotProof)
+	if err != nil {
+		log.Fatal("Failed to verify slot proof: ", err)
+	}
+
+	fmt.Printf("  verified against state root: %v\n", valid)
+
+	// 3. Prove a single validator inside the Validators list. The
+	// generalized index is derived step by step, the same walk used to
+	// prove validators out of the real beacon state.
+	validatorIndex := uint64(42)
+
+	fmt.Printf("\n3. Prove validator %d inside the Validators list:\n", validatorIndex)
+
+	gid := uint64(1)                                // start at the root
+	gid = gid*stateChunkCeil + validatorsFieldIndex // descend to the Validators field
+	gid *= 2                                        // lists mix in their length: data subtree is the left child
+	gid = gid*validatorsLimit + validatorIndex      // descend to element 42 within the 1024-leaf data subtree
+
+	fmt.Printf("  generalized index: 1 → %d (field) → %d (list data) → %d (element)\n",
+		stateChunkCeil+validatorsFieldIndex, (stateChunkCeil+validatorsFieldIndex)*2, gid)
+
+	validatorProof, err := tree.Prove(int(gid))
+	if err != nil {
+		log.Fatal("Failed to prove validator: ", err)
+	}
+
+	// Sanity-check the proof leaf against the validator's own hash tree root
+	// before using it — always do this for proofs that get submitted
+	// on-chain.
+	validatorRoot, err := ds.HashTreeRoot(&state.Validators[validatorIndex])
+	if err != nil {
+		log.Fatal("Failed to hash validator: ", err)
+	}
+
+	if !bytes.Equal(validatorProof.Leaf, validatorRoot[:]) {
+		log.Fatal("proof leaf does not match validator root")
+	}
+
+	fmt.Printf("  proof leaf matches HashTreeRoot(validator[%d]): true\n", validatorIndex)
+	fmt.Printf("  proof depth: %d sibling hashes\n", len(validatorProof.Hashes))
+
+	valid, err = treeproof.VerifyProof(tree.Hash(), validatorProof)
+	if err != nil {
+		log.Fatal("Failed to verify validator proof: ", err)
+	}
+
+	fmt.Printf("  verified against state root: %v\n", valid)
+
+	// 4. Multiproof: prove several fields at once with shared sibling
+	// hashes — cheaper to transmit and verify than independent proofs.
+	fmt.Println("\n4. Multiproof over GenesisTime, Slot and FinalizedCheckpoint:")
+
+	indices := []int{
+		stateChunkCeil + 0, // GenesisTime
+		stateChunkCeil + 1, // Slot
+		stateChunkCeil + 7, // FinalizedCheckpoint
+	}
+
+	multiproof, err := tree.ProveMulti(indices)
+	if err != nil {
+		log.Fatal("Failed to build multiproof: ", err)
+	}
+
+	fmt.Printf("  %d leaves proven with %d shared hashes ", len(multiproof.Leaves), len(multiproof.Hashes))
+	fmt.Printf("(three single proofs would need %d)\n", 3*len(slotProof.Hashes))
+
+	valid, err = treeproof.VerifyMultiproof(tree.Hash(), multiproof.Hashes, multiproof.Leaves, multiproof.Indices)
+	if err != nil {
+		log.Fatal("Failed to verify multiproof: ", err)
+	}
+
+	fmt.Printf("  multiproof verified: %v\n", valid)
+
+	// 5. Verification is standalone: root + proof, no tree, no original
+	// data. This is what runs on the other side (a contract, a light
+	// client, another process).
+	fmt.Println("\n5. Standalone verification:")
+
+	root := tree.Hash()
+	tree = nil // the tree can be dropped now — for large states, nil it out to release memory early
+
+	_ = tree
+
+	valid, err = treeproof.VerifyProof(root, validatorProof)
+	if err != nil {
+		log.Fatal("Failed to verify: ", err)
+	}
+
+	fmt.Printf("  validator proof verified with only the root and the proof: %v\n", valid)
+}
+
+func buildState(validatorCount int) *BeaconState {
+	state := &BeaconState{
+		GenesisTime: 1606824023,
+		Slot:        123456,
+		LatestBlockHeader: BeaconBlockHeader{
+			Slot:          123455,
+			ProposerIndex: 7,
+		},
+		BlockRoots: make([][32]byte, 64),
+		StateRoots: make([][32]byte, 64),
+		Validators: make([]Validator, 0, validatorCount),
+		Balances:   make([]uint64, 0, validatorCount),
+		FinalizedCheckpoint: Checkpoint{
+			Epoch: 3858,
+			Root:  [32]byte{0x01},
+		},
+	}
+
+	for i := 0; i < validatorCount; i++ {
+		validator := Validator{
+			EffectiveBalance: 32_000_000_000,
+			ExitEpoch:        ^uint64(0),
+		}
+		validator.Pubkey[0] = byte(i)
+		validator.WithdrawalCredentials[0] = 0x01
+
+		state.Validators = append(state.Validators, validator)
+		state.Balances = append(state.Balances, 32_000_000_000+uint64(i))
+	}
+
+	return state
+}

--- a/examples/streaming/README.md
+++ b/examples/streaming/README.md
@@ -1,0 +1,47 @@
+# Streaming Example
+
+Stream SSZ directly to/from files and network connections without holding the
+serialized payload in memory next to the decoded struct.
+
+The canonical use case is beacon state ingestion: a mainnet state is ~310 MB
+serialized, and decoding it straight off the HTTP response body with
+`UnmarshalSSZReader` drops the duplicate payload buffer:
+
+```go
+var SSZ = dynssz.NewDynSsz(nil, dynssz.WithStreamReaderBufferSize(1<<20))
+```
+
+## Run
+
+```bash
+go run .
+```
+
+## What it shows
+
+1. **`MarshalSSZWriter`** — stream-encode a 100k-validator registry (~11 MB)
+   straight into a file.
+2. **`UnmarshalSSZReader`** — stream-decode with a known total size (from
+   `os.Stat`, or an HTTP `Content-Length`). The size is required because SSZ
+   offsets can't be interpreted without it.
+3. **A size-known / size-unknown fallback** for HTTP downloads: stream when
+   `Content-Length` is present, fall back to `io.ReadAll` + `UnmarshalSSZ`
+   for chunked responses. (Tip: request with `Accept-Encoding: identity` to
+   keep `Content-Length` available on beacon API downloads.)
+4. **`io.Pipe` streaming** — encoder goroutine feeding a decoder with no
+   intermediate buffer at all, the shape of direct network transmission.
+5. **Allocation measurement** — buffered decode allocates payload + struct,
+   streamed decode allocates the struct only.
+
+## Notes
+
+- **Untrusted input**: the unknown-size fallback reads to EOF unbounded. Wrap
+  untrusted readers in an `io.LimitReader` and pass that limit as the size.
+- **CPU trade-off**: streaming costs ~1.3x (encode) to ~2x (decode) CPU
+  because stream encoders can't seek back to patch offsets. Use it for large
+  payloads, not small messages.
+- **Codegen**: `dynssz-gen -with-streaming` (or `with-streaming: true` in a
+  config file) additionally emits `MarshalSSZEncoder`/`UnmarshalSSZDecoder`
+  methods so generated types take the optimized path under
+  `MarshalSSZWriter`/`UnmarshalSSZReader` too. See
+  [docs/streaming.md](../../docs/streaming.md).

--- a/examples/streaming/go.mod
+++ b/examples/streaming/go.mod
@@ -1,0 +1,13 @@
+module streaming-example
+
+go 1.25.8
+
+require github.com/pk910/dynamic-ssz v1.3.2
+
+require (
+	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/pk910/hashtree-bindings v0.2.5 // indirect
+	golang.org/x/sys v0.30.0 // indirect
+)
+
+replace github.com/pk910/dynamic-ssz => ../../

--- a/examples/streaming/go.sum
+++ b/examples/streaming/go.sum
@@ -1,0 +1,6 @@
+github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
+github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
+github.com/pk910/hashtree-bindings v0.2.5 h1:zwONqRIgw40yGEOnGXBORvQVYaXtdZE3bS1ZJohc2/s=
+github.com/pk910/hashtree-bindings v0.2.5/go.mod h1:zrWt88783JmhBfcgni6kkIMYRdXTZi/FL//OyI5T/l4=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/examples/streaming/main.go
+++ b/examples/streaming/main.go
@@ -1,0 +1,265 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+
+// Package main demonstrates streaming SSZ encoding and decoding.
+//
+// Streaming lets you process large SSZ objects without holding the entire
+// serialized form in memory next to the decoded struct. The canonical case
+// is downloading a mainnet beacon state (~310 MB serialized) and decoding it
+// straight off the HTTP response body with UnmarshalSSZReader — halving peak
+// memory versus read-then-unmarshal.
+//
+// Shown here:
+//  1. Stream-encoding to a file with MarshalSSZWriter.
+//  2. Stream-decoding from a file with UnmarshalSSZReader and a known size.
+//  3. A size-known / size-unknown fallback helper for HTTP bodies
+//     (Content-Length present vs chunked responses).
+//  4. Network-style streaming through an io.Pipe without any intermediate
+//     buffer.
+//  5. An allocation comparison between buffered and streamed decoding.
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"runtime"
+
+	dynssz "github.com/pk910/dynamic-ssz"
+)
+
+// Validator mirrors the consensus-spec validator container (shortened).
+type Validator struct {
+	Pubkey                [48]byte
+	WithdrawalCredentials [32]byte
+	EffectiveBalance      uint64
+	Slashed               bool
+	ActivationEpoch       uint64
+	ExitEpoch             uint64
+}
+
+// ValidatorRegistry is a large, list-heavy structure — the shape where
+// streaming pays off. With 100k validators it serializes to ~11 MB.
+type ValidatorRegistry struct {
+	Slot       uint64
+	BlockRoots [][32]byte  `ssz-size:"64,32"`
+	Validators []Validator `ssz-max:"1099511627776"`
+	Balances   []uint64    `ssz-max:"1099511627776"`
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	fmt.Println("Streaming Example — SSZ without the intermediate buffer")
+	fmt.Println("========================================================")
+
+	// The stream reader buffer defaults to 2 KB. For multi-megabyte payloads
+	// a larger buffer avoids many small reads — 1 MB is a good fit for
+	// beacon-state-sized downloads.
+	ds := dynssz.NewDynSsz(nil, dynssz.WithStreamReaderBufferSize(1<<20))
+
+	registry := buildRegistry(100_000)
+
+	size, err := ds.SizeSSZ(registry)
+	if err != nil {
+		return fmt.Errorf("failed to compute size: %w", err)
+	}
+
+	fmt.Printf("\nRegistry with %d validators serializes to %.1f MB\n",
+		len(registry.Validators), float64(size)/(1<<20))
+
+	// 1. Stream-encode directly to a file — no full serialization buffer.
+	fmt.Println("\n1. MarshalSSZWriter — stream-encode to a file:")
+
+	file, err := os.CreateTemp("", "registry-*.ssz")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer os.Remove(file.Name())
+
+	if err = ds.MarshalSSZWriter(registry, file); err != nil {
+		return fmt.Errorf("failed to stream-encode: %w", err)
+	}
+
+	if err = file.Close(); err != nil {
+		return fmt.Errorf("failed to close file: %w", err)
+	}
+
+	info, err := os.Stat(file.Name())
+	if err != nil {
+		return fmt.Errorf("failed to stat file: %w", err)
+	}
+
+	fmt.Printf("  wrote %d bytes to %s\n", info.Size(), file.Name())
+
+	// 2. Stream-decode from the file. The total size must be known so
+	// offsets can be interpreted; for files it comes from Stat.
+	fmt.Println("\n2. UnmarshalSSZReader — stream-decode with a known size:")
+
+	reader, err := os.Open(file.Name())
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+
+	var decoded ValidatorRegistry
+
+	err = ds.UnmarshalSSZReader(&decoded, reader, int(info.Size()))
+
+	_ = reader.Close()
+
+	if err != nil {
+		return fmt.Errorf("failed to stream-decode: %w", err)
+	}
+
+	fmt.Printf("  decoded %d validators, %d balances\n", len(decoded.Validators), len(decoded.Balances))
+
+	originalRoot, err := ds.HashTreeRoot(registry)
+	if err != nil {
+		return fmt.Errorf("failed to hash original: %w", err)
+	}
+
+	decodedRoot, err := ds.HashTreeRoot(&decoded)
+	if err != nil {
+		return fmt.Errorf("failed to hash decoded: %w", err)
+	}
+
+	fmt.Printf("  hash tree roots match: %v\n", originalRoot == decodedRoot)
+
+	// 3. The download fallback pattern: stream when the size is known
+	// (HTTP Content-Length), buffer when it is not (chunked encoding).
+	fmt.Println("\n3. Size-known / size-unknown fallback (HTTP download pattern):")
+
+	chunked, err := os.Open(file.Name())
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+
+	var fromChunked ValidatorRegistry
+	if err = decodeSSZ(ds, &fromChunked, chunked, -1); err != nil {
+		return fmt.Errorf("failed to decode without size: %w", err)
+	}
+
+	fmt.Printf("  chunked response (unknown size) decoded via buffered fallback: %d validators\n",
+		len(fromChunked.Validators))
+
+	// 4. Network-style streaming: encoder and decoder connected by a pipe.
+	// Nothing is ever fully buffered — bytes flow from MarshalSSZWriter to
+	// UnmarshalSSZReader as they are produced. The receiver only needs to
+	// know the total size up front (an SSZ response's Content-Length).
+	fmt.Println("\n4. io.Pipe — sender and receiver with no intermediate buffer:")
+
+	pipeReader, pipeWriter := io.Pipe()
+
+	go func() {
+		pipeWriter.CloseWithError(ds.MarshalSSZWriter(registry, pipeWriter))
+	}()
+
+	var received ValidatorRegistry
+	if err = ds.UnmarshalSSZReader(&received, pipeReader, size); err != nil {
+		return fmt.Errorf("failed to decode from pipe: %w", err)
+	}
+
+	fmt.Printf("  received %d validators over the pipe\n", len(received.Validators))
+
+	// 5. Allocation comparison: read-then-unmarshal vs streamed decode.
+	fmt.Println("\n5. Allocations, buffered vs streamed decode:")
+
+	buffered, err := measureAllocs(func() error {
+		data, readErr := os.ReadFile(file.Name())
+		if readErr != nil {
+			return fmt.Errorf("failed to read file: %w", readErr)
+		}
+
+		var target ValidatorRegistry
+
+		return ds.UnmarshalSSZ(&target, data)
+	})
+	if err != nil {
+		return err
+	}
+
+	streamed, err := measureAllocs(func() error {
+		streamFile, openErr := os.Open(file.Name())
+		if openErr != nil {
+			return fmt.Errorf("failed to open file: %w", openErr)
+		}
+		defer streamFile.Close()
+
+		var target ValidatorRegistry
+
+		return ds.UnmarshalSSZReader(&target, streamFile, int(info.Size()))
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("  buffered: %6.1f MB allocated (payload buffer + decoded struct)\n", float64(buffered)/(1<<20))
+	fmt.Printf("  streamed: %6.1f MB allocated (decoded struct only)\n", float64(streamed)/(1<<20))
+	fmt.Println()
+	fmt.Println("Streaming trades ~1.3-2x CPU for the dropped payload buffer — worth it")
+	fmt.Println("for beacon states, not for small messages. See docs/streaming.md.")
+
+	return nil
+}
+
+// decodeSSZ is a fallback helper for beacon API downloads: stream directly
+// when the payload size is known, buffer when it is not (SSZ offsets cannot
+// be interpreted without the total size). For untrusted streams, wrap the
+// reader in an io.LimitReader instead of using the unbounded buffered path.
+func decodeSSZ(ds *dynssz.DynSsz, target any, data io.ReadCloser, size int64) error {
+	defer func() { _ = data.Close() }()
+
+	if size > 0 {
+		return ds.UnmarshalSSZReader(target, data, int(size))
+	}
+
+	dataBytes, err := io.ReadAll(data)
+	if err != nil {
+		return fmt.Errorf("failed to read payload: %w", err)
+	}
+
+	return ds.UnmarshalSSZ(target, dataBytes)
+}
+
+func measureAllocs(work func() error) (uint64, error) {
+	var before, after runtime.MemStats
+
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+
+	if err := work(); err != nil {
+		return 0, err
+	}
+
+	runtime.ReadMemStats(&after)
+
+	return after.TotalAlloc - before.TotalAlloc, nil
+}
+
+func buildRegistry(validatorCount int) *ValidatorRegistry {
+	registry := &ValidatorRegistry{
+		Slot:       123456,
+		BlockRoots: make([][32]byte, 64),
+		Validators: make([]Validator, 0, validatorCount),
+		Balances:   make([]uint64, 0, validatorCount),
+	}
+
+	for i := 0; i < validatorCount; i++ {
+		validator := Validator{
+			EffectiveBalance: 32_000_000_000,
+			ExitEpoch:        ^uint64(0),
+		}
+		validator.Pubkey[0] = byte(i)
+		validator.Pubkey[1] = byte(i >> 8)
+
+		registry.Validators = append(registry.Validators, validator)
+		registry.Balances = append(registry.Balances, 32_000_000_000+uint64(i))
+	}
+
+	return registry
+}

--- a/examples/streaming/main.go
+++ b/examples/streaming/main.go
@@ -154,6 +154,7 @@ func run() error {
 	fmt.Println("\n4. io.Pipe — sender and receiver with no intermediate buffer:")
 
 	pipeReader, pipeWriter := io.Pipe()
+	defer pipeReader.Close()
 
 	go func() {
 		pipeWriter.CloseWithError(ds.MarshalSSZWriter(registry, pipeWriter))


### PR DESCRIPTION
## Summary

Adds four new CI-tested examples covering the library's advanced features as they are used in production:

- **`examples/chain-specs`** — preset-aware serialization: loads a beacon-chain config YAML into a spec map, shows the dual `ssz-*`/`dynssz-*` tag convention with arithmetic expressions, the byte-identical `NewDynSsz(nil)` mainnet fallback, and preset-mismatch detection.
- **`examples/streaming`** — `MarshalSSZWriter`/`UnmarshalSSZReader` with `WithStreamReaderBufferSize`, a known/unknown-size fallback for HTTP downloads, `io.Pipe` network-style streaming, and a live allocation comparison (buffered vs streamed decode).
- **`examples/merkle-proofs`** — `GetTree`/`Prove`/`ProveMulti` with step-by-step generalized-index arithmetic into a validator list, leaf sanity checks against `HashTreeRoot`, multiproofs, and standalone `VerifyProof`/`VerifyMultiproof`.
- **`examples/fork-views`** — one fork-agnostic `BuilderBid` data type with per-fork view types, `WithViewDescriptor` round-trips, startup `ValidateType` checks, view + dynamic-spec composition, and a working view-only `generate.yaml`.

Each example is a standalone module (`replace` to the repo root) runnable with a single `go run .`. All four are added to the examples CI matrix and the root README listing; the examples workflow now runs on the latest Go version only (no version matrix).

## Test plan

- [x] `go vet ./...`, `gofmt -l`, and full `go run .` pass for all four examples
- [x] fork-views `generate.yaml` verified end-to-end: generated view codecs produce byte-identical output and roots vs reflection
- [x] Examples CI workflow extended to run all four