### PR TITLE
Fuzzing fixes: unknown-size stream over-read + codegen without-dynamic-expressions delegation

### DIFF
--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -831,6 +831,27 @@ func TestGenerateWithReflectViews(t *testing.T) {
 	}
 }
 
+// TestGenerateViewSameAsDataType verifies that listing the data type itself as
+// a view is rejected. Emitting it would produce a `case *T` alongside the
+// dispatcher's own `case nil, *T`, a duplicate type-switch case that does not
+// compile — yet generation used to report success.
+func TestGenerateViewSameAsDataType(t *testing.T) {
+	cg := NewCodeGenerator(nil)
+	baseType := reflect.TypeOf((*SimpleTestStruct)(nil)).Elem()
+
+	cg.BuildFile("test.go",
+		WithReflectType(baseType, WithReflectViewTypes(baseType)),
+	)
+
+	_, err := cg.GenerateToMap()
+	if err == nil {
+		t.Fatal("expected error when the data type is listed as its own view")
+	}
+	if !strings.Contains(err.Error(), "same as the data type") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 // TestGenerateWithViewOnly tests code generation using view-only mode
 // via the reflect API.
 func TestGenerateWithViewOnly(t *testing.T) {

--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -1351,3 +1351,126 @@ func TestGoTypesPromotedMethodsNotDelegation(t *testing.T) {
 		t.Error("generated code does not handle the sibling Label field")
 	}
 }
+
+// nodynChild is a container reached as a nested field/element by the parents
+// below. Its dynamic []byte field makes it a variable-size type, so parents
+// delegate to it rather than treating it as a fixed blob.
+type nodynChild struct {
+	A []byte `ssz-max:"8"`
+	B uint8
+}
+
+type nodynParentProg struct {
+	L []nodynChild `ssz-type:"progressive-list" ssz-max:"100"`
+}
+type nodynParentList struct {
+	L []nodynChild `ssz-max:"100"`
+}
+type nodynParentVec struct {
+	V [3]nodynChild
+}
+type nodynParentField struct {
+	C nodynChild
+	N uint16
+}
+
+// The invariant (maintainer, non-negotiable): with WithoutDynamicExpressions the
+// generated code must NEVER reference a *Dyn buffer function. A parent nesting a
+// generated child must reach it through the child's static MarshalSSZTo /
+// UnmarshalSSZ / SizeSSZ / HashTreeRootWith methods — never MarshalSSZDyn etc.,
+// and never by wrapping the streaming Encoder/Decoder into the static buffer
+// path. This holds across every combination of -without-fastssz and
+// -with-streaming.
+func TestGenerateWithoutDynExprNeverEmitsDynBuffer(t *testing.T) {
+	dynTokens := []string{"MarshalSSZDyn", "UnmarshalSSZDyn", "SizeSSZDyn", "HashTreeRootWithDyn"}
+
+	combos := []struct {
+		name string
+		opts []CodeGeneratorOption
+	}{
+		{"plain", nil},
+		{"nofast", []CodeGeneratorOption{WithNoFastSsz()}},
+		{"streaming", []CodeGeneratorOption{WithCreateEncoderFn(), WithCreateDecoderFn()}},
+		{"nofast+streaming", []CodeGeneratorOption{WithNoFastSsz(), WithCreateEncoderFn(), WithCreateDecoderFn()}},
+	}
+
+	for _, combo := range combos {
+		t.Run(combo.name, func(t *testing.T) {
+			typeOpts := append([]CodeGeneratorOption{WithoutDynamicExpressions()}, combo.opts...)
+			cg := NewCodeGenerator(nil)
+			cg.BuildFile("gen_nodyn.go",
+				WithReflectType(reflect.TypeFor[nodynParentProg](), typeOpts...),
+				WithReflectType(reflect.TypeFor[nodynParentList](), typeOpts...),
+				WithReflectType(reflect.TypeFor[nodynParentVec](), typeOpts...),
+				WithReflectType(reflect.TypeFor[nodynParentField](), typeOpts...),
+				WithReflectType(reflect.TypeFor[nodynChild](), typeOpts...),
+			)
+			files, err := cg.GenerateToMap()
+			if err != nil {
+				t.Fatalf("generate: %v", err)
+			}
+			code := files["gen_nodyn.go"]
+			if code == "" {
+				t.Fatal("no code generated")
+			}
+			for _, tok := range dynTokens {
+				if strings.Contains(code, tok) {
+					t.Errorf("generated code references forbidden %s under without-dynamic-expressions:\n%s", tok, code)
+				}
+			}
+			// The parents must actually reach the child via its static methods.
+			for _, want := range []string{".MarshalSSZTo(", ".UnmarshalSSZ(", ".SizeSSZ()", ".HashTreeRootWith("} {
+				if !strings.Contains(code, want) {
+					t.Errorf("expected the parent to call the child's static %s, not found:\n%s", want, code)
+				}
+			}
+		})
+	}
+}
+
+// nodynExtInlineHolder nests regenDelegated, an EXTERNAL fully-delegated type
+// that implements only the Dynamic* methods and carries ssz-static:"true".
+// Under WithoutDynamicExpressions its dynamic methods cannot be called, so it is
+// inlined from its traversed structure instead of forwarded to *Dyn or errored.
+type nodynExtInlineHolder struct {
+	A uint64
+	N regenDelegated
+}
+
+func TestGenerateWithoutDynExprInlinesExternalDynOnly(t *testing.T) {
+	cg := NewCodeGenerator(nil)
+	cg.BuildFile("gen_nodyn_inline.go",
+		WithReflectType(reflect.TypeFor[nodynExtInlineHolder](), WithoutDynamicExpressions()))
+	files, err := cg.GenerateToMap()
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	code := files["gen_nodyn_inline.go"]
+	for _, tok := range []string{"MarshalSSZDyn", "UnmarshalSSZDyn", "SizeSSZDyn", "HashTreeRootWithDyn"} {
+		if strings.Contains(code, tok) {
+			t.Errorf("external dynamic-only type must be inlined, not forwarded to %s:\n%s", tok, code)
+		}
+	}
+	// The inlined structure must appear (the delegated type's V [8]byte field).
+	if !strings.Contains(code, ".V[") {
+		t.Errorf("expected the external type's structure to be inlined (field V), got:\n%s", code)
+	}
+}
+
+// A cyclic type generated with WithoutDynamicExpressions terminates the cycle
+// through the member's static MarshalSSZTo (generation-set members carry the
+// fastssz-style flag in this mode) even with -without-fastssz, since the static
+// path is mandatory there.
+func TestGenerateWithoutDynExprRecursiveCycle(t *testing.T) {
+	cg := NewCodeGenerator(nil)
+	cg.BuildFile("gen_rec_nodyn.go",
+		WithReflectType(reflect.TypeFor[inlineCycleRoot](), WithoutDynamicExpressions(), WithNoFastSsz()),
+		WithReflectType(reflect.TypeFor[inlineCycleMember](), WithoutDynamicExpressions(), WithNoFastSsz()))
+	files, err := cg.GenerateToMap()
+	if err != nil {
+		t.Fatalf("recursive cycle should generate statically under without-dynamic-expressions: %v", err)
+	}
+	if strings.Contains(files["gen_rec_nodyn.go"], "Dyn(") {
+		t.Errorf("static recursive output must contain no *Dyn call:\n%s", files["gen_rec_nodyn.go"])
+	}
+}

--- a/codegen/gen_decoder.go
+++ b/codegen/gen_decoder.go
@@ -751,7 +751,11 @@ func (ctx *decoderContext) unmarshalVector(desc *ssztypes.TypeDescriptor, varNam
 		ctx.appendCode(indent, "startOffset, err := dec.DecodeOffset()\n")
 		ctx.appendCode(indent, "if err != nil {\n\treturn %s\n}\n", typePath.getErrorWith("err"))
 		errCode = fmt.Sprintf("sszutils.ErrFirstOffsetMismatchFn(startOffset, %s*4)", limitVar)
-		ctx.appendCode(indent, "if startOffset != %s*4 {\n\treturn %s\n}\n", limitVar, typePath.getErrorWith(errCode))
+		// startOffset is a uint32 (from DecodeOffset); limitVar may be a typed
+		// int expression (e.g. int(expr0)) when the vector length is dynamic, so
+		// the comparison RHS must be converted to uint32 to keep the types
+		// compatible. A bare int literal limitVar stays an untyped constant.
+		ctx.appendCode(indent, "if startOffset != uint32(%s*4) {\n\treturn %s\n}\n", limitVar, typePath.getErrorWith(errCode))
 
 		// read offsets
 		ctx.appendCode(indent, "var offsets []uint32\n")

--- a/codegen/gen_decoder.go
+++ b/codegen/gen_decoder.go
@@ -270,18 +270,27 @@ func (ctx *decoderContext) unmarshalDelegatedMethod(desc *ssztypes.TypeDescripto
 		// fall through: inline the type's structure via the switch below
 	} else if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicUnmarshaler != 0 {
 		sizeStr := "-1"
-		if desc.Size > 0 {
-			sizeStr = fmt.Sprintf("%d", desc.Size)
-		} else if desc.SszTypeFlags&ssztypes.SszTypeFlagIsDynamic == 0 &&
-			desc.SszTypeFlags&ssztypes.SszTypeFlagHasSizeExpr != 0 && !ctx.options.WithoutDynamicExpressions {
-			// A delegated STATIC type without a compile-time size (shallow
-			// descriptor) occupies exactly its own runtime size; reading the
-			// whole remaining region would swallow subsequent fields.
+		switch {
+		case desc.SszTypeFlags&ssztypes.SszTypeFlagIsDynamic == 0 &&
+			desc.SszTypeFlags&ssztypes.SszTypeFlagHasSizeExpr != 0 && !ctx.options.WithoutDynamicExpressions:
+			// A delegated fixed-size type carrying a size expression occupies its
+			// RUNTIME-resolved size, which is what the (always runtime-resolving)
+			// streaming encoder used to write it. Frame the delegated region with
+			// that runtime size, NOT the baked static desc.Size: preferring the
+			// static size here makes the streaming decoder under-/over-read the
+			// region whenever the runtime specs differ from the static default,
+			// so it cannot decode its own valid output (ws14-01). This branch is
+			// checked before the static one precisely because such a type has both
+			// a concrete desc.Size and a size expression. A shallow delegated type
+			// (desc.Size == 0) also lands here — reading the whole remaining region
+			// would otherwise swallow subsequent fields.
 			sizeVar, verr := ctx.staticSizeVars.getStaticSizeVar(desc)
 			if verr != nil {
 				return false, verr
 			}
 			sizeStr = fmt.Sprintf("int(%s)", sizeVar)
+		case desc.Size > 0:
+			sizeStr = fmt.Sprintf("%d", desc.Size)
 		}
 		ctx.appendCode(indent, "if buf, err := sszutils.DecodeDelegateBuffer(dec, %s); err != nil {\n", sizeStr)
 		ctx.appendCode(indent+1, "return err\n")

--- a/codegen/gen_decoder.go
+++ b/codegen/gen_decoder.go
@@ -207,6 +207,81 @@ func (ctx *decoderContext) isInlinable(desc *ssztypes.TypeDescriptor) bool {
 	return false
 }
 
+// unmarshalDelegatedMethod emits a delegation to a nested type's generated
+// decoder/unmarshaler when one is available and returns handled=true; it returns
+// handled=false to signal the caller should inline the type's structure via the
+// structural switch. It must only be called for non-root, non-view types.
+func (ctx *decoderContext) unmarshalDelegatedMethod(desc *ssztypes.TypeDescriptor, varName string, indent int) (handled bool, err error) {
+	hasDynamicSize := desc.SszTypeFlags&ssztypes.SszTypeFlagHasSizeExpr != 0
+	isFastsszUnmarshaler := desc.SszCompatFlags&ssztypes.SszCompatFlagFastSSZMarshaler != 0
+	useFastSsz := !ctx.options.NoFastSsz && isFastsszUnmarshaler && !hasDynamicSize
+	if !useFastSsz && desc.SszType == ssztypes.SszCustomType {
+		useFastSsz = true
+	}
+	// Custom types prefer their spec-aware dynssz methods over fastssz.
+	if desc.SszType == ssztypes.SszCustomType &&
+		desc.SszCompatFlags&(ssztypes.SszCompatFlagDynamicUnmarshaler|ssztypes.SszCompatFlagDynamicDecoder) != 0 {
+		useFastSsz = false
+	}
+
+	if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicDecoder != 0 {
+		ctx.appendCode(indent, "if err = %s.UnmarshalSSZDecoder(ds, dec); err != nil {\n\treturn err\n}\n", varName)
+		ctx.usedDynSpecs = true
+		return true, nil
+	}
+
+	if useFastSsz {
+		sizeStr := "-1"
+		if desc.Size > 0 {
+			sizeStr = fmt.Sprintf("%d", desc.Size)
+		}
+		ctx.appendCode(indent, "if buf, err := sszutils.DecodeDelegateBuffer(dec, %s); err != nil {\n", sizeStr)
+		ctx.appendCode(indent+1, "return err\n")
+		ctx.appendCode(indent, "} else if err = %s.UnmarshalSSZ(buf); err != nil {\n", varName)
+		ctx.appendCode(indent+1, "return err\n")
+		ctx.appendCode(indent, "}\n")
+		return true, nil
+	}
+
+	// The streaming decoder may take ds, but it must still never reference a
+	// *Dyn buffer method under WithoutDynamicExpressions. A generated child is
+	// reached via its static UnmarshalSSZ or its streaming UnmarshalSSZDecoder
+	// above; a remaining dynamic-only type is inlined by falling through to the
+	// structural switch below, unless it has no traversable structure (custom
+	// or shallow-delegated externals), which cannot be inlined.
+	if ctx.options.WithoutDynamicExpressions &&
+		desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicUnmarshaler != 0 {
+		if desc.SszType == ssztypes.SszCustomType || isShallowDelegatedDescriptor(desc) {
+			return false, fmt.Errorf("cannot generate static decoder for %s under without-dynamic-expressions: it provides only a dynamic (spec-aware) UnmarshalSSZDyn and has no static UnmarshalSSZ, streaming UnmarshalSSZDecoder, or inlinable structure; add it to the generation set or provide a static unmarshaler", ctx.typePrinter.TypeString(desc))
+		}
+		// fall through: inline the type's structure via the switch below
+	} else if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicUnmarshaler != 0 {
+		sizeStr := "-1"
+		if desc.Size > 0 {
+			sizeStr = fmt.Sprintf("%d", desc.Size)
+		} else if desc.SszTypeFlags&ssztypes.SszTypeFlagIsDynamic == 0 &&
+			desc.SszTypeFlags&ssztypes.SszTypeFlagHasSizeExpr != 0 && !ctx.options.WithoutDynamicExpressions {
+			// A delegated STATIC type without a compile-time size (shallow
+			// descriptor) occupies exactly its own runtime size; reading the
+			// whole remaining region would swallow subsequent fields.
+			sizeVar, verr := ctx.staticSizeVars.getStaticSizeVar(desc)
+			if verr != nil {
+				return false, verr
+			}
+			sizeStr = fmt.Sprintf("int(%s)", sizeVar)
+		}
+		ctx.appendCode(indent, "if buf, err := sszutils.DecodeDelegateBuffer(dec, %s); err != nil {\n", sizeStr)
+		ctx.appendCode(indent+1, "return err\n")
+		ctx.appendCode(indent, "} else if err = %s.UnmarshalSSZDyn(ds, buf); err != nil {\n", varName)
+		ctx.appendCode(indent+1, "return err\n")
+		ctx.appendCode(indent, "}\n")
+		ctx.usedDynSpecs = true
+		return true, nil
+	}
+
+	return false, nil
+}
+
 // unmarshalType generates unmarshal code for any SSZ type, delegating to specific unmarshalers.
 func (ctx *decoderContext) unmarshalType(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int, isRoot, noBufCheck bool) error {
 	// Handle types that have generated methods we can call
@@ -262,70 +337,11 @@ func (ctx *decoderContext) unmarshalType(desc *ssztypes.TypeDescriptor, varName 
 	}
 
 	if !isRoot && !isView {
-		hasDynamicSize := desc.SszTypeFlags&ssztypes.SszTypeFlagHasSizeExpr != 0
-		isFastsszUnmarshaler := desc.SszCompatFlags&ssztypes.SszCompatFlagFastSSZMarshaler != 0
-		useFastSsz := !ctx.options.NoFastSsz && isFastsszUnmarshaler && !hasDynamicSize
-		if !useFastSsz && desc.SszType == ssztypes.SszCustomType {
-			useFastSsz = true
+		handled, err := ctx.unmarshalDelegatedMethod(desc, varName, indent)
+		if err != nil {
+			return err
 		}
-		// Custom types prefer their spec-aware dynssz methods over fastssz.
-		if desc.SszType == ssztypes.SszCustomType &&
-			desc.SszCompatFlags&(ssztypes.SszCompatFlagDynamicUnmarshaler|ssztypes.SszCompatFlagDynamicDecoder) != 0 {
-			useFastSsz = false
-		}
-
-		if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicDecoder != 0 {
-			ctx.appendCode(indent, "if err = %s.UnmarshalSSZDecoder(ds, dec); err != nil {\n\treturn err\n}\n", varName)
-			ctx.usedDynSpecs = true
-			return nil
-		}
-
-		if useFastSsz {
-			sizeStr := "-1"
-			if desc.Size > 0 {
-				sizeStr = fmt.Sprintf("%d", desc.Size)
-			}
-			ctx.appendCode(indent, "if buf, err := sszutils.DecodeDelegateBuffer(dec, %s); err != nil {\n", sizeStr)
-			ctx.appendCode(indent+1, "return err\n")
-			ctx.appendCode(indent, "} else if err = %s.UnmarshalSSZ(buf); err != nil {\n", varName)
-			ctx.appendCode(indent+1, "return err\n")
-			ctx.appendCode(indent, "}\n")
-			return nil
-		}
-
-		// The streaming decoder may take ds, but it must still never reference a
-		// *Dyn buffer method under WithoutDynamicExpressions. A generated child is
-		// reached via its static UnmarshalSSZ or its streaming UnmarshalSSZDecoder
-		// above; a remaining dynamic-only type is inlined by falling through to the
-		// structural switch below, unless it has no traversable structure (custom
-		// or shallow-delegated externals), which cannot be inlined.
-		if ctx.options.WithoutDynamicExpressions &&
-			desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicUnmarshaler != 0 {
-			if desc.SszType == ssztypes.SszCustomType || isShallowDelegatedDescriptor(desc) {
-				return fmt.Errorf("cannot generate static decoder for %s under without-dynamic-expressions: it provides only a dynamic (spec-aware) UnmarshalSSZDyn and has no static UnmarshalSSZ, streaming UnmarshalSSZDecoder, or inlinable structure; add it to the generation set or provide a static unmarshaler", ctx.typePrinter.TypeString(desc))
-			}
-			// fall through: inline the type's structure via the switch below
-		} else if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicUnmarshaler != 0 {
-			sizeStr := "-1"
-			if desc.Size > 0 {
-				sizeStr = fmt.Sprintf("%d", desc.Size)
-			} else if desc.SszTypeFlags&ssztypes.SszTypeFlagIsDynamic == 0 &&
-				desc.SszTypeFlags&ssztypes.SszTypeFlagHasSizeExpr != 0 && !ctx.options.WithoutDynamicExpressions {
-				// A delegated STATIC type without a compile-time size (shallow
-				// descriptor) occupies exactly its own runtime size; reading the
-				// whole remaining region would swallow subsequent fields.
-				sizeVar, err := ctx.staticSizeVars.getStaticSizeVar(desc)
-				if err != nil {
-					return err
-				}
-				sizeStr = fmt.Sprintf("int(%s)", sizeVar)
-			}
-			ctx.appendCode(indent, "if buf, err := sszutils.DecodeDelegateBuffer(dec, %s); err != nil {\n", sizeStr)
-			ctx.appendCode(indent+1, "return err\n")
-			ctx.appendCode(indent, "} else if err = %s.UnmarshalSSZDyn(ds, buf); err != nil {\n", varName)
-			ctx.appendCode(indent+1, "return err\n")
-			ctx.appendCode(indent, "}\n")
-			ctx.usedDynSpecs = true
+		if handled {
 			return nil
 		}
 	}

--- a/codegen/gen_decoder.go
+++ b/codegen/gen_decoder.go
@@ -191,12 +191,15 @@ func (ctx *decoderContext) isInlinable(desc *ssztypes.TypeDescriptor) bool {
 		return true
 	}
 
-	// Inline types with generated unmarshal methods
-	if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicUnmarshaler != 0 {
+	// Inline types with generated unmarshal methods. Under WithoutDynamicExpressions
+	// the *Dyn buffer method is never called (the type is structurally inlined
+	// instead), so its presence must not shortcut temp-var creation here.
+	if !ctx.options.WithoutDynamicExpressions && desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicUnmarshaler != 0 {
 		return true
 	}
 
-	// Inline types with generated decoder methods
+	// Inline types with generated decoder methods (streaming; still used under
+	// WithoutDynamicExpressions).
 	if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicDecoder != 0 {
 		return true
 	}
@@ -290,7 +293,19 @@ func (ctx *decoderContext) unmarshalType(desc *ssztypes.TypeDescriptor, varName 
 			return nil
 		}
 
-		if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicUnmarshaler != 0 {
+		// The streaming decoder may take ds, but it must still never reference a
+		// *Dyn buffer method under WithoutDynamicExpressions. A generated child is
+		// reached via its static UnmarshalSSZ or its streaming UnmarshalSSZDecoder
+		// above; a remaining dynamic-only type is inlined by falling through to the
+		// structural switch below, unless it has no traversable structure (custom
+		// or shallow-delegated externals), which cannot be inlined.
+		if ctx.options.WithoutDynamicExpressions &&
+			desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicUnmarshaler != 0 {
+			if desc.SszType == ssztypes.SszCustomType || isShallowDelegatedDescriptor(desc) {
+				return fmt.Errorf("cannot generate static decoder for %s under without-dynamic-expressions: it provides only a dynamic (spec-aware) UnmarshalSSZDyn and has no static UnmarshalSSZ, streaming UnmarshalSSZDecoder, or inlinable structure; add it to the generation set or provide a static unmarshaler", ctx.typePrinter.TypeString(desc))
+			}
+			// fall through: inline the type's structure via the switch below
+		} else if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicUnmarshaler != 0 {
 			sizeStr := "-1"
 			if desc.Size > 0 {
 				sizeStr = fmt.Sprintf("%d", desc.Size)

--- a/codegen/gen_decoder.go
+++ b/codegen/gen_decoder.go
@@ -42,6 +42,12 @@ type decoderContext struct {
 	offsetSliceCounter int
 	offsetSliceLimit   int
 	indexCounter       int
+	// noDynBufferCalls preserves the original WithoutDynamicExpressions setting.
+	// The streaming decoder clears options.WithoutDynamicExpressions so it can use
+	// ds-driven size expressions, but the no-*Dyn-buffer-call invariant must still
+	// hold: a dynamic-only child must be inlined (or rejected), never reached via
+	// UnmarshalSSZDyn. That decision keys off this field, not options.
+	noDynBufferCalls bool
 }
 
 // generateDecoder generates decoder methods for a specific type.
@@ -61,6 +67,10 @@ type decoderContext struct {
 func generateDecoder(rootTypeDesc *ssztypes.TypeDescriptor, codeBuilder *strings.Builder, typePrinter *TypePrinter, viewName string, options *CodeGeneratorOptions) error {
 	// Streaming code always uses dynamic expressions since the decoder interface
 	// requires DynamicSpecs. Override WithoutDynamicExpressions for this generator.
+	// The no-*Dyn-buffer-call invariant is preserved separately via
+	// ctx.noDynBufferCalls so a dynamic-only child is still inlined or rejected
+	// rather than reached through UnmarshalSSZDyn.
+	noDynBufferCalls := options.WithoutDynamicExpressions
 	if options.WithoutDynamicExpressions {
 		optsCopy := *options
 		optsCopy.WithoutDynamicExpressions = false
@@ -75,8 +85,9 @@ func generateDecoder(rootTypeDesc *ssztypes.TypeDescriptor, codeBuilder *strings
 			}
 			codeBuf.WriteString(indentStr(code, indent))
 		},
-		typePrinter: typePrinter,
-		options:     options,
+		typePrinter:      typePrinter,
+		options:          options,
+		noDynBufferCalls: noDynBufferCalls,
 	}
 
 	ctx.exprVars = newExprVarGenerator("expr", typePrinter, options)
@@ -193,8 +204,9 @@ func (ctx *decoderContext) isInlinable(desc *ssztypes.TypeDescriptor) bool {
 
 	// Inline types with generated unmarshal methods. Under WithoutDynamicExpressions
 	// the *Dyn buffer method is never called (the type is structurally inlined
-	// instead), so its presence must not shortcut temp-var creation here.
-	if !ctx.options.WithoutDynamicExpressions && desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicUnmarshaler != 0 {
+	// instead), so its presence must not shortcut temp-var creation here. Keyed off
+	// noDynBufferCalls because the streaming decoder clears options.WithoutDynamicExpressions.
+	if !ctx.noDynBufferCalls && desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicUnmarshaler != 0 {
 		return true
 	}
 
@@ -248,8 +260,9 @@ func (ctx *decoderContext) unmarshalDelegatedMethod(desc *ssztypes.TypeDescripto
 	// reached via its static UnmarshalSSZ or its streaming UnmarshalSSZDecoder
 	// above; a remaining dynamic-only type is inlined by falling through to the
 	// structural switch below, unless it has no traversable structure (custom
-	// or shallow-delegated externals), which cannot be inlined.
-	if ctx.options.WithoutDynamicExpressions &&
+	// or shallow-delegated externals), which cannot be inlined. Keyed off
+	// noDynBufferCalls because the streaming decoder clears WithoutDynamicExpressions.
+	if ctx.noDynBufferCalls &&
 		desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicUnmarshaler != 0 {
 		if desc.SszType == ssztypes.SszCustomType || isShallowDelegatedDescriptor(desc) {
 			return false, fmt.Errorf("cannot generate static decoder for %s under without-dynamic-expressions: it provides only a dynamic (spec-aware) UnmarshalSSZDyn and has no static UnmarshalSSZ, streaming UnmarshalSSZDecoder, or inlinable structure; add it to the generation set or provide a static unmarshaler", ctx.typePrinter.TypeString(desc))

--- a/codegen/gen_encoder.go
+++ b/codegen/gen_encoder.go
@@ -326,7 +326,19 @@ func (ctx *encoderContext) marshalType(desc *ssztypes.TypeDescriptor, varName st
 		return nil
 	}
 
-	if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicMarshaler != 0 && !isRoot && !isView {
+	// The streaming encoder may take ds, but it must still never reference a *Dyn
+	// buffer method under WithoutDynamicExpressions. A generated child is reached
+	// via its static MarshalSSZTo or its streaming MarshalSSZEncoder above; a
+	// remaining dynamic-only type is inlined by falling through to the structural
+	// switch below, unless it has no traversable structure (custom or
+	// shallow-delegated externals), which cannot be inlined.
+	if ctx.options.WithoutDynamicExpressions && !isRoot && !isView &&
+		desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicMarshaler != 0 {
+		if desc.SszType == ssztypes.SszCustomType || isShallowDelegatedDescriptor(desc) {
+			return fmt.Errorf("cannot generate static encoder for %s under without-dynamic-expressions: it provides only a dynamic (spec-aware) MarshalSSZDyn and has no static MarshalSSZTo, streaming MarshalSSZEncoder, or inlinable structure; add it to the generation set or provide a static marshaler", ctx.typePrinter.TypeString(desc))
+		}
+		// fall through: inline the type's structure via the switch below
+	} else if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicMarshaler != 0 && !isRoot && !isView {
 		ctx.appendCode(indent, "if buf, err := %s.MarshalSSZDyn(ds, enc.GetBuffer()); err != nil {\n\treturn %s\n} else {\n\tenc.SetBuffer(buf)\n}\n", varName, typePath.getErrorWith("err"))
 		ctx.usedDynSpecs = true
 		return nil

--- a/codegen/gen_encoder.go
+++ b/codegen/gen_encoder.go
@@ -431,7 +431,7 @@ func (ctx *encoderContext) marshalType(desc *ssztypes.TypeDescriptor, varName st
 	case ssztypes.SszOptionalListType:
 		return ctx.marshalOptionalList(desc, varName, typePath, indent)
 	case ssztypes.SszBigIntType:
-		return ctx.marshalBigInt(desc, varName, indent)
+		return ctx.marshalBigInt(desc, varName, typePath, indent)
 
 	default:
 		return fmt.Errorf("unsupported SSZ type: %v", desc.SszType)
@@ -472,7 +472,15 @@ func (ctx *encoderContext) marshalOptionalList(desc *ssztypes.TypeDescriptor, va
 }
 
 // marshalBigInt generates marshal code for SSZ big int types.
-func (ctx *encoderContext) marshalBigInt(_ *ssztypes.TypeDescriptor, varName string, indent int) error {
+func (ctx *encoderContext) marshalBigInt(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int) error {
+	// Enforce a static ssz-max (payload = sign byte + magnitude), matching the
+	// buffer marshaller so the streaming path rejects an over-max value instead
+	// of serializing it. Dynamic (dynssz-max expression) limits stay unchecked to
+	// keep generated code consistent with the reflection engine.
+	if desc.MaxExpression == nil && desc.Limit > 0 {
+		errCode := fmt.Sprintf("sszutils.NewSszErrorf(sszutils.ErrListTooBig, \"big.Int payload length %%d exceeds maximum %%d\", uint64(1+len(%s.Bytes())), %d)", varName, desc.Limit)
+		ctx.appendCode(indent, "if uint64(1+len(%s.Bytes())) > %d {\n\treturn %s\n}\n", varName, desc.Limit, typePath.getErrorWith(errCode))
+	}
 	// sign byte (0 = non-negative, 1 = negative) followed by the big-endian magnitude
 	ctx.appendCode(indent, "if %s.Sign() < 0 {\n\tenc.EncodeUint8(1)\n} else {\n\tenc.EncodeUint8(0)\n}\n", varName)
 	ctx.appendCode(indent, "enc.EncodeBytes(%s.Bytes())\n", varName)

--- a/codegen/gen_encoder.go
+++ b/codegen/gen_encoder.go
@@ -37,6 +37,12 @@ type encoderContext struct {
 	sizeFnSignature   map[string]string
 	sizeFnNameCounter int
 	indexCounter      int
+	// noDynBufferCalls preserves the original WithoutDynamicExpressions setting.
+	// The streaming encoder clears options.WithoutDynamicExpressions so it can use
+	// ds-driven size expressions, but the no-*Dyn-buffer-call invariant must still
+	// hold: a dynamic-only child must be inlined (or rejected), never reached via
+	// MarshalSSZDyn. That decision keys off this field, not options.
+	noDynBufferCalls bool
 }
 
 // generateEncoder generates encoder methods for a specific type.
@@ -56,6 +62,10 @@ type encoderContext struct {
 func generateEncoder(rootTypeDesc *ssztypes.TypeDescriptor, codeBuilder *strings.Builder, typePrinter *TypePrinter, viewName string, options *CodeGeneratorOptions) error {
 	// Streaming code always uses dynamic expressions since the encoder interface
 	// requires DynamicSpecs. Override WithoutDynamicExpressions for this generator.
+	// The no-*Dyn-buffer-call invariant is preserved separately via
+	// ctx.noDynBufferCalls so a dynamic-only child is still inlined or rejected
+	// rather than reached through MarshalSSZDyn.
+	noDynBufferCalls := options.WithoutDynamicExpressions
 	if options.WithoutDynamicExpressions {
 		optsCopy := *options
 		optsCopy.WithoutDynamicExpressions = false
@@ -70,10 +80,11 @@ func generateEncoder(rootTypeDesc *ssztypes.TypeDescriptor, codeBuilder *strings
 			}
 			codeBuf.WriteString(indentStr(code, indent))
 		},
-		typePrinter:     typePrinter,
-		options:         options,
-		sizeFnNameMap:   make(map[*ssztypes.TypeDescriptor]int),
-		sizeFnSignature: make(map[string]string),
+		typePrinter:      typePrinter,
+		options:          options,
+		sizeFnNameMap:    make(map[*ssztypes.TypeDescriptor]int),
+		sizeFnSignature:  make(map[string]string),
+		noDynBufferCalls: noDynBufferCalls,
 	}
 
 	ctx.exprVars = newExprVarGenerator("ctx.exprs", typePrinter, options)
@@ -332,7 +343,7 @@ func (ctx *encoderContext) marshalType(desc *ssztypes.TypeDescriptor, varName st
 	// remaining dynamic-only type is inlined by falling through to the structural
 	// switch below, unless it has no traversable structure (custom or
 	// shallow-delegated externals), which cannot be inlined.
-	if ctx.options.WithoutDynamicExpressions && !isRoot && !isView &&
+	if ctx.noDynBufferCalls && !isRoot && !isView &&
 		desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicMarshaler != 0 {
 		if desc.SszType == ssztypes.SszCustomType || isShallowDelegatedDescriptor(desc) {
 			return fmt.Errorf("cannot generate static encoder for %s under without-dynamic-expressions: it provides only a dynamic (spec-aware) MarshalSSZDyn and has no static MarshalSSZTo, streaming MarshalSSZEncoder, or inlinable structure; add it to the generation set or provide a static marshaler", ctx.typePrinter.TypeString(desc))

--- a/codegen/gen_hashtreeroot.go
+++ b/codegen/gen_hashtreeroot.go
@@ -424,19 +424,25 @@ func (ctx *hashTreeRootContext) hashOptional(desc *ssztypes.TypeDescriptor, varN
 // the length (0 or 1). The merkleization limit is always 1 (one chunk for
 // basic elements ≤32 bytes, or one element for complex elements).
 func (ctx *hashTreeRootContext) hashOptionalList(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int) error {
-	// Wrap in braces so `idx` and `vlen` don't collide with any caller's locals.
+	// Wrap in braces so `idx` and the length var don't collide with any caller's
+	// locals. The length var uses a dedicated name (not `vlen`): the element is
+	// hashed inline in the same `if` block and a fixed-size vector/list element
+	// declares its own `vlen := len(...)` there. Reusing `vlen` here would let
+	// that inner declaration shadow ours, so the mixin length assignment would
+	// target the element's local and leave the outer length at 0 — mixing in a
+	// length of 0 for a present element and producing the wrong root.
 	ctx.appendCode(indent, "{\n")
 	ctx.appendCode(indent+1, "idx := hh.StartTree(sszutils.TreeTypeBinary)\n")
-	ctx.appendCode(indent+1, "vlen := uint64(0)\n")
+	ctx.appendCode(indent+1, "optListLen := uint64(0)\n")
 	ctx.appendCode(indent+1, "if %s != nil {\n", varName)
+	ctx.appendCode(indent+2, "optListLen = 1\n")
 	innerVarName := fmt.Sprintf("(*%s)", varName)
 	if err := ctx.hashType(desc.ElemDesc, innerVarName, typePath.append("[0]"), indent+2, false, true); err != nil {
 		return err
 	}
-	ctx.appendCode(indent+2, "vlen = 1\n")
 	ctx.appendCode(indent+1, "}\n")
 	ctx.appendCode(indent+1, "hh.FillUpTo32()\n")
-	ctx.appendCode(indent+1, "hh.MerkleizeWithMixin(idx, vlen, 1)\n")
+	ctx.appendCode(indent+1, "hh.MerkleizeWithMixin(idx, optListLen, 1)\n")
 	ctx.appendCode(indent, "}\n")
 	return nil
 }

--- a/codegen/gen_hashtreeroot.go
+++ b/codegen/gen_hashtreeroot.go
@@ -428,7 +428,7 @@ func (ctx *hashTreeRootContext) hashType(desc *ssztypes.TypeDescriptor, varName 
 	case ssztypes.SszOptionalListType:
 		return ctx.hashOptionalList(desc, varName, typePath, indent)
 	case ssztypes.SszBigIntType:
-		return ctx.hashBigInt(desc, varName, indent)
+		return ctx.hashBigInt(desc, varName, typePath, indent)
 
 	default:
 		return fmt.Errorf("unsupported SSZ type: %v", desc.SszType)
@@ -480,7 +480,15 @@ func (ctx *hashTreeRootContext) hashOptionalList(desc *ssztypes.TypeDescriptor, 
 }
 
 // hashBigInt generates hash tree root code for SSZ big int types.
-func (ctx *hashTreeRootContext) hashBigInt(_ *ssztypes.TypeDescriptor, varName string, indent int) error {
+func (ctx *hashTreeRootContext) hashBigInt(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int) error {
+	// Enforce a static ssz-max (payload = sign byte + magnitude), matching the
+	// buffer marshaller so HashTreeRoot does not produce a root for a value that
+	// cannot be serialized. Dynamic (dynssz-max expression) limits stay unchecked
+	// to keep generated code consistent with the reflection engine.
+	if desc.MaxExpression == nil && desc.Limit > 0 {
+		errCode := fmt.Sprintf("sszutils.NewSszErrorf(sszutils.ErrListTooBig, \"big.Int payload length %%d exceeds maximum %%d\", uint64(1+len(%s.Bytes())), %d)", varName, desc.Limit)
+		ctx.appendCode(indent, "if uint64(1+len(%s.Bytes())) > %d {\n\treturn %s\n}\n", varName, desc.Limit, typePath.getErrorWith(errCode))
+	}
 	// Hash the payload byte length, then the sign byte and big-endian magnitude.
 	// Prepending the length keeps it ahead of the trailing-zero chunk padding so
 	// values whose encodings differ only by trailing zeros (e.g. N and N<<8) do

--- a/codegen/gen_hashtreeroot.go
+++ b/codegen/gen_hashtreeroot.go
@@ -226,6 +226,45 @@ func (ctx *hashTreeRootContext) getPtrPrefix(desc *ssztypes.TypeDescriptor, pref
 	return ""
 }
 
+// hashUsesFastSsz reports whether a nested type is hashed through its static
+// fastssz-style method (HashTreeRootWith / HashTreeRoot) rather than being
+// inlined. Under WithoutDynamicExpressions the static method is used even when
+// fastssz delegation is otherwise disabled, because the dynamic path is forbidden.
+func (ctx *hashTreeRootContext) hashUsesFastSsz(desc *ssztypes.TypeDescriptor, isRoot bool) bool {
+	isFastsszHasher := desc.SszCompatFlags&ssztypes.SszCompatFlagFastSSZHasher != 0
+	isFastsszHashWith := desc.SszCompatFlags&ssztypes.SszCompatFlagHashTreeRootWith != 0
+	hasDynamicSize := desc.SszTypeFlags&ssztypes.SszTypeFlagHasSizeExpr != 0 && !ctx.options.WithoutDynamicExpressions
+	hasDynamicMax := desc.SszTypeFlags&ssztypes.SszTypeFlagHasMaxExpr != 0 && !ctx.options.WithoutDynamicExpressions
+
+	useFastSsz := !isRoot && !hasDynamicSize && !hasDynamicMax && (isFastsszHasher || isFastsszHashWith) &&
+		(!ctx.options.NoFastSsz || ctx.options.WithoutDynamicExpressions)
+	if !useFastSsz && desc.SszType == ssztypes.SszCustomType {
+		useFastSsz = true
+	}
+	return useFastSsz
+}
+
+// hashDynamicRoot emits a delegation to a nested type's dynamic hash root method
+// when dynamic expressions are allowed. Under WithoutDynamicExpressions it never
+// calls HashTreeRootWithDyn: it either rejects a type with no inlinable structure
+// or signals (done=false) that the caller should inline the type structurally.
+// It must only be called for non-root, non-view types carrying DynamicHashRoot.
+func (ctx *hashTreeRootContext) hashDynamicRoot(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int, useFastSsz bool) (done bool, err error) {
+	if !ctx.options.WithoutDynamicExpressions {
+		ctx.appendCode(indent, "if err := %s.HashTreeRootWithDyn(ds, hh); err != nil {\n\treturn %s\n}\n", varName, typePath.getErrorWith("err"))
+		ctx.usedDynSpecs = true
+		return true, nil
+	}
+	// The static hash path must never call HashTreeRootWithDyn. If no static
+	// HashTreeRootWith is available, the type is inlined by falling through to
+	// the structural switch below — unless it has no traversable structure
+	// (custom or shallow-delegated externals), which cannot be inlined.
+	if !useFastSsz && (desc.SszType == ssztypes.SszCustomType || isShallowDelegatedDescriptor(desc)) {
+		return true, fmt.Errorf("cannot generate static hash tree root for %s under without-dynamic-expressions: it provides only dynamic (spec-aware) SSZ methods and has no static HashTreeRootWith or inlinable structure; add it to the generation set or provide a static hasher", ctx.typePrinter.TypeString(desc))
+	}
+	return false, nil
+}
+
 // hashType generates hash tree root code for any SSZ type, delegating to specific hashers.
 func (ctx *hashTreeRootContext) hashType(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int, isRoot, pack bool) error {
 	if desc.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 && desc.SszType != ssztypes.SszOptionalType && desc.SszType != ssztypes.SszOptionalListType {
@@ -244,34 +283,12 @@ func (ctx *hashTreeRootContext) hashType(desc *ssztypes.TypeDescriptor, varName 
 		}
 	}
 
-	isFastsszHasher := desc.SszCompatFlags&ssztypes.SszCompatFlagFastSSZHasher != 0
 	isFastsszHashWith := desc.SszCompatFlags&ssztypes.SszCompatFlagHashTreeRootWith != 0
-	hasDynamicSize := desc.SszTypeFlags&ssztypes.SszTypeFlagHasSizeExpr != 0 && !ctx.options.WithoutDynamicExpressions
-	hasDynamicMax := desc.SszTypeFlags&ssztypes.SszTypeFlagHasMaxExpr != 0 && !ctx.options.WithoutDynamicExpressions
-
-	// Under WithoutDynamicExpressions the generated code must be fully static and
-	// must never call HashTreeRootWithDyn. A child exposing a static
-	// HashTreeRootWith (every dynssz-generated child in this mode, plus external
-	// fastssz types) is reached through it even when fastssz delegation is
-	// otherwise disabled, because the dynamic path is forbidden.
-	useFastSsz := !isRoot && !hasDynamicSize && !hasDynamicMax && (isFastsszHasher || isFastsszHashWith) &&
-		(!ctx.options.NoFastSsz || ctx.options.WithoutDynamicExpressions)
-	if !useFastSsz && desc.SszType == ssztypes.SszCustomType {
-		useFastSsz = true
-	}
+	useFastSsz := ctx.hashUsesFastSsz(desc, isRoot)
 
 	if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicHashRoot != 0 && !isRoot && !isView {
-		if !ctx.options.WithoutDynamicExpressions {
-			ctx.appendCode(indent, "if err := %s.HashTreeRootWithDyn(ds, hh); err != nil {\n\treturn %s\n}\n", varName, typePath.getErrorWith("err"))
-			ctx.usedDynSpecs = true
-			return nil
-		}
-		// The static hash path must never call HashTreeRootWithDyn. If no static
-		// HashTreeRootWith is available, the type is inlined by falling through to
-		// the structural switch below — unless it has no traversable structure
-		// (custom or shallow-delegated externals), which cannot be inlined.
-		if !useFastSsz && (desc.SszType == ssztypes.SszCustomType || isShallowDelegatedDescriptor(desc)) {
-			return fmt.Errorf("cannot generate static hash tree root for %s under without-dynamic-expressions: it provides only dynamic (spec-aware) SSZ methods and has no static HashTreeRootWith or inlinable structure; add it to the generation set or provide a static hasher", ctx.typePrinter.TypeString(desc))
+		if done, err := ctx.hashDynamicRoot(desc, varName, typePath, indent, useFastSsz); done {
+			return err
 		}
 	}
 

--- a/codegen/gen_hashtreeroot.go
+++ b/codegen/gen_hashtreeroot.go
@@ -244,20 +244,35 @@ func (ctx *hashTreeRootContext) hashType(desc *ssztypes.TypeDescriptor, varName 
 		}
 	}
 
-	if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicHashRoot != 0 && !isRoot && !isView {
-		ctx.appendCode(indent, "if err := %s.HashTreeRootWithDyn(ds, hh); err != nil {\n\treturn %s\n}\n", varName, typePath.getErrorWith("err"))
-		ctx.usedDynSpecs = true
-		return nil
-	}
-
 	isFastsszHasher := desc.SszCompatFlags&ssztypes.SszCompatFlagFastSSZHasher != 0
 	isFastsszHashWith := desc.SszCompatFlags&ssztypes.SszCompatFlagHashTreeRootWith != 0
 	hasDynamicSize := desc.SszTypeFlags&ssztypes.SszTypeFlagHasSizeExpr != 0 && !ctx.options.WithoutDynamicExpressions
 	hasDynamicMax := desc.SszTypeFlags&ssztypes.SszTypeFlagHasMaxExpr != 0 && !ctx.options.WithoutDynamicExpressions
 
-	useFastSsz := !isRoot && !ctx.options.NoFastSsz && !hasDynamicSize && !hasDynamicMax && (isFastsszHasher || isFastsszHashWith)
+	// Under WithoutDynamicExpressions the generated code must be fully static and
+	// must never call HashTreeRootWithDyn. A child exposing a static
+	// HashTreeRootWith (every dynssz-generated child in this mode, plus external
+	// fastssz types) is reached through it even when fastssz delegation is
+	// otherwise disabled, because the dynamic path is forbidden.
+	useFastSsz := !isRoot && !hasDynamicSize && !hasDynamicMax && (isFastsszHasher || isFastsszHashWith) &&
+		(!ctx.options.NoFastSsz || ctx.options.WithoutDynamicExpressions)
 	if !useFastSsz && desc.SszType == ssztypes.SszCustomType {
 		useFastSsz = true
+	}
+
+	if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicHashRoot != 0 && !isRoot && !isView {
+		if !ctx.options.WithoutDynamicExpressions {
+			ctx.appendCode(indent, "if err := %s.HashTreeRootWithDyn(ds, hh); err != nil {\n\treturn %s\n}\n", varName, typePath.getErrorWith("err"))
+			ctx.usedDynSpecs = true
+			return nil
+		}
+		// The static hash path must never call HashTreeRootWithDyn. If no static
+		// HashTreeRootWith is available, the type is inlined by falling through to
+		// the structural switch below — unless it has no traversable structure
+		// (custom or shallow-delegated externals), which cannot be inlined.
+		if !useFastSsz && (desc.SszType == ssztypes.SszCustomType || isShallowDelegatedDescriptor(desc)) {
+			return fmt.Errorf("cannot generate static hash tree root for %s under without-dynamic-expressions: it provides only dynamic (spec-aware) SSZ methods and has no static HashTreeRootWith or inlinable structure; add it to the generation set or provide a static hasher", ctx.typePrinter.TypeString(desc))
+		}
 	}
 
 	if useFastSsz && !isView {

--- a/codegen/gen_marshal.go
+++ b/codegen/gen_marshal.go
@@ -213,7 +213,12 @@ func (ctx *marshalContext) marshalType(desc *ssztypes.TypeDescriptor, varName st
 	// Handle types that have generated methods we can call
 	hasDynamicSize := desc.SszTypeFlags&ssztypes.SszTypeFlagHasSizeExpr != 0 && !ctx.options.WithoutDynamicExpressions
 	isFastsszMarshaler := desc.SszCompatFlags&ssztypes.SszCompatFlagFastSSZMarshaler != 0
-	useFastSsz := !ctx.options.NoFastSsz && isFastsszMarshaler && !hasDynamicSize
+	// Under WithoutDynamicExpressions the generated buffer code must be fully
+	// static and must never call a *Dyn method. A child exposing a static
+	// MarshalSSZTo (every dynssz-generated child in this mode, plus external
+	// fastssz types) is reached through that static method even when fastssz
+	// delegation is otherwise disabled, because the dynamic path is forbidden.
+	useFastSsz := isFastsszMarshaler && !hasDynamicSize && (!ctx.options.NoFastSsz || ctx.options.WithoutDynamicExpressions)
 	if !useFastSsz && desc.SszType == ssztypes.SszCustomType {
 		useFastSsz = true
 	}
@@ -251,15 +256,24 @@ func (ctx *marshalContext) marshalType(desc *ssztypes.TypeDescriptor, varName st
 		return nil
 	}
 
-	if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicMarshaler != 0 && !isRoot && !isView {
+	// Under WithoutDynamicExpressions the static buffer path must never call a
+	// *Dyn method. Instead of delegating, the type is inlined by falling through
+	// to the structural switch below (its layout is walked directly). Types that
+	// have no traversable structure — custom types and shallow-delegated external
+	// types — cannot be inlined, so they are rejected with a clear error.
+	if ctx.options.WithoutDynamicExpressions && !isRoot && !isView &&
+		desc.SszCompatFlags&(ssztypes.SszCompatFlagDynamicMarshaler|ssztypes.SszCompatFlagDynamicEncoder) != 0 {
+		if desc.SszType == ssztypes.SszCustomType || isShallowDelegatedDescriptor(desc) {
+			return fmt.Errorf("cannot generate static marshaler for %s under without-dynamic-expressions: it provides only dynamic (spec-aware) SSZ methods and has no static MarshalSSZTo or inlinable structure; add it to the generation set or provide a static marshaler", ctx.typePrinter.TypeString(desc))
+		}
+		// fall through: inline the type's structure via the switch below
+	} else if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicMarshaler != 0 && !isRoot && !isView {
 		ctx.appendCode(indent, "if dst, err = %s.MarshalSSZDyn(ds, dst); err != nil {\n", varName)
 		ctx.appendCode(indent+1, "return nil, %s\n", typePath.getErrorWith("err"))
 		ctx.appendCode(indent, "}\n")
 		ctx.usedDynSpecs = true
 		return nil
-	}
-
-	if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicEncoder != 0 && !isRoot && !isView {
+	} else if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicEncoder != 0 && !isRoot && !isView {
 		ctx.appendCode(indent, "enc := sszutils.NewBufferEncoder(dst)\n")
 		ctx.appendCode(indent, "if err = %s.MarshalSSZEncoder(ds, enc); err != nil {\n", varName)
 		ctx.appendCode(indent+1, "return nil, %s\n", typePath.getErrorWith("err"))

--- a/codegen/gen_marshal.go
+++ b/codegen/gen_marshal.go
@@ -261,19 +261,20 @@ func (ctx *marshalContext) marshalType(desc *ssztypes.TypeDescriptor, varName st
 	// to the structural switch below (its layout is walked directly). Types that
 	// have no traversable structure — custom types and shallow-delegated external
 	// types — cannot be inlined, so they are rejected with a clear error.
-	if ctx.options.WithoutDynamicExpressions && !isRoot && !isView &&
-		desc.SszCompatFlags&(ssztypes.SszCompatFlagDynamicMarshaler|ssztypes.SszCompatFlagDynamicEncoder) != 0 {
+	switch {
+	case ctx.options.WithoutDynamicExpressions && !isRoot && !isView &&
+		desc.SszCompatFlags&(ssztypes.SszCompatFlagDynamicMarshaler|ssztypes.SszCompatFlagDynamicEncoder) != 0:
 		if desc.SszType == ssztypes.SszCustomType || isShallowDelegatedDescriptor(desc) {
 			return fmt.Errorf("cannot generate static marshaler for %s under without-dynamic-expressions: it provides only dynamic (spec-aware) SSZ methods and has no static MarshalSSZTo or inlinable structure; add it to the generation set or provide a static marshaler", ctx.typePrinter.TypeString(desc))
 		}
 		// fall through: inline the type's structure via the switch below
-	} else if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicMarshaler != 0 && !isRoot && !isView {
+	case desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicMarshaler != 0 && !isRoot && !isView:
 		ctx.appendCode(indent, "if dst, err = %s.MarshalSSZDyn(ds, dst); err != nil {\n", varName)
 		ctx.appendCode(indent+1, "return nil, %s\n", typePath.getErrorWith("err"))
 		ctx.appendCode(indent, "}\n")
 		ctx.usedDynSpecs = true
 		return nil
-	} else if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicEncoder != 0 && !isRoot && !isView {
+	case desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicEncoder != 0 && !isRoot && !isView:
 		ctx.appendCode(indent, "enc := sszutils.NewBufferEncoder(dst)\n")
 		ctx.appendCode(indent, "if err = %s.MarshalSSZEncoder(ds, enc); err != nil {\n", varName)
 		ctx.appendCode(indent+1, "return nil, %s\n", typePath.getErrorWith("err"))

--- a/codegen/gen_size.go
+++ b/codegen/gen_size.go
@@ -230,20 +230,40 @@ func (ctx *sizeContext) sizeType(desc *ssztypes.TypeDescriptor, varName, sizeVar
 
 	if !isRoot && !isView {
 		hasDynamicSize := desc.SszTypeFlags&ssztypes.SszTypeFlagHasSizeExpr != 0 && !ctx.options.WithoutDynamicExpressions
-		useFastSsz := !ctx.options.NoFastSsz && desc.SszCompatFlags&ssztypes.SszCompatFlagFastSSZMarshaler != 0 && !hasDynamicSize
+		// Under WithoutDynamicExpressions the generated code must be fully static
+		// and must never call a *Dyn method. A child exposing a static SizeSSZ
+		// (every dynssz-generated child in this mode, plus external fastssz types)
+		// is reached through it even when fastssz delegation is otherwise disabled.
+		useFastSsz := desc.SszCompatFlags&ssztypes.SszCompatFlagFastSSZMarshaler != 0 && !hasDynamicSize &&
+			(!ctx.options.NoFastSsz || ctx.options.WithoutDynamicExpressions)
 		if !useFastSsz && desc.SszType == ssztypes.SszCustomType {
 			useFastSsz = true
 		}
 
-		if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicSizer != 0 {
-			ctx.appendCode(indent, "%s += %s.SizeSSZDyn(ds)\n", sizeVar, varName)
-			ctx.usedDynSpecs = true
-			return nil
-		}
+		if ctx.options.WithoutDynamicExpressions {
+			if useFastSsz {
+				ctx.appendCode(indent, "%s += %s.SizeSSZ()\n", sizeVar, varName)
+				return nil
+			}
+			// Never call a *Dyn method. A dynamic-only type is inlined by falling
+			// through to the structural switch below; only types with no
+			// traversable structure (custom or shallow-delegated externals) are
+			// rejected.
+			if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicSizer != 0 &&
+				(desc.SszType == ssztypes.SszCustomType || isShallowDelegatedDescriptor(desc)) {
+				return fmt.Errorf("cannot generate static sizer for %s under without-dynamic-expressions: it provides only dynamic (spec-aware) SSZ methods and has no static SizeSSZ or inlinable structure; add it to the generation set or provide a static sizer", ctx.typePrinter.TypeString(desc))
+			}
+		} else {
+			if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicSizer != 0 {
+				ctx.appendCode(indent, "%s += %s.SizeSSZDyn(ds)\n", sizeVar, varName)
+				ctx.usedDynSpecs = true
+				return nil
+			}
 
-		if useFastSsz {
-			ctx.appendCode(indent, "%s += %s.SizeSSZ()\n", sizeVar, varName)
-			return nil
+			if useFastSsz {
+				ctx.appendCode(indent, "%s += %s.SizeSSZ()\n", sizeVar, varName)
+				return nil
+			}
 		}
 	}
 

--- a/codegen/gen_size.go
+++ b/codegen/gen_size.go
@@ -632,8 +632,16 @@ func (ctx *sizeContext) sizeUnion(desc *ssztypes.TypeDescriptor, varName, sizeVa
 			ctx.appendCode(indent, "\tif !ok {\n")
 			ctx.appendCode(indent, "\t\treturn 0\n")
 			ctx.appendCode(indent, "\t}\n")
+			sizeStart := ctx.codeBuf.Len()
 			if err := ctx.sizeType(variantDesc, "v", sizeVar, indent+1, false); err != nil {
 				return err
+			}
+			// A variant whose size is fully determined by a size expression (e.g.
+			// a static container with a dynssz-size field) never reads the asserted
+			// value, which would leave `v` declared-and-unused. Reference it
+			// explicitly so the generated code compiles.
+			if !codeReferencesIdent(ctx.codeBuf.String()[sizeStart:], "v") {
+				ctx.appendCode(indent, "\t_ = v\n")
 			}
 		} else {
 			// A fixed-size variant still validates the data type: sizing
@@ -655,4 +663,42 @@ func (ctx *sizeContext) sizeUnion(desc *ssztypes.TypeDescriptor, varName, sizeVa
 	ctx.appendCode(indent, "}\n")
 
 	return nil
+}
+
+// codeReferencesIdent reports whether the generated code snippet uses ident as a
+// standalone token, ignoring // line comments. It lets the union-variant sizing
+// code decide whether the asserted value var is actually read; a variant whose
+// size is a pure expression never reads it, which would otherwise leave the
+// variable declared-and-unused.
+func codeReferencesIdent(code, ident string) bool {
+	isIdentByte := func(b byte) bool {
+		return b == '_' ||
+			(b >= 'a' && b <= 'z') ||
+			(b >= 'A' && b <= 'Z') ||
+			(b >= '0' && b <= '9')
+	}
+	for _, line := range strings.Split(code, "\n") {
+		if i := strings.Index(line, "//"); i >= 0 {
+			line = line[:i]
+		}
+		for start := 0; start < len(line); {
+			j := strings.Index(line[start:], ident)
+			if j < 0 {
+				break
+			}
+			pos := start + j
+			var before, after byte = ' ', ' '
+			if pos > 0 {
+				before = line[pos-1]
+			}
+			if pos+len(ident) < len(line) {
+				after = line[pos+len(ident)]
+			}
+			if !isIdentByte(before) && !isIdentByte(after) {
+				return true
+			}
+			start = pos + len(ident)
+		}
+	}
+	return false
 }

--- a/codegen/gen_size.go
+++ b/codegen/gen_size.go
@@ -338,6 +338,12 @@ func (ctx *sizeContext) sizeType(desc *ssztypes.TypeDescriptor, varName, sizeVar
 	case ssztypes.SszOptionalListType:
 		return ctx.sizeOptionalList(desc, varName, sizeVar, indent)
 	case ssztypes.SszBigIntType:
+		// A static ssz-max is enforced by the marshal/HTR paths (which return an
+		// error); the size path has no error channel, so an over-max value yields
+		// size 0 to signal it is not serializable rather than a misleading size.
+		if desc.MaxExpression == nil && desc.Limit > 0 {
+			ctx.appendCode(indent, "if uint64(1+len(%s.Bytes())) > %d {\n\treturn 0\n}\n", varName, desc.Limit)
+		}
 		ctx.appendCode(indent, "%s += 1 + len(%s.Bytes())\n", sizeVar, varName)
 
 	default:

--- a/codegen/gen_static_nodyn_test.go
+++ b/codegen/gen_static_nodyn_test.go
@@ -1,0 +1,298 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the dynamic-ssz library.
+
+package codegen
+
+import (
+	"encoding/binary"
+	"reflect"
+	"strings"
+	"testing"
+
+	dynssz "github.com/pk910/dynamic-ssz"
+	"github.com/pk910/dynamic-ssz/sszutils"
+)
+
+// ---- deeply nested generated containers ----
+
+type nsLeaf struct {
+	A []byte `ssz-max:"8"`
+	B uint8
+}
+type nsD5 struct {
+	L nsLeaf
+	X uint16
+}
+type nsD4 struct {
+	N nsD5
+	L []nsD5 `ssz-max:"4"`
+}
+type nsD3 struct {
+	N nsD4
+	V [2]nsD4
+}
+type nsD2 struct {
+	N nsD3
+	P []nsD3 `ssz-type:"progressive-list" ssz-max:"8"`
+}
+type nsD1 struct {
+	N nsD2
+	Z uint64
+}
+
+// ---- container-of-container as list/vector/progressive-list ----
+
+type nsListOfC struct {
+	L []nsLeaf `ssz-max:"16"`
+}
+type nsVecOfC struct {
+	V [3]nsLeaf
+}
+type nsProgOfC struct {
+	L []nsLeaf `ssz-type:"progressive-list" ssz-max:"16"`
+}
+
+// ---- TypeWrapper wrapping a nested generated container (unexported variant) ----
+
+type nsWrapperHolder struct {
+	W dynssz.TypeWrapper[struct {
+		Data nsD4 `ssz-size:"?"`
+	}, nsD4]
+}
+
+// ---- union whose variants are nested generated containers (unexported) ----
+
+type nsUnionHolder struct {
+	U dynssz.CompatibleUnion[struct {
+		F1 nsLeaf
+		F2 nsD4
+	}]
+}
+
+// ---- optional / optional-list of nested generated containers ----
+
+type nsOptHolder struct {
+	Opt *nsD4 `ssz-type:"optional"`
+}
+type nsOptListHolder struct {
+	Opt *nsD4 `ssz-type:"optional-list"`
+}
+
+// ---- self-referential + mutually recursive (all in generation set) ----
+
+type nsSelfRec struct {
+	V     []byte      `ssz-max:"4"`
+	Peers []nsSelfRec `ssz-max:"4"`
+}
+type nsMutA struct {
+	V []byte   `ssz-max:"4"`
+	B []nsMutB `ssz-max:"4"`
+}
+type nsMutB struct {
+	V []byte   `ssz-max:"4"`
+	A []nsMutA `ssz-max:"4"`
+}
+
+var nsDynTokens = []string{"MarshalSSZDyn", "UnmarshalSSZDyn", "SizeSSZDyn", "HashTreeRootWithDyn"}
+
+func nsAssertNoDyn(t *testing.T, name, code string) {
+	t.Helper()
+	if code == "" {
+		t.Fatalf("%s: no code generated", name)
+	}
+	for _, tok := range nsDynTokens {
+		if idx := strings.Index(code, tok); idx >= 0 {
+			lo, hi := idx-140, idx+140
+			if lo < 0 {
+				lo = 0
+			}
+			if hi > len(code) {
+				hi = len(code)
+			}
+			t.Errorf("%s: forbidden %s under without-dynamic-expressions near:\n...%s...", name, tok, code[lo:hi])
+		}
+	}
+}
+
+// nsCombos enumerates flag combinations that must all keep the generated buffer
+// AND streaming paths free of *Dyn calls under WithoutDynamicExpressions.
+func nsCombos() []struct {
+	name string
+	opts []CodeGeneratorOption
+} {
+	return []struct {
+		name string
+		opts []CodeGeneratorOption
+	}{
+		{"plain", nil},
+		{"nofast", []CodeGeneratorOption{WithNoFastSsz()}},
+		{"streaming", []CodeGeneratorOption{WithCreateEncoderFn(), WithCreateDecoderFn()}},
+		{"nofast+streaming", []CodeGeneratorOption{WithNoFastSsz(), WithCreateEncoderFn(), WithCreateDecoderFn()}},
+		{"legacy", []CodeGeneratorOption{WithCreateLegacyFn()}},
+		{"all", []CodeGeneratorOption{WithNoFastSsz(), WithCreateEncoderFn(), WithCreateDecoderFn(), WithCreateLegacyFn()}},
+	}
+}
+
+// TestStaticNoDynNested generates a large family of nested generated containers
+// (deep containers-of-containers, list/vector/progressive-list nesting, union and
+// TypeWrapper variants with unexported nested types, optional/optional-list)
+// together under WithoutDynamicExpressions across every flag combo. The generated
+// code must be valid Go and must never reference a *Dyn buffer function — in the
+// buffer methods or in the streaming encoder/decoder.
+func TestStaticNoDynNested(t *testing.T) {
+	types := []reflect.Type{
+		reflect.TypeFor[nsLeaf](), reflect.TypeFor[nsD5](), reflect.TypeFor[nsD4](),
+		reflect.TypeFor[nsD3](), reflect.TypeFor[nsD2](), reflect.TypeFor[nsD1](),
+		reflect.TypeFor[nsListOfC](), reflect.TypeFor[nsVecOfC](), reflect.TypeFor[nsProgOfC](),
+		reflect.TypeFor[nsWrapperHolder](), reflect.TypeFor[nsUnionHolder](),
+		reflect.TypeFor[nsOptHolder](), reflect.TypeFor[nsOptListHolder](),
+	}
+	for _, combo := range nsCombos() {
+		t.Run(combo.name, func(t *testing.T) {
+			typeOpts := append([]CodeGeneratorOption{WithoutDynamicExpressions(), WithExtendedTypes()}, combo.opts...)
+			cg := NewCodeGenerator(nil)
+			buildOpts := make([]CodeGeneratorOption, 0, len(types))
+			for _, rt := range types {
+				buildOpts = append(buildOpts, WithReflectType(rt, typeOpts...))
+			}
+			cg.BuildFile("gen.go", buildOpts...)
+			files, err := cg.GenerateToMap()
+			if err != nil {
+				t.Fatalf("generate: %v", err)
+			}
+			nsAssertNoDyn(t, combo.name, files["gen.go"])
+		})
+	}
+}
+
+// TestStaticNoDynRecursion checks self-referential and mutually-recursive types
+// terminate (no infinite generator loop) and stay *Dyn-free across combos.
+func TestStaticNoDynRecursion(t *testing.T) {
+	for _, combo := range nsCombos() {
+		t.Run(combo.name, func(t *testing.T) {
+			typeOpts := append([]CodeGeneratorOption{WithoutDynamicExpressions()}, combo.opts...)
+			cg := NewCodeGenerator(nil)
+			cg.BuildFile("gen.go",
+				WithReflectType(reflect.TypeFor[nsSelfRec](), typeOpts...),
+				WithReflectType(reflect.TypeFor[nsMutA](), typeOpts...),
+				WithReflectType(reflect.TypeFor[nsMutB](), typeOpts...),
+			)
+			files, err := cg.GenerateToMap()
+			if err != nil {
+				t.Fatalf("generate: %v", err)
+			}
+			nsAssertNoDyn(t, combo.name, files["gen.go"])
+		})
+	}
+}
+
+// TestStaticStreamingUnexportedGenericArg is a regression guard for the type-name
+// printer: a generic type argument (a CompatibleUnion / TypeWrapper parameter)
+// referencing an UNEXPORTED same-package type must be emitted as an unqualified
+// identifier, never as its full import path. The reflect type-name cleanup regex
+// previously only matched exported ([A-Z]) type names, so an unexported variant
+// leaked "github.com/.../pkg.typeName" into the streaming encoder's sizeFn
+// signatures, producing invalid Go.
+func TestStaticStreamingUnexportedGenericArg(t *testing.T) {
+	for _, rt := range []reflect.Type{reflect.TypeFor[nsUnionHolder](), reflect.TypeFor[nsWrapperHolder]()} {
+		cg := NewCodeGenerator(nil)
+		cg.BuildFile("gen.go", WithReflectType(rt, WithExtendedTypes(), WithCreateEncoderFn(), WithCreateDecoderFn()))
+		files, err := cg.GenerateToMap()
+		if err != nil {
+			t.Fatalf("%s: generate: %v", rt, err)
+		}
+		if strings.Contains(files["gen.go"], "dynamic-ssz/codegen.") {
+			t.Errorf("%s: import path leaked as a type name in generated code", rt)
+		}
+	}
+}
+
+// nsWellDelegated is an external fully-delegated type whose Go struct layout
+// matches its wire form exactly. Under WithoutDynamicExpressions it is inlined
+// from its structure; the inlined static output must equal its Dynamic* method.
+type nsWellDelegated struct {
+	V uint64
+}
+
+var _ = sszutils.Annotate[nsWellDelegated](`ssz-static:"true"`)
+
+func (n *nsWellDelegated) SizeSSZDyn(_ sszutils.DynamicSpecs) int { return 8 }
+func (n *nsWellDelegated) MarshalSSZDyn(_ sszutils.DynamicSpecs, buf []byte) ([]byte, error) {
+	return binary.LittleEndian.AppendUint64(buf, n.V), nil
+}
+func (n *nsWellDelegated) UnmarshalSSZDyn(_ sszutils.DynamicSpecs, buf []byte) error {
+	n.V = binary.LittleEndian.Uint64(buf)
+	return nil
+}
+func (n *nsWellDelegated) HashTreeRootWithDyn(_ sszutils.DynamicSpecs, hh sszutils.HashWalker) error {
+	hh.PutUint64(n.V)
+	return nil
+}
+
+type nsWellHolder struct {
+	A uint64
+	N nsWellDelegated
+	V [2]nsWellDelegated
+}
+
+// TestStaticStreamingInlinesExternalDelegated is the regression guard for the
+// streaming encoder/decoder *Dyn leak: an external dynamic-only delegated child
+// nested in a WithoutDynamicExpressions type must be inlined from its structure
+// in BOTH the buffer methods and the streaming encoder/decoder, never reached via
+// MarshalSSZDyn/UnmarshalSSZDyn. Previously the streaming generators cleared the
+// WithoutDynamicExpressions flag wholesale and forwarded to the *Dyn buffer method.
+func TestStaticStreamingInlinesExternalDelegated(t *testing.T) {
+	cg := NewCodeGenerator(nil)
+	cg.BuildFile("gen.go", WithReflectType(reflect.TypeFor[nsWellHolder](),
+		WithoutDynamicExpressions(), WithNoFastSsz(), WithCreateEncoderFn(), WithCreateDecoderFn()))
+	files, err := cg.GenerateToMap()
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	nsAssertNoDyn(t, "external-delegated-streaming", files["gen.go"])
+	// The child's uint64 field must be inlined structurally in the streaming path.
+	if !strings.Contains(files["gen.go"], "enc.EncodeUint64(t.V)") {
+		t.Errorf("expected the streaming encoder to inline the delegated child's uint64 field")
+	}
+}
+
+// nsIllegalDelegated mirrors the repo's nestedDelegatedInner: a delegated type
+// with a structurally-invalid innard (zero-length array). Under
+// WithoutDynamicExpressions the parser traverses it (NoDelegation) and must
+// reject it with a clear error rather than emit a *Dyn call or panic.
+type nsIllegalDelegated struct {
+	Bad   [0]uint64
+	Value uint32
+}
+
+var _ = sszutils.Annotate[nsIllegalDelegated](`ssz-static:"true"`)
+
+func (n *nsIllegalDelegated) SizeSSZDyn(_ sszutils.DynamicSpecs) int { return 4 }
+func (n *nsIllegalDelegated) MarshalSSZDyn(_ sszutils.DynamicSpecs, buf []byte) ([]byte, error) {
+	return binary.LittleEndian.AppendUint32(buf, n.Value), nil
+}
+func (n *nsIllegalDelegated) UnmarshalSSZDyn(_ sszutils.DynamicSpecs, buf []byte) error {
+	n.Value = binary.LittleEndian.Uint32(buf)
+	return nil
+}
+func (n *nsIllegalDelegated) HashTreeRootWithDyn(_ sszutils.DynamicSpecs, hh sszutils.HashWalker) error {
+	hh.PutUint32(n.Value)
+	return nil
+}
+
+type nsIllegalHolder struct {
+	A uint64
+	N nsIllegalDelegated
+}
+
+// TestStaticRejectsUnInlinableDelegated confirms a delegated type that cannot be
+// faithfully inlined (structurally-invalid innard) is rejected with a clear error
+// instead of silently producing wrong code or panicking.
+func TestStaticRejectsUnInlinableDelegated(t *testing.T) {
+	cg := NewCodeGenerator(nil)
+	cg.BuildFile("gen.go", WithReflectType(reflect.TypeFor[nsIllegalHolder](), WithoutDynamicExpressions()))
+	if _, err := cg.GenerateToMap(); err == nil {
+		t.Fatal("expected a clear error inlining a delegated type with an invalid innard")
+	}
+}

--- a/codegen/gen_unmarshal.go
+++ b/codegen/gen_unmarshal.go
@@ -1280,14 +1280,29 @@ func (ctx *unmarshalContext) unmarshalUnion(desc *ssztypes.TypeDescriptor, varNa
 		childTypePath := typePath.append(fmt.Sprintf("[v:%d]", variant))
 
 		// Check that buf has enough bytes for the selector plus the variant value.
-		// A fixed-size variant occupies exactly 1+elemSize bytes of the union
+		// A fixed-size variant occupies exactly 1+variantSize bytes of the union
 		// region, so any extra bytes are trailing data and must be rejected
 		// (matching the reflection and streaming-decoder paths).
 		elemSize := variantDesc.Size
 		if elemSize > 0 {
-			eofErr := childTypePath.getErrorWith(fmt.Sprintf("sszutils.ErrUnionVariantEOFFn(len(buf), %d)", 1+elemSize))
-			trailErr := childTypePath.getErrorWith(fmt.Sprintf("sszutils.ErrTrailingDataFn(len(buf) - %d)", 1+elemSize))
-			ctx.appendExactLenCheck(indent+1, fmt.Sprintf("%d", 1+elemSize), "len(buf)", eofErr, trailErr)
+			// When the variant's serialized size comes from a spec expression, its
+			// byte length is resolved at runtime and must not be baked to the
+			// static default: doing so under-/over-reads the union region for any
+			// preset whose resolved size differs from the static fallback. Compute
+			// the runtime size the same way the size/marshal paths do.
+			var sizeExpr string
+			if variantDesc.SszTypeFlags&ssztypes.SszTypeFlagHasSizeExpr != 0 && !ctx.options.WithoutDynamicExpressions {
+				sizeVar, serr := ctx.staticSizeVars.getStaticSizeVar(variantDesc)
+				if serr != nil {
+					return serr
+				}
+				sizeExpr = fmt.Sprintf("1 + %s", sizeVar)
+			} else {
+				sizeExpr = fmt.Sprintf("%d", 1+elemSize)
+			}
+			eofErr := childTypePath.getErrorWith(fmt.Sprintf("sszutils.ErrUnionVariantEOFFn(len(buf), %s)", sizeExpr))
+			trailErr := childTypePath.getErrorWith(fmt.Sprintf("sszutils.ErrTrailingDataFn(len(buf) - (%s))", sizeExpr))
+			ctx.appendExactLenCheck(indent+1, sizeExpr, "len(buf)", eofErr, trailErr)
 		}
 
 		valVar := ctx.getValVar()

--- a/codegen/gen_unmarshal.go
+++ b/codegen/gen_unmarshal.go
@@ -200,10 +200,11 @@ func (ctx *unmarshalContext) isInlinable(desc *ssztypes.TypeDescriptor) bool {
 		return true
 	}
 
-	// Inline types with fastssz unmarshaler
+	// Inline types with fastssz unmarshaler (or, under WithoutDynamicExpressions,
+	// any type exposing a static UnmarshalSSZ — matching unmarshalCompatType).
 	hasDynamicSize := desc.SszTypeFlags&ssztypes.SszTypeFlagHasSizeExpr != 0 && !ctx.options.WithoutDynamicExpressions
 	isFastsszUnmarshaler := desc.SszCompatFlags&ssztypes.SszCompatFlagFastSSZMarshaler != 0
-	useFastSsz := !ctx.options.NoFastSsz && isFastsszUnmarshaler && !hasDynamicSize
+	useFastSsz := isFastsszUnmarshaler && !hasDynamicSize && (!ctx.options.NoFastSsz || ctx.options.WithoutDynamicExpressions)
 	if !useFastSsz && desc.SszType == ssztypes.SszCustomType {
 		useFastSsz = true
 	}
@@ -211,8 +212,10 @@ func (ctx *unmarshalContext) isInlinable(desc *ssztypes.TypeDescriptor) bool {
 		return true
 	}
 
-	// Inline types with generated unmarshal methods
-	if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicUnmarshaler != 0 {
+	// Inline types with generated unmarshal methods. Under WithoutDynamicExpressions
+	// the *Dyn method is never called (the type is structurally inlined instead),
+	// so its presence must not shortcut temp-var creation here.
+	if !ctx.options.WithoutDynamicExpressions && desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicUnmarshaler != 0 {
 		return true
 	}
 
@@ -241,10 +244,14 @@ func (ctx *unmarshalContext) unmarshalViewType(desc *ssztypes.TypeDescriptor, va
 	return false
 }
 
-func (ctx *unmarshalContext) unmarshalCompatType(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int) bool {
+func (ctx *unmarshalContext) unmarshalCompatType(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int) (bool, error) {
 	hasDynamicSize := desc.SszTypeFlags&ssztypes.SszTypeFlagHasSizeExpr != 0 && !ctx.options.WithoutDynamicExpressions
 	isFastsszUnmarshaler := desc.SszCompatFlags&ssztypes.SszCompatFlagFastSSZMarshaler != 0
-	useFastSsz := !ctx.options.NoFastSsz && isFastsszUnmarshaler && !hasDynamicSize
+	// Under WithoutDynamicExpressions the generated code must be fully static and
+	// must never call a *Dyn method. A child exposing a static UnmarshalSSZ
+	// (every dynssz-generated child in this mode, plus external fastssz types) is
+	// reached through it even when fastssz delegation is otherwise disabled.
+	useFastSsz := isFastsszUnmarshaler && !hasDynamicSize && (!ctx.options.NoFastSsz || ctx.options.WithoutDynamicExpressions)
 	if !useFastSsz && desc.SszType == ssztypes.SszCustomType {
 		useFastSsz = true
 	}
@@ -256,23 +263,36 @@ func (ctx *unmarshalContext) unmarshalCompatType(desc *ssztypes.TypeDescriptor, 
 
 	if useFastSsz {
 		ctx.appendCode(indent, "if err = %s.UnmarshalSSZ(buf); err != nil {\n\treturn %s\n}\n", varName, typePath.getErrorWith("err"))
-		return true
+		return true, nil
+	}
+
+	// Under WithoutDynamicExpressions the static buffer path must never call a
+	// *Dyn method. Instead of delegating, a dynamic-only type is inlined by
+	// returning "not handled" so the caller walks its structure. Types with no
+	// traversable structure (custom or shallow-delegated externals) cannot be
+	// inlined, so they are rejected with a clear error.
+	if ctx.options.WithoutDynamicExpressions {
+		if desc.SszCompatFlags&(ssztypes.SszCompatFlagDynamicUnmarshaler|ssztypes.SszCompatFlagDynamicDecoder) != 0 &&
+			(desc.SszType == ssztypes.SszCustomType || isShallowDelegatedDescriptor(desc)) {
+			return false, fmt.Errorf("cannot generate static unmarshaler for %s under without-dynamic-expressions: it provides only dynamic (spec-aware) SSZ methods and has no static UnmarshalSSZ or inlinable structure; add it to the generation set or provide a static unmarshaler", ctx.typePrinter.TypeString(desc))
+		}
+		return false, nil
 	}
 
 	if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicUnmarshaler != 0 {
 		ctx.appendCode(indent, "if err = %s.UnmarshalSSZDyn(ds, buf); err != nil {\n\treturn %s\n}\n", varName, typePath.getErrorWith("err"))
 		ctx.usedDynSpecs = true
-		return true
+		return true, nil
 	}
 
 	if desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicDecoder != 0 {
 		ctx.appendCode(indent, "dec := sszutils.NewBufferDecoder(buf)\n")
 		ctx.appendCode(indent, "if err = %s.UnmarshalSSZDecoder(ds, dec); err != nil {\n\treturn %s\n}\n", varName, typePath.getErrorWith("err"))
 		ctx.usedDynSpecs = true
-		return true
+		return true, nil
 	}
 
-	return false
+	return false, nil
 }
 
 func (ctx *unmarshalContext) unmarshalType(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int, isRoot, noBufCheck bool) error {
@@ -285,7 +305,9 @@ func (ctx *unmarshalContext) unmarshalType(desc *ssztypes.TypeDescriptor, varNam
 	}
 
 	if !isRoot && !isView {
-		if handled := ctx.unmarshalCompatType(desc, varName, typePath, indent); handled {
+		if handled, err := ctx.unmarshalCompatType(desc, varName, typePath, indent); err != nil {
+			return err
+		} else if handled {
 			return nil
 		}
 	}

--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -221,6 +221,17 @@ func (cg *CodeGenerator) analyzeTypes() error {
 				// A duplicate view would emit its methods and dispatcher case
 				// twice, producing non-compiling output.
 				seenViews := make(map[string]bool, len(t.ViewReflectTypes)+len(t.ViewGoTypesTypes))
+				// A view identical to the data type would emit a `case *T`
+				// alongside the dispatcher's own `case nil, *T`, producing a
+				// duplicate type-switch case that does not compile. The base
+				// type was already pointer-wrapped above, so its String() key
+				// matches a normalized view key. Reserve it up front.
+				baseViewKey := ""
+				if t.ReflectType != nil {
+					baseViewKey = t.ReflectType.String()
+				} else if t.GoTypesType != nil {
+					baseViewKey = t.GoTypesType.String()
+				}
 				for _, viewType := range t.ViewReflectTypes {
 					// Pointer-wrap the view like the base type, regardless of
 					// kind, so runtime and schema kinds stay aligned in the
@@ -228,6 +239,9 @@ func (cg *CodeGenerator) analyzeTypes() error {
 					// before the dedup key so T and *T collide as one entry.
 					if viewType.Kind() != reflect.Pointer {
 						viewType = reflect.PointerTo(viewType)
+					}
+					if viewType.String() == baseViewKey {
+						return fmt.Errorf("view type %s is the same as the data type %s; a data type cannot list itself as a view", viewType.String(), typeName)
 					}
 					if seenViews[viewType.String()] {
 						return fmt.Errorf("view type %s is listed more than once for %s; remove the duplicate entry", viewType.String(), typeName)
@@ -247,6 +261,9 @@ func (cg *CodeGenerator) analyzeTypes() error {
 					}
 					if _, ok := viewType.(*types.Pointer); !ok {
 						viewType = types.NewPointer(viewType)
+					}
+					if viewType.String() == baseViewKey {
+						return fmt.Errorf("view type %s is the same as the data type %s; a data type cannot list itself as a view", viewType.String(), typeName)
 					}
 					if seenViews[viewType.String()] {
 						return fmt.Errorf("view type %s is listed more than once for %s; remove the duplicate entry", viewType.String(), typeName)

--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -169,6 +169,16 @@ func (cg *CodeGenerator) analyzeTypes() error {
 			var desc *ssztypes.TypeDescriptor
 			var err error
 
+			// Without dynamic expressions the generated code must never call a
+			// delegated *Dyn method, so a fully-delegated ssz-static type cannot be
+			// reached through its dynamic methods and must instead be inlined from
+			// its traversed structure. Disable the shallow-build shortcut so the
+			// subtree is available. The flag is never lowered (mirroring
+			// ExtendedTypes): a shared cache/parser stays in the stricter mode.
+			if t.Options.WithoutDynamicExpressions {
+				cg.typeCache.NoDelegation = true
+			}
+
 			if t.ReflectType != nil {
 				// Always wrap in pointer so generated methods use pointer receivers
 				// (needed for unmarshal to write back modified values).
@@ -190,6 +200,9 @@ func (cg *CodeGenerator) analyzeTypes() error {
 					parser.CompatFlags = cg.compatFlags
 					parser.ExtendedTypes = t.Options.ExtendedTypes
 					parser.AnnotationResolver = cg.annotationResolver
+				}
+				if t.Options.WithoutDynamicExpressions {
+					parser.NoDelegation = true
 				}
 				if _, ok := t.GoTypesType.(*types.Pointer); !ok {
 					t.GoTypesType = types.NewPointer(t.GoTypesType)
@@ -537,11 +550,19 @@ func (cg *CodeGenerator) generateFile(packagePath string, opts *CodeGeneratorFil
 		// A recursive descriptor graph is only emittable when every cycle can be
 		// broken by a delegated method call; verify before emission so an
 		// unsupported shape produces a clear error instead of unbounded recursion.
-		if err := validateEmittableGraph(t.Descriptor); err != nil {
+		// A generated child is reached through its static MarshalSSZTo either when
+		// fastssz delegation is enabled, or when WithoutDynamicExpressions forces
+		// the static path regardless of NoFastSsz. Dynamic* delegation only
+		// terminates a cycle when the emitter actually calls those methods, which
+		// it never does under WithoutDynamicExpressions (dynamic-only children are
+		// inlined there).
+		staticDelegation := !t.Options.NoFastSsz || t.Options.WithoutDynamicExpressions
+		dynamicDelegation := !t.Options.WithoutDynamicExpressions
+		if err := validateEmittableGraph(t.Descriptor, staticDelegation, dynamicDelegation); err != nil {
 			return "", fmt.Errorf("cannot generate code for %s: %w", t.TypeName, err)
 		}
 		for _, viewDesc := range t.ViewDescriptors {
-			if err := validateEmittableGraph(viewDesc); err != nil {
+			if err := validateEmittableGraph(viewDesc, staticDelegation, dynamicDelegation); err != nil {
 				return "", fmt.Errorf("cannot generate code for view of %s: %w", t.TypeName, err)
 			}
 		}

--- a/codegen/parser.go
+++ b/codegen/parser.go
@@ -122,6 +122,13 @@ type Parser struct {
 	// It lets the parser read a referenced, fully-delegated type's ssz-static
 	// declaration so its subtree need not be traversed or validated.
 	AnnotationResolver func(types.Type) string
+
+	// NoDelegation disables the shallow-build shortcut for fully-delegated
+	// ssz-static types, forcing their subtree to be traversed. Code generated
+	// without dynamic expressions must never call a delegated *Dyn method, so
+	// such a type is inlined from its structure instead — which requires the
+	// traversed descriptor.
+	NoDelegation bool
 }
 
 // NewParser creates a new compile-time type parser for code generation.
@@ -509,7 +516,7 @@ func (p *Parser) buildTypeDescriptor(dataType, schemaType types.Type, typeHints 
 	// registered under neither. Field-level hints are already handled inline by the
 	// caller (it strips delegation flags).
 	beingGenerated := p.getCompatFlag(innerDataType, innerSchemaType) != 0 || p.getCompatFlag(innerDataType, innerDataType) != 0
-	if p.AnnotationResolver != nil && len(typeHints) == 0 && len(sizeHints) == 0 && len(maxSizeHints) == 0 && !beingGenerated && p.fullyDelegatesSSZ(originalType) {
+	if p.AnnotationResolver != nil && !p.NoDelegation && len(typeHints) == 0 && len(sizeHints) == 0 && len(maxSizeHints) == 0 && !beingGenerated && p.fullyDelegatesSSZ(originalType) {
 		if staticStr, ok := reflect.StructTag(p.AnnotationResolver(originalType)).Lookup("ssz-static"); ok {
 			switch staticStr {
 			case "true":

--- a/codegen/parser.go
+++ b/codegen/parser.go
@@ -722,7 +722,12 @@ func (p *Parser) buildTypeDescriptor(dataType, schemaType types.Type, typeHints 
 		case reflect.Array:
 			sszType = ssztypes.SszVectorType
 		case reflect.Slice:
-			if len(sizeHints) > 0 && sizeHints[0].Size > 0 {
+			// A size expression (dynssz-size) with no static ssz-size fallback
+			// still fixes the length at runtime, so the slice is a Vector — the
+			// reflection typecache reaches the same result after resolving the
+			// expression to a concrete size before this decision. Codegen has no
+			// specs at generation time, so it keys off the expression itself.
+			if len(sizeHints) > 0 && (sizeHints[0].Size > 0 || sizeHints[0].Expr != "") {
 				sszType = ssztypes.SszVectorType
 			} else if err := rejectZeroSizeHint(sizeHints); err != nil {
 				return nil, err
@@ -730,7 +735,7 @@ func (p *Parser) buildTypeDescriptor(dataType, schemaType types.Type, typeHints 
 				sszType = ssztypes.SszListType
 			}
 		case reflect.String:
-			if len(sizeHints) > 0 && sizeHints[0].Size > 0 {
+			if len(sizeHints) > 0 && (sizeHints[0].Size > 0 || sizeHints[0].Expr != "") {
 				sszType = ssztypes.SszVectorType
 			} else if err := rejectZeroSizeHint(sizeHints); err != nil {
 				return nil, err
@@ -1369,25 +1374,36 @@ func (p *Parser) buildVectorDescriptor(desc *ssztypes.TypeDescriptor, dataType, 
 		}
 	case *types.Slice:
 		schemaElemType = t.Elem()
-		if len(sizeHints) > 0 && sizeHints[0].Size > 0 {
+		switch {
+		case len(sizeHints) > 0 && sizeHints[0].Size > 0:
 			length = sizeHints[0].Size
 			if sizeHints[0].Bits {
 				length = (length + 7) / 8 // ceil up to the next multiple of 8
 			}
-		} else {
+		case len(sizeHints) > 0 && sizeHints[0].Expr != "":
+			// Length comes purely from a runtime dynssz-size expression with no
+			// static ssz-size fallback. Leave the static length at 0; the
+			// generated code resolves desc.SizeExpression at runtime.
+			length = 0
+		default:
 			return fmt.Errorf("vector slice type requires explicit size hint")
 		}
 	case *types.Basic:
 		if t.Kind() == types.String {
 			// String as vector
-			if len(sizeHints) > 0 && sizeHints[0].Size > 0 {
+			switch {
+			case len(sizeHints) > 0 && sizeHints[0].Size > 0:
 				length = sizeHints[0].Size
 				if sizeHints[0].Bits {
 					length = (length + 7) / 8 // ceil up to the next multiple of 8
 				}
 				desc.GoTypeFlags |= ssztypes.GoTypeFlagIsByteArray
 				schemaElemType = byteType
-			} else {
+			case len(sizeHints) > 0 && sizeHints[0].Expr != "":
+				length = 0
+				desc.GoTypeFlags |= ssztypes.GoTypeFlagIsByteArray
+				schemaElemType = byteType
+			default:
 				return fmt.Errorf("string vector type requires explicit size hint")
 			}
 		} else {
@@ -1435,8 +1451,11 @@ func (p *Parser) buildVectorDescriptor(desc *ssztypes.TypeDescriptor, dataType, 
 	desc.Len = length
 
 	// Per the SSZ spec, Vector[type, 0] and Bitvector[0] are illegal: a vector
-	// must have a length greater than zero (e.g. a [0]T array).
-	if desc.Len == 0 {
+	// must have a length greater than zero (e.g. a [0]T array). A vector whose
+	// length is supplied purely by a runtime dynssz-size expression legitimately
+	// carries a static length of 0 here (the expression resolves at runtime), so
+	// only reject a genuine static zero length.
+	if desc.Len == 0 && desc.SizeExpression == nil {
 		return fmt.Errorf("vector type %v has zero length, which is invalid per the SSZ spec", schemaType)
 	}
 

--- a/codegen/parser.go
+++ b/codegen/parser.go
@@ -1925,15 +1925,17 @@ func (p *Parser) buildOptionalListDescriptor(desc *ssztypes.TypeDescriptor, data
 		return fmt.Errorf("optional-list ssz type can only be represented by pointer types, got %v", desc.Kind)
 	}
 
-	childSizeHints := []ssztypes.SszSizeHint{}
-	if len(sizeHints) > 1 {
-		childSizeHints = sizeHints[1:]
-	}
+	// The optional-list frames the Go pointer as List[T, 1]. That framing consumes
+	// the leading ssz-type dimension (the "optional-list" hint itself), but it has
+	// no size or max of its own — the list limit is fixed at 1 — so it consumes no
+	// ssz-size / ssz-max dimension. The remaining size/max hints belong to the
+	// pointed-to element T and must be forwarded in full, exactly as a plain
+	// pointer forwards them (e.g. `*[]uint16 ssz-size:"2"` -> Vector[uint16,2]).
+	// Peeling them here dropped the element's constraint and mis-classified a
+	// fixed inner vector as a variable list.
+	childSizeHints := sizeHints
 
-	childMaxSizeHints := []ssztypes.SszMaxSizeHint{}
-	if len(maxSizeHints) > 1 {
-		childMaxSizeHints = maxSizeHints[1:]
-	}
+	childMaxSizeHints := maxSizeHints
 
 	childTypeHints := []ssztypes.SszTypeHint{}
 	if len(typeHints) > 1 {

--- a/codegen/recursion.go
+++ b/codegen/recursion.go
@@ -17,7 +17,20 @@ import (
 // or delegated methods (a type in the generation set always qualifies). A
 // cycle consisting only of inline-emitted descriptors would recurse forever,
 // so it is rejected with a pointer to the type that must be generated.
-func validateEmittableGraph(root *ssztypes.TypeDescriptor) error {
+//
+// A generation-set type delegates through its own generated methods either via
+// the Dynamic* interface (default mode) or via the fastssz-style MarshalSSZTo /
+// HashTreeRootWith methods (with-legacy or without-dynamic-expressions mode).
+// A reference only terminates the recursion when the emitter actually delegates
+// to a method rather than inlining the child:
+//   - dynamicDelegation (!WithoutDynamicExpressions): the emitter calls the
+//     Dynamic* methods. Under WithoutDynamicExpressions the emitter never calls a
+//     *Dyn method — a dynamic-only child is inlined instead — so DynamicMarshaler
+//     no longer terminates the cycle.
+//   - staticDelegation (!NoFastSsz || WithoutDynamicExpressions): the emitter
+//     calls the fastssz-style static methods (WithoutDynamicExpressions forces
+//     the static path regardless of NoFastSsz).
+func validateEmittableGraph(root *ssztypes.TypeDescriptor, staticDelegation, dynamicDelegation bool) error {
 	const done = 2
 	const onStack = 1
 	state := map[*ssztypes.TypeDescriptor]int{}
@@ -36,9 +49,18 @@ func validateEmittableGraph(root *ssztypes.TypeDescriptor) error {
 			return fmt.Errorf("container type has no SSZ fields, which is invalid per the SSZ spec")
 		}
 		// Emission delegates non-root references with generated/delegated
-		// methods instead of inlining them, which terminates the recursion.
-		if !isRoot && desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicMarshaler != 0 {
-			return nil
+		// methods instead of inlining them, which terminates the recursion. A
+		// method only terminates the cycle when the emitter actually calls it:
+		// Dynamic* methods when dynamicDelegation is set (never under
+		// WithoutDynamicExpressions, where dynamic-only children are inlined),
+		// fastssz-style methods when staticDelegation is set.
+		if !isRoot {
+			if dynamicDelegation && desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicMarshaler != 0 {
+				return nil
+			}
+			if staticDelegation && desc.SszCompatFlags&ssztypes.SszCompatFlagFastSSZMarshaler != 0 {
+				return nil
+			}
 		}
 		if state[desc] == onStack {
 			return fmt.Errorf("recursive type %s is only referenced inline; include it in the code generation set so its methods can be called instead", describeDescriptor(desc))

--- a/codegen/tests/codegen_test.go
+++ b/codegen/tests/codegen_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
+	"os"
 	"reflect"
 	"runtime"
 	"strings"
@@ -345,6 +346,29 @@ func TestCodegenCoverageTypes7(t *testing.T) {
 
 func TestCodegenNoDynExprTypes(t *testing.T) {
 	testCodegenPayloadByReflection(t, NoDynExprTypes_Payload, nil)
+}
+
+// TestCodegenNoDynNest enforces the without-dynamic-expressions invariant on a
+// set of parents nesting a generated child, generated with -with-streaming
+// -without-fastssz -without-dynamic-expressions (gen_nodynnest.yaml). The
+// generated file (compiled as part of this package) must contain no *Dyn buffer
+// function and must round-trip against reflection for every parent shape.
+func TestCodegenNoDynNest(t *testing.T) {
+	code, err := os.ReadFile("gen_nodynnest.go")
+	if err != nil {
+		t.Fatalf("read generated file: %v", err)
+	}
+	for _, tok := range []string{"MarshalSSZDyn", "UnmarshalSSZDyn", "SizeSSZDyn", "HashTreeRootWithDyn"} {
+		if strings.Contains(string(code), tok) {
+			t.Errorf("generated file references forbidden %s under without-dynamic-expressions", tok)
+		}
+	}
+
+	testCodegenPayloadByReflection(t, NoDynNestProg_Payload, nil)
+	testCodegenPayloadByReflection(t, NoDynNestList_Payload, nil)
+	testCodegenPayloadByReflection(t, NoDynNestVec_Payload, nil)
+	testCodegenPayloadByReflection(t, NoDynNestField_Payload, nil)
+	testCodegenPayloadByReflection(t, NoDynNestChild{A: []byte{1, 2}, B: 9}, nil)
 }
 
 // A dynssz expression that resolves to 0 must fall back to the static value in

--- a/codegen/tests/codegen_test.go
+++ b/codegen/tests/codegen_test.go
@@ -377,6 +377,59 @@ func TestCodegenNoDynNest(t *testing.T) {
 	testCodegenPayloadByReflection(t, NoDynNestChild{A: []byte{1, 2}, B: 9}, nil)
 }
 
+// TestCodegenAtkNest hammers the without-dynamic-expressions static/inlining
+// path on richer shapes (gen_atknest.yaml, generated with -with-streaming
+// -without-fastssz -without-dynamic-expressions -with-extended-types): deep
+// containers-of-containers, union/wrapper/optional nesting of generated children,
+// and an external well-behaved delegated type inlined from its structure. The
+// generated file must contain no *Dyn buffer call (the buffer AND streaming
+// paths), must round-trip byte/size/root-identical to reflection for every shape,
+// and the inlined delegated region must equal what the delegated Dynamic* method
+// produces.
+func TestCodegenAtkNest(t *testing.T) {
+	code, err := os.ReadFile("gen_atknest.go")
+	if err != nil {
+		t.Fatalf("read generated file: %v", err)
+	}
+	for _, tok := range []string{"MarshalSSZDyn", "UnmarshalSSZDyn", "SizeSSZDyn", "HashTreeRootWithDyn"} {
+		if strings.Contains(string(code), tok) {
+			t.Errorf("generated file references forbidden %s under without-dynamic-expressions", tok)
+		}
+	}
+
+	ext := dynssz.WithExtendedTypes()
+	testCodegenPayloadByReflection(t, AtkNestD1_Payload, nil, ext)
+	testCodegenPayloadByReflection(t, AtkNestUnion_Payload, nil, ext)
+	testCodegenPayloadByReflection(t, AtkNestWrapper_Payload, nil, ext)
+	testCodegenPayloadByReflection(t, AtkNestOpt_Payload, nil, ext)
+	testCodegenPayloadByReflection(t, AtkNestOptList_Payload, nil, ext)
+	testCodegenPayloadByReflection(t, AtkWellHolder_Payload, nil, ext)
+
+	// The inlined static encoding of the external delegated child must be
+	// byte-identical to what its own Dynamic* method produces. AtkWellHolder is
+	// A(uint64) N(child) V([2]child); marshal it and check each 8-byte child
+	// region equals child.MarshalSSZDyn.
+	genDs := dynssz.NewDynSsz(nil, ext)
+	got, err := genDs.MarshalSSZ(AtkWellHolder_Payload)
+	if err != nil {
+		t.Fatalf("marshal AtkWellHolder: %v", err)
+	}
+	if len(got) != 32 {
+		t.Fatalf("AtkWellHolder expected 32 bytes, got %d", len(got))
+	}
+	children := []atkWellDelegated{AtkWellHolder_Payload.N, AtkWellHolder_Payload.V[0], AtkWellHolder_Payload.V[1]}
+	for i, child := range children {
+		want, err := child.MarshalSSZDyn(nil, nil)
+		if err != nil {
+			t.Fatalf("child.MarshalSSZDyn: %v", err)
+		}
+		region := got[8+i*8 : 8+i*8+8]
+		if !bytes.Equal(region, want) {
+			t.Errorf("inlined child region %d = %x, delegated method = %x", i, region, want)
+		}
+	}
+}
+
 // A dynssz expression that resolves to 0 must fall back to the static value in
 // both engines. Previously the generated code applied the literal
 // 0 limit and rejected the value while reflection fell back, diverging.

--- a/codegen/tests/codegen_test.go
+++ b/codegen/tests/codegen_test.go
@@ -355,6 +355,12 @@ func TestCodegenNoDynExprTypes(t *testing.T) {
 // function and must round-trip against reflection for every parent shape.
 func TestCodegenNoDynNest(t *testing.T) {
 	code, err := os.ReadFile("gen_nodynnest.go")
+	if os.IsNotExist(err) {
+		// The gen_*.go files are gitignored; without go generate this job
+		// exercises only the reflection engine and there is no generated file
+		// to enforce the no-*Dyn invariant against.
+		t.Skip("no generated code present")
+	}
 	if err != nil {
 		t.Fatalf("read generated file: %v", err)
 	}

--- a/codegen/tests/codegen_test.go
+++ b/codegen/tests/codegen_test.go
@@ -689,6 +689,43 @@ func TestCodegenUnionExprVariantSize(t *testing.T) {
 	testCodegenPayloadByReflection(t, UnionExprVariantSize_Payload, UnionExprVariantSize_Specs, dynssz.WithExtendedTypes())
 }
 
+// TestCodegenUnionExprVariantSizeCrossPreset is a regression test for the
+// generated buffer decoder of a union whose fixed-size variant length comes
+// from a dynssz-size expression. The decoder baked the variant's byte length to
+// the static ssz-size fallback (here 4 uint16 = 8 bytes) instead of the runtime
+// resolved size, so any preset whose resolved size differed from the static
+// value made the generated UnmarshalSSZ reject valid encodings with an
+// "incorrect offset: N bytes trailing data" (resolved > static) or an
+// unexpected-EOF (resolved < static). The static-equal case (matching the
+// existing UnionExprVariantSize test) accidentally masked it. Both engines must
+// round-trip identically for resolved sizes above and below the static one.
+func TestCodegenUnionExprVariantSizeCrossPreset(t *testing.T) {
+	mk := func(n int) UnionExprVariantSize {
+		data := make([]uint16, n)
+		for i := range data {
+			data[i] = uint16(i + 1)
+		}
+		return UnionExprVariantSize{
+			U: dynssz.CompatibleUnion[struct {
+				F0 []uint16 `ssz-size:"4" dynssz-size:"UNION_VEC_SIZE"`
+			}]{Variant: 1, Data: data},
+		}
+	}
+	for _, tc := range []struct {
+		name string
+		size uint64
+	}{
+		{"resolved_gt_static", 6},
+		{"resolved_lt_static", 2},
+		{"resolved_eq_static", 4},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testCodegenPayloadByReflection(t, mk(int(tc.size)),
+				map[string]any{"UNION_VEC_SIZE": tc.size}, dynssz.WithExtendedTypes())
+		})
+	}
+}
+
 // TestCodegenVecDynElemExprSize is a regression test for the generated stream
 // decoder of a vector of dynamic-size elements whose length is a dynssz-size
 // expression. The first-offset check compared a uint32 offset against a typed

--- a/codegen/tests/codegen_test.go
+++ b/codegen/tests/codegen_test.go
@@ -622,6 +622,83 @@ func TestCodegenOptionalListTypes(t *testing.T) {
 	}
 }
 
+// TestCodegenOptionalListSliceVector is a regression test for two independent
+// bugs in ssz-type:"optional-list" over a pointer to a slice made fixed-length
+// via ssz-size (i.e. an inner vector, e.g. *[]uint16 ssz-size:"2"):
+//
+//  1. buildOptionalListDescriptor peeled the leading ssz-size/ssz-max dimension
+//     before descending into the element (sizeHints[1:] / maxSizeHints[1:]),
+//     dropping the element's size constraint so the inner vector degraded to a
+//     variable list. That produced a wrong (12-byte) serialization and a wrong
+//     root on BOTH engines — the golden checks below guard it, since a
+//     reflection-vs-codegen comparison alone would not (both engines share the
+//     descriptor and would agree on the wrong encoding).
+//  2. the generated optional-list HTR reused the `vlen` local for its mixin
+//     length, which the fixed-vector element's own `vlen := len(...)` shadowed,
+//     so a present element mixed in a length of 0 — a codegen-only wrong root
+//     caught by the reflection-vs-codegen comparison.
+//
+// Golden roots and serializations are cross-checked against remerkleable
+// (List[Vector[T,N], 1]).
+func TestCodegenOptionalListSliceVector(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload OptionalListSliceVector
+		root    string
+		ser     string
+	}{
+		{"BothSet", OptionalListSliceVector_Payload1, "7e7694aa13e4558ea4e91c3aaef6319a0409a80ad8ea79df3f6a2fd03d8dee92", "080000000c00000034127856aabbccdd"},
+		{"BothNil", OptionalListSliceVector_Payload2, "db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71", "0800000008000000"},
+		{"U16Only", OptionalListSliceVector_Payload3, "53f263191c776497f3a21a93ec0d767753533479ce3a7e5847496c63c7baa905", "080000000c00000034127856"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reflection-vs-codegen agreement (marshal, size, HTR, roundtrip,
+			// streaming) — catches the codegen-only HTR shadowing bug once the
+			// generated methods exist.
+			testCodegenPayloadByReflection(t, tc.payload, nil)
+
+			// Absolute golden values — catch a descriptor regression that would
+			// make both engines agree on the wrong (variable-list) encoding.
+			ds := dynssz.NewDynSsz(nil)
+			root, err := ds.HashTreeRoot(tc.payload)
+			if err != nil {
+				t.Fatalf("HashTreeRoot: %v", err)
+			}
+			if got := hex.EncodeToString(root[:]); got != tc.root {
+				t.Fatalf("optional-list slice-vector root changed: got %s want %s", got, tc.root)
+			}
+			ser, err := ds.MarshalSSZ(tc.payload)
+			if err != nil {
+				t.Fatalf("MarshalSSZ: %v", err)
+			}
+			if got := hex.EncodeToString(ser); got != tc.ser {
+				t.Fatalf("optional-list slice-vector serialization changed: got %s want %s", got, tc.ser)
+			}
+		})
+	}
+}
+
+// TestCodegenUnionExprVariantSize is a regression test for the generated union
+// size code: a union variant whose size is fully determined by a dynssz-size
+// expression never reads the type-asserted variant value, which previously left
+// `v` declared-and-unused so the generated size method failed to compile. This
+// test only exercises the compile fix once the generated methods exist (via
+// go generate); the reflection comparison still validates the sizing itself.
+func TestCodegenUnionExprVariantSize(t *testing.T) {
+	testCodegenPayloadByReflection(t, UnionExprVariantSize_Payload, UnionExprVariantSize_Specs, dynssz.WithExtendedTypes())
+}
+
+// TestCodegenVecDynElemExprSize is a regression test for the generated stream
+// decoder of a vector of dynamic-size elements whose length is a dynssz-size
+// expression. The first-offset check compared a uint32 offset against a typed
+// int length expression, which failed to compile without a uint32 cast. Only
+// meaningful once the generated methods exist (via go generate); the reflection
+// comparison still validates the decoding.
+func TestCodegenVecDynElemExprSize(t *testing.T) {
+	testCodegenPayloadByReflection(t, VecDynElemExprSize_Payload, VecDynElemExprSize_Specs)
+}
+
 // TestCodegenViewTypes2 tests nested view dispatch: a container whose child
 // has view dispatch methods. This exercises the isView code paths in all
 // generators (marshal, unmarshal, encoder, decoder, size, hash).

--- a/codegen/tests/codegen_test.go
+++ b/codegen/tests/codegen_test.go
@@ -388,6 +388,12 @@ func TestCodegenNoDynNest(t *testing.T) {
 // produces.
 func TestCodegenAtkNest(t *testing.T) {
 	code, err := os.ReadFile("gen_atknest.go")
+	if os.IsNotExist(err) {
+		// The gen_*.go files are gitignored; the "without generated code" CI job
+		// runs before go generate, so there is no generated file to enforce the
+		// no-*Dyn invariant against here.
+		t.Skip("no generated code present")
+	}
 	if err != nil {
 		t.Fatalf("read generated file: %v", err)
 	}

--- a/codegen/tests/codegen_test.go
+++ b/codegen/tests/codegen_test.go
@@ -898,6 +898,26 @@ func TestCodegenMultiDimSpecVec(t *testing.T) {
 	}
 }
 
+// A fixed-size vector of variable-size elements whose length is a dynssz
+// expression must generate compiling streaming decoder code (the first-offset
+// check compares a uint32 offset against limit*4, where limit is int(expr)).
+// The package building at all is the compile regression guard; the differential
+// confirms the value round-trips identically in both engines.
+func TestCodegenStreamVecDynSize(t *testing.T) {
+	for _, specs := range []map[string]any{nil, StreamVecDynSize_Specs} {
+		testCodegenPayloadByReflection(t, StreamVecDynSize_Payload, specs)
+		testCodegenPayloadByReflection(t, StreamVecDynSize{V: []StreamVecElem{}}, specs)
+	}
+}
+
+// A compatible-union whose variant is an inline container sized purely by a size
+// expression must still generate compiling SizeSSZ code: the asserted variant
+// value would otherwise be declared-and-unused. The package compiling is the
+// regression guard; the differential confirms sizing agreement.
+func TestCodegenSizeUnionExprVariant(t *testing.T) {
+	testCodegenPayloadByReflection(t, SizeUnionExprVariant_Payload, SizeUnionExprVariant_Specs)
+}
+
 // A bitlist without ssz-max must produce the same root in both engines
 // (length mixin with a limit derived from the serialized bit length).
 func TestCodegenNoMaxBitlist(t *testing.T) {

--- a/codegen/tests/dynsize_vector_test.go
+++ b/codegen/tests/dynsize_vector_test.go
@@ -1,0 +1,76 @@
+package tests
+
+import (
+	"encoding/hex"
+	"testing"
+
+	dynssz "github.com/pk910/dynamic-ssz"
+)
+
+// TestCodegenDynSizeVectorNoStatic is a regression test for a codegen parser
+// bug: a slice sized purely by a dynssz-size expression (no static ssz-size
+// fallback) was classified as a variable List instead of a Vector. The
+// reflection typecache resolves the expression to a concrete size at
+// descriptor-build time and correctly treats such a slice as Vector[T, N]; the
+// codegen parser, which has no spec values at generation time, keyed the
+// vector/list decision on the static size alone (0 here) and emitted a
+// variable-list encoding — a 4-byte offset header plus contents, ignoring the
+// spec entirely (MarshalSSZDyn dropped its DynamicSpecs argument). That diverged
+// from reflection and the SSZ spec on size, serialization and hash tree root.
+//
+// The differential leg (reflection vs codegen) catches the divergence; the
+// golden serializations and roots — cross-checked against ethereum/remerkleable
+// (Container{V: Vector[uint16,N], AV: Vector[Vector[uint16,N],2]}) — guard
+// against a future regression that made both engines agree on the wrong
+// (variable-list) encoding.
+func TestCodegenDynSizeVectorNoStatic(t *testing.T) {
+	cases := []struct {
+		name string
+		n    int
+		len  uint64
+		ser  string
+		root string
+	}{
+		{
+			name: "mainnet",
+			n:    3,
+			len:  3,
+			ser:  "010002000300010002000300650066006700",
+			root: "aa5624c38c6705e5c2925da004ebd588149376b911a1e00d98841566a996ea50",
+		},
+		{
+			name: "minimal",
+			n:    5,
+			len:  5,
+			ser:  "010002000300040005000100020003000400050065006600670068006900",
+			root: "c642c4f85bb485ac64d226a098b9f9bb2df187664a746f12d0042cb8f265d91e",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			specs := map[string]any{"DSV_LEN": tc.len}
+			payload := DynSizeVectorNoStaticPayload(tc.n)
+
+			// Reflection-vs-codegen agreement across marshal, size, HTR,
+			// buffer/stream round-trips.
+			testCodegenPayloadByReflection(t, payload, specs)
+
+			// Absolute golden values cross-checked with remerkleable.
+			ds := dynssz.NewDynSsz(specs)
+			ser, err := ds.MarshalSSZ(payload)
+			if err != nil {
+				t.Fatalf("MarshalSSZ: %v", err)
+			}
+			if got := hex.EncodeToString(ser); got != tc.ser {
+				t.Fatalf("serialization changed: got %s want %s", got, tc.ser)
+			}
+			root, err := ds.HashTreeRoot(payload)
+			if err != nil {
+				t.Fatalf("HashTreeRoot: %v", err)
+			}
+			if got := hex.EncodeToString(root[:]); got != tc.root {
+				t.Fatalf("root changed: got %s want %s", got, tc.root)
+			}
+		})
+	}
+}

--- a/codegen/tests/gen_atknest.yaml
+++ b/codegen/tests/gen_atknest.yaml
@@ -1,0 +1,25 @@
+# Richer nested/inlining attack shapes for the without-dynamic-expressions
+# static path, generated with the hardest static combination:
+# -with-streaming -without-fastssz -without-dynamic-expressions -with-extended-types.
+# Deep containers-of-containers, union/wrapper/optional nesting of generated
+# children, and an external well-behaved delegated type that must be inlined
+# byte/root-identically to its Dynamic* methods. The generated file compiling as
+# part of this package is the invariant guard; the differential test confirms the
+# static code round-trips against reflection and matches the delegated encoding.
+package: github.com/pk910/dynamic-ssz/codegen/tests
+output: gen_atknest.go
+with-streaming: true
+without-fastssz: true
+without-dynamic-expressions: true
+with-extended-types: true
+
+types:
+  - AtkNestLeaf
+  - AtkNestD3
+  - AtkNestD2
+  - AtkNestD1
+  - AtkNestUnion
+  - AtkNestWrapper
+  - AtkNestOpt
+  - AtkNestOptList
+  - AtkWellHolder

--- a/codegen/tests/gen_nodynnest.yaml
+++ b/codegen/tests/gen_nodynnest.yaml
@@ -1,0 +1,18 @@
+# Nested generated containers generated with the hardest static combination:
+# -with-streaming -without-fastssz -without-dynamic-expressions. Every parent
+# must reach the nested child through its static methods, never a *Dyn buffer
+# function and never by wrapping the streaming encoder into the static path.
+# The generated file compiling as part of this package is the invariant guard;
+# the differential test confirms the static code round-trips against reflection.
+package: github.com/pk910/dynamic-ssz/codegen/tests
+output: gen_nodynnest.go
+with-streaming: true
+without-fastssz: true
+without-dynamic-expressions: true
+
+types:
+  - NoDynNestProg
+  - NoDynNestList
+  - NoDynNestVec
+  - NoDynNestField
+  - NoDynNestChild

--- a/codegen/tests/gen_ssz.yaml
+++ b/codegen/tests/gen_ssz.yaml
@@ -99,6 +99,12 @@ types:
     views:
       - ViewTypes3_View1
 
+  - name: StreamVecDynSize
+    output: gen_divergence.go
+  - name: StreamVecElem
+    output: gen_divergence.go
+  - name: SizeUnionExprVariant
+    output: gen_divergence.go
   - name: MultiDimSpecVec
     output: gen_divergence.go
   - name: NoMaxBitlist

--- a/codegen/tests/gen_ssz.yaml
+++ b/codegen/tests/gen_ssz.yaml
@@ -186,3 +186,6 @@ types:
     output: gen_recursive.go
   - name: RecursiveTreeBranch
     output: gen_recursive.go
+
+  - name: DynSizeVectorNoStatic
+    output: gen_dynsizevec.go

--- a/codegen/tests/gen_ssz.yaml
+++ b/codegen/tests/gen_ssz.yaml
@@ -79,6 +79,14 @@ types:
     output: gen_optionallist.go
   - name: OptionalListTypes_Inner
     output: gen_optionallist.go
+  - name: OptionalListSliceVector
+    output: gen_optionallist.go
+  - name: UnionExprVariantSize
+    output: gen_optionallist.go
+  - name: VecDynElemExprSize
+    output: gen_optionallist.go
+  - name: VecDynElemExprSize_Inner
+    output: gen_optionallist.go
 
   - name: ViewTypes1_Base
     output: gen_viewtypes1.go

--- a/codegen/tests/generate.go
+++ b/codegen/tests/generate.go
@@ -10,3 +10,4 @@ package tests
 //go:generate go run -cover ../../dynssz-gen -config gen_annotated.yaml
 //go:generate go run -cover ../../dynssz-gen -config gen_viewtypes4.yaml
 //go:generate go run -cover ../../dynssz-gen -config gen_nodynexpr.yaml
+//go:generate go run -cover ../../dynssz-gen -config gen_nodynnest.yaml

--- a/codegen/tests/generate.go
+++ b/codegen/tests/generate.go
@@ -11,3 +11,4 @@ package tests
 //go:generate go run -cover ../../dynssz-gen -config gen_viewtypes4.yaml
 //go:generate go run -cover ../../dynssz-gen -config gen_nodynexpr.yaml
 //go:generate go run -cover ../../dynssz-gen -config gen_nodynnest.yaml
+//go:generate go run -cover ../../dynssz-gen -config gen_atknest.yaml

--- a/codegen/tests/types.go
+++ b/codegen/tests/types.go
@@ -1021,6 +1021,58 @@ var NoDynExprTypes_Payload = NoDynExprTypes{
 	Str1:   "hello",
 }
 
+// NoDynNestChild is a variable-size container nested by the NoDynNest* parents.
+// Generated with -with-streaming -without-fastssz -without-dynamic-expressions,
+// its parents must reach it through its static MarshalSSZTo/UnmarshalSSZ/SizeSSZ/
+// HashTreeRootWith methods — never the *Dyn buffer variants and never by wrapping
+// the streaming encoder into the static buffer path.
+type NoDynNestChild struct {
+	A []byte `ssz-max:"8"`
+	B uint8
+}
+
+// NoDynNestProg nests the child as a progressive-list.
+type NoDynNestProg struct {
+	L []NoDynNestChild `ssz-type:"progressive-list" ssz-max:"100"`
+}
+
+// NoDynNestList nests the child as a bounded list.
+type NoDynNestList struct {
+	L []NoDynNestChild `ssz-max:"100"`
+}
+
+// NoDynNestVec nests the child as a fixed vector.
+type NoDynNestVec struct {
+	V [3]NoDynNestChild
+}
+
+// NoDynNestField nests the child as a plain container field.
+type NoDynNestField struct {
+	C NoDynNestChild
+	N uint16
+}
+
+var (
+	NoDynNestProg_Payload = NoDynNestProg{L: []NoDynNestChild{
+		{A: []byte{1, 2, 3}, B: 7},
+		{A: nil, B: 0},
+		{A: []byte{9}, B: 255},
+	}}
+	NoDynNestList_Payload = NoDynNestList{L: []NoDynNestChild{
+		{A: []byte{4, 5}, B: 1},
+		{A: []byte{6, 7, 8}, B: 2},
+	}}
+	NoDynNestVec_Payload = NoDynNestVec{V: [3]NoDynNestChild{
+		{A: []byte{1}, B: 10},
+		{A: []byte{2, 2}, B: 20},
+		{A: nil, B: 30},
+	}}
+	NoDynNestField_Payload = NoDynNestField{
+		C: NoDynNestChild{A: []byte{3, 3, 3}, B: 42},
+		N: 1234,
+	}
+)
+
 // InterpretedAnnotatedList tests Annotate with an interpreted (double-quoted) string literal.
 type InterpretedAnnotatedList []uint32
 

--- a/codegen/tests/types.go
+++ b/codegen/tests/types.go
@@ -602,6 +602,82 @@ var OptionalListTypes_Payload1 = OptionalListTypes{
 	DynamicOpt: optListInner,
 }
 
+// OptionalListSliceVector exercises ssz-type:"optional-list" over a pointer to a
+// SLICE whose fixed length comes from ssz-size (a vector), plus the byte-vector
+// form. These are spec-identical to an optional-list over a Go array
+// (*[2]uint16 / *[4]byte): the optional-list frames the pointer as List[T, 1]
+// where T is the fixed-size inner vector. The slice spelling only stays correct
+// if the element's ssz-size survives into the element descriptor — otherwise the
+// inner vector degrades to a variable list (wrong marshal + wrong root).
+type OptionalListSliceVector struct {
+	VecU16  *[]uint16 `ssz-size:"2" ssz-type:"optional-list"`
+	VecByte *[]byte   `ssz-size:"4" ssz-type:"optional-list"`
+}
+
+var (
+	optSliceVecU16  = []uint16{0x1234, 0x5678}
+	optSliceVecByte = []byte{0xaa, 0xbb, 0xcc, 0xdd}
+)
+
+// Both optional vectors present.
+var OptionalListSliceVector_Payload1 = OptionalListSliceVector{
+	VecU16:  &optSliceVecU16,
+	VecByte: &optSliceVecByte,
+}
+
+// Both nil.
+var OptionalListSliceVector_Payload2 = OptionalListSliceVector{}
+
+// Only the uint16 vector present.
+var OptionalListSliceVector_Payload3 = OptionalListSliceVector{
+	VecU16: &optSliceVecU16,
+}
+
+// UnionExprVariantSize is a regression type for the generated union size code.
+// The union variant is a vector whose length comes from a dynssz-size
+// expression, so its size is computed purely from that expression and never
+// reads the type-asserted variant value. Without an explicit `_ = v`, the
+// generated size code left `v` declared-and-unused and failed to compile.
+type UnionExprVariantSize struct {
+	U dynssz.CompatibleUnion[struct {
+		F0 []uint16 `ssz-size:"4" dynssz-size:"UNION_VEC_SIZE"`
+	}]
+}
+
+var UnionExprVariantSize_Specs = map[string]any{
+	"UNION_VEC_SIZE": uint64(4),
+}
+
+var UnionExprVariantSize_Payload = UnionExprVariantSize{
+	U: dynssz.CompatibleUnion[struct {
+		F0 []uint16 `ssz-size:"4" dynssz-size:"UNION_VEC_SIZE"`
+	}]{Variant: 1, Data: []uint16{1, 2, 3, 4}},
+}
+
+// VecDynElemExprSize is a regression type for the generated stream decoder: a
+// vector of dynamic-size elements whose length comes from a dynssz-size
+// expression. The decoder's first-offset check compares the uint32 offset
+// against `<len-expr>*4`; when the length is a typed int expression the RHS must
+// be cast to uint32, otherwise the generated code failed to compile.
+type VecDynElemExprSize_Inner struct {
+	D []byte `ssz-max:"8"`
+}
+
+type VecDynElemExprSize struct {
+	V []VecDynElemExprSize_Inner `ssz-size:"2" dynssz-size:"VDE_SIZE"`
+}
+
+var VecDynElemExprSize_Specs = map[string]any{
+	"VDE_SIZE": uint64(2),
+}
+
+var VecDynElemExprSize_Payload = VecDynElemExprSize{
+	V: []VecDynElemExprSize_Inner{
+		{D: []byte{1, 2, 3}},
+		{D: []byte{4, 5}},
+	},
+}
+
 // Both pointers nil.
 var OptionalListTypes_Payload2 = OptionalListTypes{
 	StaticOpt:  nil,

--- a/codegen/tests/types.go
+++ b/codegen/tests/types.go
@@ -1739,3 +1739,59 @@ var RecursiveTree_Payload = RecursiveTree{
 		}},
 	},
 }
+
+// StreamVecDynSize is a fixed-size vector (slice with ssz-size + dynssz-size) of
+// variable-size elements. With -with-streaming the decoder emits a first-offset
+// check `startOffset != <limit>*4`; when the limit is a dynssz expression the
+// limit renders as a typed int(expr), so the comparison against the uint32
+// startOffset must be uint32-converted or the generated code fails to compile.
+type StreamVecDynSize struct {
+	V []StreamVecElem `ssz-size:"2" dynssz-size:"STREAMVEC_LEN"`
+}
+
+type StreamVecElem struct {
+	X []byte `ssz-max:"8"`
+}
+
+var StreamVecDynSize_Specs = map[string]any{
+	"STREAMVEC_LEN": uint64(2),
+}
+
+var StreamVecDynSize_Payload = StreamVecDynSize{
+	V: []StreamVecElem{
+		{X: []byte{1, 2, 3}},
+		{X: []byte{4, 5}},
+	},
+}
+
+// SizeUnionExprVariant has a compatible-union whose second variant is an inline
+// container sized entirely by a size expression (a fixed-size string with a
+// dynssz-size). The SizeSSZ generator asserts the variant value but the
+// expression-only size never reads it, which must not leave the asserted
+// variable declared-and-unused in the generated code.
+type SizeUnionExprVariant struct {
+	U dynssz.CompatibleUnion[struct {
+		A uint32
+		B struct {
+			S string `ssz-size:"8" dynssz-size:"SUEV_LEN"`
+		}
+	}]
+}
+
+var SizeUnionExprVariant_Specs = map[string]any{
+	"SUEV_LEN": uint64(8),
+}
+
+var SizeUnionExprVariant_Payload = SizeUnionExprVariant{
+	U: dynssz.CompatibleUnion[struct {
+		A uint32
+		B struct {
+			S string `ssz-size:"8" dynssz-size:"SUEV_LEN"`
+		}
+	}]{
+		Variant: 2,
+		Data: struct {
+			S string `ssz-size:"8" dynssz-size:"SUEV_LEN"`
+		}{S: "abcdefgh"},
+	},
+}

--- a/codegen/tests/types.go
+++ b/codegen/tests/types.go
@@ -1958,3 +1958,119 @@ func DynSizeVectorNoStaticPayload(n int) DynSizeVectorNoStatic {
 	}
 	return DynSizeVectorNoStatic{V: v, AV: av}
 }
+
+// ---------------------------------------------------------------------------
+// Attack shapes for the without-dynamic-expressions static/inlining path.
+// All generated with -with-streaming -without-fastssz -without-dynamic-expressions
+// -with-extended-types (gen_atknest.yaml). Every parent must reach nested
+// generated children through their static methods (never a *Dyn buffer call)
+// and must round-trip byte/size/root-identical to reflection.
+// ---------------------------------------------------------------------------
+
+// AtkNestLeaf is a variable-size leaf container nested at several depths.
+type AtkNestLeaf struct {
+	A []byte `ssz-max:"8"`
+	B uint8
+}
+
+// AtkNestD3/D2/D1 build a depth-4 chain of variable-size containers-of-containers
+// mixing list, vector, and progressive-list nesting.
+type AtkNestD3 struct {
+	L AtkNestLeaf
+	V [2]AtkNestLeaf
+	X uint16
+}
+type AtkNestD2 struct {
+	N AtkNestD3
+	L []AtkNestD3 `ssz-max:"4"`
+}
+type AtkNestD1 struct {
+	N AtkNestD2
+	P []AtkNestD2 `ssz-type:"progressive-list" ssz-max:"8"`
+	Z uint64
+}
+
+// AtkNestUnion nests generated containers as union variants.
+type AtkNestUnion struct {
+	U dynssz.CompatibleUnion[struct {
+		F1 AtkNestLeaf
+		F2 AtkNestD2
+	}]
+}
+
+// AtkNestWrapper wraps a nested generated container in a TypeWrapper.
+type AtkNestWrapper struct {
+	W dynssz.TypeWrapper[struct {
+		Data AtkNestD2 `ssz-size:"?"`
+	}, AtkNestD2]
+}
+
+// AtkNestOpt / AtkNestOptList nest a generated container behind an optional and
+// an optional-list pointer.
+type AtkNestOpt struct {
+	Opt *AtkNestD2 `ssz-type:"optional"`
+	N   uint16
+}
+type AtkNestOptList struct {
+	Opt *AtkNestD2 `ssz-type:"optional-list"`
+}
+
+var (
+	atkNestLeafA = AtkNestLeaf{A: []byte{1, 2, 3}, B: 7}
+	atkNestLeafB = AtkNestLeaf{A: nil, B: 0}
+	atkNestD3v   = AtkNestD3{L: atkNestLeafA, V: [2]AtkNestLeaf{atkNestLeafA, atkNestLeafB}, X: 9}
+	atkNestD2v   = AtkNestD2{N: atkNestD3v, L: []AtkNestD3{atkNestD3v, atkNestD3v}}
+
+	AtkNestD1_Payload = AtkNestD1{
+		N: atkNestD2v,
+		P: []AtkNestD2{atkNestD2v, atkNestD2v},
+		Z: 0xdeadbeef,
+	}
+	AtkNestUnion_Payload = AtkNestUnion{U: dynssz.CompatibleUnion[struct {
+		F1 AtkNestLeaf
+		F2 AtkNestD2
+	}]{Variant: 1, Data: atkNestLeafA}}
+	AtkNestWrapper_Payload = AtkNestWrapper{W: dynssz.TypeWrapper[struct {
+		Data AtkNestD2 `ssz-size:"?"`
+	}, AtkNestD2]{Data: atkNestD2v}}
+	AtkNestOpt_Payload     = AtkNestOpt{Opt: &atkNestD2v, N: 4321}
+	AtkNestOptList_Payload = AtkNestOptList{Opt: &atkNestD2v}
+)
+
+// atkWellDelegated is an external fully-delegated type whose Go struct layout
+// matches its wire form exactly (a single uint64 field). Under
+// without-dynamic-expressions the parser (NoDelegation) traverses it and the
+// static generators inline its structure. The inlined static encoding must be
+// byte/root-identical to what its own Dynamic* methods produce.
+type atkWellDelegated struct {
+	V uint64
+}
+
+var _ = sszutils.Annotate[atkWellDelegated](`ssz-static:"true"`)
+
+func (n *atkWellDelegated) SizeSSZDyn(_ sszutils.DynamicSpecs) int { return 8 }
+func (n *atkWellDelegated) MarshalSSZDyn(_ sszutils.DynamicSpecs, buf []byte) ([]byte, error) {
+	return binary.LittleEndian.AppendUint64(buf, n.V), nil
+}
+func (n *atkWellDelegated) UnmarshalSSZDyn(_ sszutils.DynamicSpecs, buf []byte) error {
+	n.V = binary.LittleEndian.Uint64(buf)
+	return nil
+}
+func (n *atkWellDelegated) HashTreeRootWithDyn(_ sszutils.DynamicSpecs, hh sszutils.HashWalker) error {
+	hh.PutUint64(n.V)
+	return nil
+}
+
+// AtkWellHolder nests the well-behaved delegated type as a static field and a
+// vector; generated statically it inlines the delegated type's structure.
+type AtkWellHolder struct {
+	A uint64
+	N atkWellDelegated
+	V [2]atkWellDelegated
+}
+
+var AtkWellHolder_Payload = AtkWellHolder{
+	A: 0x1122334455667788,
+	N: atkWellDelegated{V: 0x99},
+	V: [2]atkWellDelegated{{V: 0xaa}, {V: 0xbb}},
+}

--- a/codegen/tests/types.go
+++ b/codegen/tests/types.go
@@ -1923,3 +1923,38 @@ var SizeUnionExprVariant_Payload = SizeUnionExprVariant{
 		}{S: "abcdefgh"},
 	},
 }
+
+// DynSizeVectorNoStatic covers slices whose length is fixed purely by a
+// dynssz-size expression, with no static ssz-size fallback. The reflection
+// typecache resolves the expression to a concrete size and classifies the slice
+// as a Vector; the codegen parser has no spec values at generation time and must
+// reach the same classification from the presence of the expression alone.
+// Previously the generator saw a static size of 0 and mis-encoded the field as a
+// variable List (a 4-byte offset plus contents), diverging from reflection and
+// the SSZ spec on size, serialization and hash tree root. AV additionally nests
+// the dynssz-only inner vector under a fixed outer array whose dimension is the
+// '?' placeholder.
+type DynSizeVectorNoStatic struct {
+	V  []uint16    `dynssz-size:"DSV_LEN"`
+	AV [2][]uint16 `dynssz-size:"?,DSV_LEN"`
+}
+
+var DynSizeVectorNoStatic_Specs = map[string]any{
+	"DSV_LEN": uint64(3),
+}
+
+func DynSizeVectorNoStaticPayload(n int) DynSizeVectorNoStatic {
+	v := make([]uint16, n)
+	for i := range v {
+		v[i] = uint16(i + 1)
+	}
+	var av [2][]uint16
+	for r := range av {
+		row := make([]uint16, n)
+		for i := range row {
+			row[i] = uint16(r*100 + i + 1)
+		}
+		av[r] = row
+	}
+	return DynSizeVectorNoStatic{V: v, AV: av}
+}

--- a/codegen/typename.go
+++ b/codegen/typename.go
@@ -545,7 +545,10 @@ func (p *TypePrinter) reflectGenericTypeName(t reflect.Type, trackImports bool) 
 // extractAndRegisterImports finds package paths in the type string and registers them as imports
 func (p *TypePrinter) extractAndRegisterImports(typeStr string) {
 	// Match package paths like github.com/attestantio/go-eth2-client/spec/phase0
-	pkgPattern := regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9_]*(?:\.[a-zA-Z][a-zA-Z0-9_]*)*(?:/[a-zA-Z][a-zA-Z0-9_.-]*)+)\.([A-Z][a-zA-Z0-9_]*)`)
+	// The trailing type name may be unexported (lowercase-initial): a generic type
+	// argument can reference an unexported same-package type, whose full import
+	// path must still be rewritten to an unqualified identifier.
+	pkgPattern := regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9_]*(?:\.[a-zA-Z][a-zA-Z0-9_]*)*(?:/[a-zA-Z][a-zA-Z0-9_.-]*)+)\.([A-Za-z_][a-zA-Z0-9_]*)`)
 	matches := pkgPattern.FindAllStringSubmatch(typeStr, -1)
 
 	for _, match := range matches {
@@ -576,8 +579,10 @@ func (p *TypePrinter) extractAndRegisterImports(typeStr string) {
 func (p *TypePrinter) cleanGenericTypeName(genericStr string) string {
 	result := genericStr
 
-	// Replace full package paths with alias.Type format
-	pkgPattern := regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9_]*(?:\.[a-zA-Z][a-zA-Z0-9_]*)*(?:/[a-zA-Z][a-zA-Z0-9_.-]*)+)\.([A-Z][a-zA-Z0-9_]*)`)
+	// Replace full package paths with alias.Type format. The trailing type name
+	// may be unexported (lowercase-initial): a generic type argument can reference
+	// an unexported same-package type whose full import path must be rewritten.
+	pkgPattern := regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9_]*(?:\.[a-zA-Z][a-zA-Z0-9_]*)*(?:/[a-zA-Z][a-zA-Z0-9_.-]*)+)\.([A-Za-z_][a-zA-Z0-9_]*)`)
 
 	result = pkgPattern.ReplaceAllStringFunc(result, func(match string) string {
 		submatches := pkgPattern.FindStringSubmatch(match)

--- a/multidim_dynsize_test.go
+++ b/multidim_dynsize_test.go
@@ -1,0 +1,54 @@
+package dynssz
+
+import (
+	"bytes"
+	"testing"
+)
+
+// A fixed Go array whose outer dynssz-size dimension is the "?" placeholder,
+// with the inner dimension sized by a resolved spec expression, must serialize
+// as Vector[Vector[byte, N], ArrayLen] — the array's intrinsic length is kept.
+//
+// Regression for a reflection bug where the "?" placeholder produced a
+// zero-size dynamic hint that zeroed the array length, making SizeSSZ/MarshalSSZ
+// fail with "vector type [2][]uint8 has zero length" while the codegen path
+// (and the SSZ spec) treated it as a valid 10-byte vector-of-vectors.
+func TestMultiDimArrayOuterDynSizeQuestion(t *testing.T) {
+	specs := map[string]any{"MAX_ATTESTATIONS": uint64(5)}
+	ds := NewDynSsz(specs, WithNoFastSsz(), WithNoDelegation())
+
+	type multiDim struct {
+		F [2][]byte `ssz-size:"2,6" dynssz-size:"?,MAX_ATTESTATIONS"`
+	}
+	v := &multiDim{F: [2][]byte{{1, 2, 3, 4, 5}, {6, 7, 8, 9, 10}}}
+
+	size, err := ds.SizeSSZ(v)
+	if err != nil {
+		t.Fatalf("SizeSSZ: %v", err)
+	}
+	if size != 10 {
+		t.Fatalf("size: expected 10, got %d", size)
+	}
+
+	got, err := ds.MarshalSSZ(v)
+	if err != nil {
+		t.Fatalf("MarshalSSZ: %v", err)
+	}
+	want := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("marshal: expected %x, got %x", want, got)
+	}
+
+	// Round-trip.
+	var out multiDim
+	if err := ds.UnmarshalSSZ(&out, got); err != nil {
+		t.Fatalf("UnmarshalSSZ: %v", err)
+	}
+	re, err := ds.MarshalSSZ(&out)
+	if err != nil {
+		t.Fatalf("re-marshal: %v", err)
+	}
+	if !bytes.Equal(re, want) {
+		t.Fatalf("round-trip: expected %x, got %x", want, re)
+	}
+}

--- a/multidim_dynsize_test.go
+++ b/multidim_dynsize_test.go
@@ -41,8 +41,8 @@ func TestMultiDimArrayOuterDynSizeQuestion(t *testing.T) {
 
 	// Round-trip.
 	var out multiDim
-	if err := ds.UnmarshalSSZ(&out, got); err != nil {
-		t.Fatalf("UnmarshalSSZ: %v", err)
+	if uerr := ds.UnmarshalSSZ(&out, got); uerr != nil {
+		t.Fatalf("UnmarshalSSZ: %v", uerr)
 	}
 	re, err := ds.MarshalSSZ(&out)
 	if err != nil {

--- a/reflection/overflow_internal_test.go
+++ b/reflection/overflow_internal_test.go
@@ -5,6 +5,7 @@
 package reflection
 
 import (
+	"bytes"
 	"io"
 	"math"
 	"reflect"
@@ -405,5 +406,127 @@ func TestBigIntLimitBytesOverflow(t *testing.T) {
 	}
 	if _, ok := bigIntLimitBytes(td); ok {
 		t.Fatal("expected no representable byte cap for an out-of-range limit")
+	}
+}
+
+// --- open-region streaming decode error branches ---
+//
+// These reach the read-to-EOF and offset-region error paths that only the
+// unknown-length stream decoder exercises. Unlike the overflow guards above they
+// are not platform-gated.
+
+func uint32ElemDesc() *ssztypes.TypeDescriptor {
+	return &ssztypes.TypeDescriptor{
+		Size:    4,
+		Kind:    reflect.Uint32,
+		SszType: ssztypes.SszUint32Type,
+		Type:    reflect.TypeOf(uint32(0)),
+	}
+}
+
+// A bounded but not-yet-buffered region reports LengthKnown()==false, so the
+// read-to-EOF list path runs, yet RegionOpen()==false keeps the alignment and
+// ssz-max checks active. A 5-byte region is not a multiple of the 4-byte element.
+func TestUnmarshalListUntilEOFNotAligned(t *testing.T) {
+	ctx := newCtx()
+	td := &ssztypes.TypeDescriptor{
+		SszType:  ssztypes.SszListType,
+		Kind:     reflect.Slice,
+		Type:     reflect.TypeOf([]uint32{}),
+		ElemDesc: uint32ElemDesc(),
+	}
+	dec := sszutils.NewUnknownStreamDecoder(strings.NewReader("12345"), 8, 0)
+	dec.PushLimit(5)
+	val := reflect.New(td.Type).Elem()
+	err := ctx.unmarshalType(td, val, dec, 0)
+	if err == nil || !strings.Contains(err.Error(), "not a multiple of element size") {
+		t.Fatalf("expected list-not-aligned error, got: %v", err)
+	}
+}
+
+// An 8-byte bounded region declares two 4-byte elements, but the list max is 1.
+func TestUnmarshalListUntilEOFTooLong(t *testing.T) {
+	ctx := newCtx()
+	td := &ssztypes.TypeDescriptor{
+		SszType:      ssztypes.SszListType,
+		SszTypeFlags: ssztypes.SszTypeFlagHasLimit,
+		Limit:        1,
+		Kind:         reflect.Slice,
+		Type:         reflect.TypeOf([]uint32{}),
+		ElemDesc:     uint32ElemDesc(),
+	}
+	dec := sszutils.NewUnknownStreamDecoder(strings.NewReader("12345678"), 8, 0)
+	dec.PushLimit(8)
+	val := reflect.New(td.Type).Elem()
+	err := ctx.unmarshalType(td, val, dec, 0)
+	if err == nil || !strings.Contains(err.Error(), "exceeds maximum") {
+		t.Fatalf("expected list-too-long error, got: %v", err)
+	}
+}
+
+// An element that claims an 8-byte size but decodes as a 4-byte uint32 under-
+// consumes its slot and trips the static-element consumption check.
+func TestUnmarshalListUntilEOFStaticElementNotConsumed(t *testing.T) {
+	ctx := newCtx()
+	elemDesc := &ssztypes.TypeDescriptor{
+		Size:    8,
+		Kind:    reflect.Uint32,
+		SszType: ssztypes.SszUint32Type,
+		Type:    reflect.TypeOf(uint32(0)),
+	}
+	td := &ssztypes.TypeDescriptor{
+		SszType:  ssztypes.SszListType,
+		Kind:     reflect.Slice,
+		Type:     reflect.TypeOf([]uint32{}),
+		ElemDesc: elemDesc,
+	}
+	dec := sszutils.NewUnknownStreamDecoder(strings.NewReader("12345678"), 8, 0)
+	dec.PushOpenLimit()
+	val := reflect.New(td.Type).Elem()
+	err := ctx.unmarshalType(td, val, dec, 0)
+	if err == nil || !strings.Contains(err.Error(), "element consumed to position") {
+		t.Fatalf("expected static-element-not-consumed error, got: %v", err)
+	}
+}
+
+// The trailing element of an open-region dynamic vector runs to EOF, so surplus
+// bytes after the element surface as trailing data when its region is finished.
+func TestUnmarshalDynamicVectorOpenTrailing(t *testing.T) {
+	ctx := newCtx()
+	td := &ssztypes.TypeDescriptor{
+		SszType:  ssztypes.SszVectorType,
+		Kind:     reflect.Slice,
+		Len:      1,
+		Type:     reflect.TypeOf([]uint32{}),
+		ElemDesc: uint32ElemDesc(),
+	}
+	// one offset (=4) + a 4-byte element + 2 trailing bytes.
+	data := []byte{4, 0, 0, 0, 1, 0, 0, 0, 0xFF, 0xFF}
+	dec := sszutils.NewUnknownStreamDecoder(bytes.NewReader(data), 64, 0)
+	dec.PushOpenLimit()
+	val := reflect.New(td.Type).Elem()
+	err := ctx.unmarshalDynamicVector(td, val, dec, 0)
+	if err == nil || !strings.Contains(err.Error(), "trailing data") {
+		t.Fatalf("expected trailing-data error, got: %v", err)
+	}
+}
+
+// Same trailing-data path for a dynamic list: firstOffset=4 selects one element,
+// followed by a 4-byte element and 2 trailing bytes.
+func TestUnmarshalDynamicListOpenTrailing(t *testing.T) {
+	ctx := newCtx()
+	td := &ssztypes.TypeDescriptor{
+		SszType:  ssztypes.SszListType,
+		Kind:     reflect.Slice,
+		Type:     reflect.TypeOf([]uint32{}),
+		ElemDesc: uint32ElemDesc(),
+	}
+	data := []byte{4, 0, 0, 0, 1, 0, 0, 0, 0xFF, 0xFF}
+	dec := sszutils.NewUnknownStreamDecoder(bytes.NewReader(data), 64, 0)
+	dec.PushOpenLimit()
+	val := reflect.New(td.Type).Elem()
+	err := ctx.unmarshalDynamicList(td, val, dec, 0)
+	if err == nil || !strings.Contains(err.Error(), "trailing data") {
+		t.Fatalf("expected trailing-data error, got: %v", err)
 	}
 }

--- a/ssztypes/typecache.go
+++ b/ssztypes/typecache.go
@@ -1247,8 +1247,18 @@ func (tc *TypeCache) buildUintDescriptor(desc *TypeDescriptor, t reflect.Type, b
 
 	if desc.Kind == reflect.Array {
 		dstLen := uint32(t.Len())
+		// A fixed-width uint (uint128/uint256) occupies exactly desc.Len array
+		// elements. A smaller array cannot hold it; a larger array carries trailing
+		// elements that marshal silently drops (truncating to desc.Len) while
+		// HashTreeRoot rejects the length mismatch — an inconsistency the codegen
+		// parser already refuses. Reject both here so the reflection path agrees.
+		// Unlike a Vector/Bitvector (where an oversized backing array is a valid
+		// preset pattern), a uint width is intrinsic and never preset-dependent.
 		if dstLen < desc.Len {
 			return sszutils.NewSszErrorf(sszutils.ErrInvalidConstraint, "%s ssz type does not fit in array (%d < %d)", typeName, dstLen, desc.Len)
+		}
+		if dstLen > desc.Len {
+			return sszutils.NewSszErrorf(sszutils.ErrInvalidConstraint, "%s ssz type does not fill the array (%d > %d): trailing elements would be dropped", typeName, dstLen, desc.Len)
 		}
 	}
 
@@ -1714,6 +1724,17 @@ func (tc *TypeCache) buildVectorDescriptor(desc *TypeDescriptor, runtimeType, sc
 
 	switch {
 	case desc.Kind == reflect.Array:
+		// With a view descriptor the schema (view) type defines the SSZ layout while
+		// the runtime type provides the backing storage. A schema array must not
+		// declare MORE elements than the backing array holds: there is no storage for
+		// the extra elements, so the reflection path would marshal/hash nonexistent
+		// zero-padding and the codegen path would emit an out-of-bounds slice that
+		// fails to compile. A SMALLER schema stays allowed — the Go array is sized for
+		// the largest preset and a view may use only a prefix of it. (When no view is
+		// used, runtimeType == schemaType, so this is a no-op.)
+		if runtimeType.Kind() == reflect.Array && runtimeType.Len() < t.Len() {
+			return sszutils.NewSszErrorf(sszutils.ErrInvalidConstraint, "view schema array length (%d) exceeds the backing array length (%d)", t.Len(), runtimeType.Len())
+		}
 		desc.Len = uint32(t.Len())
 		// A dynamic placeholder hint — e.g. dynssz-size:"?" on an outer dimension
 		// whose Go type is a fixed array — carries Size 0 (and no Bits) and must

--- a/ssztypes/typecache.go
+++ b/ssztypes/typecache.go
@@ -1715,7 +1715,14 @@ func (tc *TypeCache) buildVectorDescriptor(desc *TypeDescriptor, runtimeType, sc
 	switch {
 	case desc.Kind == reflect.Array:
 		desc.Len = uint32(t.Len())
-		if len(sizeHints) > 0 {
+		// A dynamic placeholder hint — e.g. dynssz-size:"?" on an outer dimension
+		// whose Go type is a fixed array — carries Size 0 (and no Bits) and must
+		// not zero the array's intrinsic length: a Go array cannot be relaxed to
+		// a variable-length list, so it keeps its intrinsic length (matching the
+		// codegen path). A concrete hint (Size > 0) or an explicit bit-size hint
+		// (Bits set, incl. ssz-bitsize:"0", which must still be rejected as a
+		// zero-length bitvector) is applied.
+		if len(sizeHints) > 0 && (sizeHints[0].Size > 0 || sizeHints[0].Bits) {
 			byteLen := sizeHints[0].Size
 			if sizeHints[0].Bits {
 				desc.BitSize = sizeHints[0].Size

--- a/ssztypes/typecache.go
+++ b/ssztypes/typecache.go
@@ -1649,15 +1649,17 @@ func (tc *TypeCache) buildOptionalListDescriptor(desc *TypeDescriptor, runtimeTy
 		return sszutils.NewSszErrorf(sszutils.ErrTypeMismatch, "optional-list ssz type can only be represented by pointer types, got %v", desc.Kind)
 	}
 
-	childSizeHints := []SszSizeHint{}
-	if len(sizeHints) > 1 {
-		childSizeHints = sizeHints[1:]
-	}
+	// The optional-list frames the Go pointer as List[T, 1]. That framing consumes
+	// the leading ssz-type dimension (the "optional-list" hint itself), but it has
+	// no size or max of its own — the list limit is fixed at 1 — so it consumes no
+	// ssz-size / ssz-max dimension. The remaining size/max hints belong to the
+	// pointed-to element T and must be forwarded in full, exactly as a plain
+	// pointer forwards them (e.g. `*[]uint16 ssz-size:"2"` -> Vector[uint16,2]).
+	// Peeling them here dropped the element's constraint and mis-classified a
+	// fixed inner vector as a variable list.
+	childSizeHints := sizeHints
 
-	childMaxSizeHints := []SszMaxSizeHint{}
-	if len(maxSizeHints) > 1 {
-		childMaxSizeHints = maxSizeHints[1:]
-	}
+	childMaxSizeHints := maxSizeHints
 
 	childTypeHints := []SszTypeHint{}
 	if len(typeHints) > 1 {

--- a/ssztypes/typecache_test.go
+++ b/ssztypes/typecache_test.go
@@ -910,6 +910,30 @@ func TestTypeCache_ZeroLengthVectorRejected(t *testing.T) {
 	}
 }
 
+// A fixed Go array whose outer dynssz-size dimension is the "?" placeholder must
+// keep its intrinsic length. The placeholder yields a dynamic size hint with
+// Size 0; a Go array cannot be relaxed to a variable-length list, so the array
+// length must survive (regression for the multi-dim empty-outer-dim bug where
+// the zero-size placeholder wrongly zeroed the array length).
+func TestTypeCache_ArrayOuterDynSizeQuestionKeepsLength(t *testing.T) {
+	cache := NewTypeCache(&dummyDynamicSpecs{specValues: map[string]uint64{"MAX_ATTESTATIONS": 5}})
+
+	type multiDim struct {
+		F [2][]byte `ssz-size:"2,6" dynssz-size:"?,MAX_ATTESTATIONS"`
+	}
+	desc, err := cache.GetTypeDescriptor(reflect.TypeOf(multiDim{}), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	f := desc.ContainerDesc.Fields[0].Type
+	if f.Len != 2 {
+		t.Fatalf("outer array length: expected 2, got %d", f.Len)
+	}
+	if f.ElemDesc == nil || f.ElemDesc.Len != 5 {
+		t.Fatalf("inner vector length: expected 5, got %+v", f.ElemDesc)
+	}
+}
+
 // Per the SSZ spec, containers must have at least one field.
 func TestTypeCache_ZeroFieldContainerRejected(t *testing.T) {
 	cache := NewTypeCache(&dummyDynamicSpecs{})

--- a/ssztypes/typecache_test.go
+++ b/ssztypes/typecache_test.go
@@ -251,6 +251,12 @@ func TestTypeCache_ErrorCases(t *testing.T) {
 				hints:    []SszTypeHint{{Type: SszUint128Type}},
 				expected: "uint128 ssz type does not fit in array",
 			},
+			{
+				name:     "uint128 array too large",
+				typ:      reflect.TypeOf([32]uint8{}),
+				hints:    []SszTypeHint{{Type: SszUint128Type}},
+				expected: "uint128 ssz type does not fill the array",
+			},
 		}
 
 		for _, tt := range tests {
@@ -291,6 +297,18 @@ func TestTypeCache_ErrorCases(t *testing.T) {
 				typ:      reflect.TypeOf([4]uint8{}),
 				hints:    []SszTypeHint{{Type: SszUint256Type}},
 				expected: "uint256 ssz type does not fit in array",
+			},
+			{
+				name:     "uint256 byte array too large",
+				typ:      reflect.TypeOf([64]uint8{}),
+				hints:    []SszTypeHint{{Type: SszUint256Type}},
+				expected: "uint256 ssz type does not fill the array",
+			},
+			{
+				name:     "uint256 uint64 array too large",
+				typ:      reflect.TypeOf([5]uint64{}),
+				hints:    []SszTypeHint{{Type: SszUint256Type}},
+				expected: "uint256 ssz type does not fill the array",
 			},
 		}
 
@@ -1202,6 +1220,33 @@ func TestTypeCache_DelegatedShallowBuild(t *testing.T) {
 		)
 		if err == nil || !strings.Contains(err.Error(), "does not provide a usable view sizer") {
 			t.Fatalf("expected unusable view sizer error, got: %v", err)
+		}
+	})
+
+	t.Run("ViewArrayLargerThanBacking", func(t *testing.T) {
+		// A view/schema fixed-array field must not declare more elements than the
+		// runtime backing array holds: there is no storage for the extra elements,
+		// so it is rejected. A smaller schema stays valid (the Go array is sized for
+		// the largest preset and a view may use only a prefix of it).
+		type viewArrBacking struct{ H [32]byte }
+		type viewArrLarger struct{ H [48]byte }
+		type viewArrSmaller struct{ H [20]byte }
+
+		_, err := cache.GetTypeDescriptorWithSchema(
+			reflect.TypeOf(viewArrBacking{}),
+			reflect.TypeOf(viewArrLarger{}),
+			nil, nil, nil,
+		)
+		if err == nil || !strings.Contains(err.Error(), "exceeds the backing array length") {
+			t.Fatalf("expected view schema array-length error, got: %v", err)
+		}
+
+		if _, err := cache.GetTypeDescriptorWithSchema(
+			reflect.TypeOf(viewArrBacking{}),
+			reflect.TypeOf(viewArrSmaller{}),
+			nil, nil, nil,
+		); err != nil {
+			t.Fatalf("a smaller view array should be allowed, got: %v", err)
 		}
 	})
 }

--- a/ssztypes/typecache_test.go
+++ b/ssztypes/typecache_test.go
@@ -1735,11 +1735,15 @@ func TestTypeCache_ExtendedTypes(t *testing.T) {
 	t.Run("OptionalListDescriptorWithChildHints", func(t *testing.T) {
 		cache := NewTypeCache(ds)
 
-		// Child size and max hints get forwarded to the element descriptor.
+		// Child size and max hints get forwarded to the element descriptor. The
+		// optional-list framing consumes only the leading ssz-type dimension (its
+		// own "optional-list" hint); the size/max hints all describe the element T
+		// and are forwarded in full, so the element list's ssz-max:"32" lands on
+		// the inner []byte and gives it Limit 32.
 		desc, err := cache.GetTypeDescriptor(
 			reflect.TypeOf((*[]byte)(nil)),
-			[]SszSizeHint{{}, {Size: 0, Dynamic: true}},
-			[]SszMaxSizeHint{{}, {Size: 32}},
+			nil,
+			[]SszMaxSizeHint{{Size: 32}},
 			[]SszTypeHint{{Type: SszOptionalListType}, {Type: SszListType}},
 		)
 		if err != nil {

--- a/sszutils/decoder_stream.go
+++ b/sszutils/decoder_stream.go
@@ -757,6 +757,15 @@ func (e *StreamDecoder) DecodeUint8() (uint8, error) {
 }
 
 func (e *StreamDecoder) DecodeUint16() (uint16, error) {
+	// Fast path: the 2 bytes are within the region limit and already buffered,
+	// so read them inline without the readBytesRef/ensureBuffered calls. This is
+	// exactly readBytesRef's buffered case; anything else defers to it.
+	if e.position+2 <= e.lastLimit && e.bufferLen-e.bufferPos >= 2 {
+		v := binary.LittleEndian.Uint16(e.buffer[e.bufferPos : e.bufferPos+2])
+		e.bufferPos += 2
+		e.position += 2
+		return v, nil
+	}
 	buf, err := e.readBytesRef(2)
 	if err != nil {
 		return 0, err
@@ -765,6 +774,15 @@ func (e *StreamDecoder) DecodeUint16() (uint16, error) {
 }
 
 func (e *StreamDecoder) DecodeUint32() (uint32, error) {
+	// Fast path: the 4 bytes are within the region limit and already buffered,
+	// so read them inline without the readBytesRef/ensureBuffered calls. This is
+	// exactly readBytesRef's buffered case; anything else defers to it.
+	if e.position+4 <= e.lastLimit && e.bufferLen-e.bufferPos >= 4 {
+		v := binary.LittleEndian.Uint32(e.buffer[e.bufferPos : e.bufferPos+4])
+		e.bufferPos += 4
+		e.position += 4
+		return v, nil
+	}
 	buf, err := e.readBytesRef(4)
 	if err != nil {
 		return 0, err
@@ -773,6 +791,15 @@ func (e *StreamDecoder) DecodeUint32() (uint32, error) {
 }
 
 func (e *StreamDecoder) DecodeUint64() (uint64, error) {
+	// Fast path: the 8 bytes are within the region limit and already buffered,
+	// so read them inline without the readBytesRef/ensureBuffered calls. This is
+	// exactly readBytesRef's buffered case; anything else defers to it.
+	if e.position+8 <= e.lastLimit && e.bufferLen-e.bufferPos >= 8 {
+		v := binary.LittleEndian.Uint64(e.buffer[e.bufferPos : e.bufferPos+8])
+		e.bufferPos += 8
+		e.position += 8
+		return v, nil
+	}
 	buf, err := e.readBytesRef(8)
 	if err != nil {
 		return 0, err
@@ -781,6 +808,16 @@ func (e *StreamDecoder) DecodeUint64() (uint64, error) {
 }
 
 func (e *StreamDecoder) DecodeBytes(buf []byte) ([]byte, error) {
+	// Fast path: within the region limit and already buffered - copy inline
+	// instead of calling readBytes (which the inliner cannot take). This mirrors
+	// readBytes' buffered case exactly; anything else defers to it.
+	n := len(buf)
+	if e.position+n <= e.lastLimit && e.bufferLen-e.bufferPos >= n {
+		copy(buf, e.buffer[e.bufferPos:e.bufferPos+n])
+		e.bufferPos += n
+		e.position += n
+		return buf, nil
+	}
 	if err := e.readBytes(buf); err != nil {
 		return nil, err
 	}

--- a/sszutils/encoder_buffer.go
+++ b/sszutils/encoder_buffer.go
@@ -86,7 +86,7 @@ func (e *BufferEncoder) EncodeUint8(v uint8) {
 // advances by 2 bytes.
 func (e *BufferEncoder) EncodeUint16(v uint16) {
 	e.ensure(2)
-	binary.LittleEndian.PutUint16(e.buffer[e.pos:], v)
+	binary.LittleEndian.PutUint16(e.buffer[e.pos:e.pos+2], v)
 	e.pos += 2
 }
 
@@ -94,7 +94,7 @@ func (e *BufferEncoder) EncodeUint16(v uint16) {
 // advances by 4 bytes.
 func (e *BufferEncoder) EncodeUint32(v uint32) {
 	e.ensure(4)
-	binary.LittleEndian.PutUint32(e.buffer[e.pos:], v)
+	binary.LittleEndian.PutUint32(e.buffer[e.pos:e.pos+4], v)
 	e.pos += 4
 }
 
@@ -102,7 +102,7 @@ func (e *BufferEncoder) EncodeUint32(v uint32) {
 // advances by 8 bytes.
 func (e *BufferEncoder) EncodeUint64(v uint64) {
 	e.ensure(8)
-	binary.LittleEndian.PutUint64(e.buffer[e.pos:], v)
+	binary.LittleEndian.PutUint64(e.buffer[e.pos:e.pos+8], v)
 	e.pos += 8
 }
 
@@ -118,7 +118,7 @@ func (e *BufferEncoder) EncodeBytes(v []byte) {
 // and advances by 4 bytes.
 func (e *BufferEncoder) EncodeOffset(v uint32) {
 	e.ensure(4)
-	binary.LittleEndian.PutUint32(e.buffer[e.pos:], v)
+	binary.LittleEndian.PutUint32(e.buffer[e.pos:e.pos+4], v)
 	e.pos += 4
 }
 
@@ -129,7 +129,7 @@ func (e *BufferEncoder) EncodeOffsetAt(pos int, v uint32) {
 	if pos < 0 || pos+4 > len(e.buffer) {
 		return
 	}
-	binary.LittleEndian.PutUint32(e.buffer[pos:], v)
+	binary.LittleEndian.PutUint32(e.buffer[pos:pos+4], v)
 }
 
 // EncodeZeroPadding writes n zero bytes at the current position and advances

--- a/sszutils/encoder_stream.go
+++ b/sszutils/encoder_stream.go
@@ -116,7 +116,7 @@ func (e *StreamEncoder) EncodeUint16(v uint16) {
 	if e.bufPos+2 > len(e.writeBuf) {
 		e.flush()
 	}
-	binary.LittleEndian.PutUint16(e.writeBuf[e.bufPos:], v)
+	binary.LittleEndian.PutUint16(e.writeBuf[e.bufPos:e.bufPos+2], v)
 	e.bufPos += 2
 	e.position += 2
 }
@@ -125,7 +125,7 @@ func (e *StreamEncoder) EncodeUint32(v uint32) {
 	if e.bufPos+4 > len(e.writeBuf) {
 		e.flush()
 	}
-	binary.LittleEndian.PutUint32(e.writeBuf[e.bufPos:], v)
+	binary.LittleEndian.PutUint32(e.writeBuf[e.bufPos:e.bufPos+4], v)
 	e.bufPos += 4
 	e.position += 4
 }
@@ -134,7 +134,7 @@ func (e *StreamEncoder) EncodeUint64(v uint64) {
 	if e.bufPos+8 > len(e.writeBuf) {
 		e.flush()
 	}
-	binary.LittleEndian.PutUint64(e.writeBuf[e.bufPos:], v)
+	binary.LittleEndian.PutUint64(e.writeBuf[e.bufPos:e.bufPos+8], v)
 	e.bufPos += 8
 	e.position += 8
 }
@@ -177,7 +177,7 @@ func (e *StreamEncoder) EncodeOffset(v uint32) {
 	if e.bufPos+4 > len(e.writeBuf) {
 		e.flush()
 	}
-	binary.LittleEndian.PutUint32(e.writeBuf[e.bufPos:], v)
+	binary.LittleEndian.PutUint32(e.writeBuf[e.bufPos:e.bufPos+4], v)
 	e.bufPos += 4
 	e.position += 4
 }

--- a/sszutils/stream_test.go
+++ b/sszutils/stream_test.go
@@ -2570,3 +2570,107 @@ func TestRegion_MaxStreamSizeIsHardBound(t *testing.T) {
 		}
 	})
 }
+
+// --- region / allowance edge branches ---
+
+// TestStreamDecoder_UnknownMaxStreamSizeClamped covers the clamp of an oversized
+// maxStreamSize down to maxAllowance in NewUnknownStreamDecoder.
+func TestStreamDecoder_UnknownMaxStreamSizeClamped(t *testing.T) {
+	dec := NewUnknownStreamDecoder(bytes.NewReader(nil), 64, math.MaxInt)
+	if dec.maxSize != maxAllowance {
+		t.Fatalf("maxSize = %d, want clamp to maxAllowance %d", dec.maxSize, maxAllowance)
+	}
+}
+
+// TestStreamDecoder_AvailableClampedToRegion covers Available() returning the
+// remaining region length when fewer region bytes remain than are buffered.
+func TestStreamDecoder_AvailableClampedToRegion(t *testing.T) {
+	dec := NewStreamDecoder(bytes.NewReader([]byte{1, 2, 3, 4, 5, 6, 7, 8}), 8, 64)
+	if err := dec.ensureBuffered(8); err != nil {
+		t.Fatalf("ensureBuffered: %v", err)
+	}
+	dec.PushLimit(2) // region shorter than the 8 buffered bytes
+	if got := dec.Available(); got != 2 {
+		t.Fatalf("Available() = %d, want 2 (clamped to region limit)", got)
+	}
+}
+
+// TestStreamDecoder_AvailableNegativeReturnsZero covers the avail < 0 guard in
+// Available() when the position has run past the region limit.
+func TestStreamDecoder_AvailableNegativeReturnsZero(t *testing.T) {
+	dec := NewStreamDecoder(bytes.NewReader([]byte{1, 2}), 2, 64)
+	dec.lastLimit = 0
+	dec.position = 5 // room = lastLimit - position = -5
+	if got := dec.Available(); got != 0 {
+		t.Fatalf("Available() = %d, want 0 for a negative remaining region", got)
+	}
+}
+
+// TestStreamDecoder_ReadMoreBeyondAllowance covers the pre-loop allowance guard
+// in readMore for an unknown-length stream (remaining <= 0).
+func TestStreamDecoder_ReadMoreBeyondAllowance(t *testing.T) {
+	dec := NewUnknownStreamDecoder(bytes.NewReader([]byte{1, 2, 3, 4}), 64, 4)
+	dec.position = dec.maxSize + 1 // whole allowance already consumed
+	if err := dec.readMore(); !errors.Is(err, ErrStreamTooLarge) {
+		t.Fatalf("readMore() = %v, want ErrStreamTooLarge", err)
+	}
+}
+
+// TestStreamDecoder_DecodeRemainingOpenMoreAtAllowance covers the DecodeRemaining
+// branch where an open region reaches its allowance with bytes still buffered:
+// More() reports more and the payload is rejected as too large.
+func TestStreamDecoder_DecodeRemainingOpenMoreAtAllowance(t *testing.T) {
+	dec := NewUnknownStreamDecoder(bytes.NewReader(nil), 64, 100)
+	dec.PushOpenLimit()
+	// Open region, region limit already reached (room == 0), but bytes still
+	// buffered so More() returns (true, nil) without touching the reader.
+	dec.lastOpen = true
+	dec.lastLimit = 0
+	dec.position = 0
+	dec.buffer = []byte{9, 9}
+	dec.bufferLen = 2
+	dec.bufferPos = 0
+	if _, err := dec.DecodeRemaining(-1); !errors.Is(err, ErrStreamTooLarge) {
+		t.Fatalf("DecodeRemaining() = %v, want ErrStreamTooLarge", err)
+	}
+}
+
+// TestStreamDecoder_DecodeRemainingOpenEOFWithData covers the open-region break
+// when EOF arrives together with the final data bytes: the buffered remainder is
+// returned and the loop stops on the sticky-EOF path.
+func TestStreamDecoder_DecodeRemainingOpenEOFWithData(t *testing.T) {
+	data := []byte{1, 2, 3, 4, 5}
+	dec := NewUnknownStreamDecoder(&partialThenEOFReader{data: data}, 64, 1024)
+	dec.PushOpenLimit()
+	got, err := dec.DecodeRemaining(-1)
+	if err != nil {
+		t.Fatalf("DecodeRemaining: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("DecodeRemaining = %x, want %x", got, data)
+	}
+}
+
+// TestStreamDecoder_DecodeRemainingOpenEOFSeenBreak covers the defensive
+// sticky-EOF break inside DecodeRemaining's open-region loop: it fires only when
+// EOF has been seen (eofSeen) while the region is still marked open with the
+// position short of the limit and nothing buffered. onEOF normally collapses an
+// open region to a bounded one, so this state is not reachable through the
+// public API; the state is constructed directly to exercise the guard.
+func TestStreamDecoder_DecodeRemainingOpenEOFSeenBreak(t *testing.T) {
+	dec := NewUnknownStreamDecoder(bytes.NewReader(nil), 64, 1024)
+	dec.PushOpenLimit()
+	dec.lastOpen = true // open region => loop-captured openRegion == true
+	dec.lastLimit = 10  // room = lastLimit - position = 10 > 0
+	dec.position = 0
+	dec.eofSeen = true // EOF already observed
+	dec.bufferLen = 0  // available == 0
+	dec.bufferPos = 0
+	got, err := dec.DecodeRemaining(-1)
+	if err != nil {
+		t.Fatalf("DecodeRemaining: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("DecodeRemaining = %x, want empty", got)
+	}
+}

--- a/sszutils/utils_test.go
+++ b/sszutils/utils_test.go
@@ -1024,3 +1024,44 @@ func TestIsStreamTooLarge(t *testing.T) {
 		t.Fatal("nil misrecognised")
 	}
 }
+
+// TestBufferDecoder_Available covers Available() on a buffer-backed decoder,
+// which reports the whole remaining region.
+func TestBufferDecoder_Available(t *testing.T) {
+	dec := NewBufferDecoder([]byte{1, 2, 3, 4, 5, 6, 7, 8})
+	if got := dec.Available(); got != 8 {
+		t.Fatalf("Available() = %d, want 8", got)
+	}
+	if _, err := dec.DecodeUint32(); err != nil {
+		t.Fatalf("DecodeUint32: %v", err)
+	}
+	if got := dec.Available(); got != 4 {
+		t.Fatalf("Available() after consuming 4 bytes = %d, want 4", got)
+	}
+}
+
+// TestCredibleCount_Guards covers the two early-return guards in CredibleCount:
+// a non-positive count, and a non-positive element size on an unknown-length
+// decoder (where the count cannot be bounded from delivered bytes).
+func TestCredibleCount_Guards(t *testing.T) {
+	// count <= 0 short-circuits to 0.
+	if got := CredibleCount(NewBufferDecoder(nil), 0, 4); got != 0 {
+		t.Fatalf("CredibleCount(_, 0, 4) = %d, want 0", got)
+	}
+	if got := CredibleCount(NewBufferDecoder(nil), -3, 4); got != 0 {
+		t.Fatalf("CredibleCount(_, -3, 4) = %d, want 0", got)
+	}
+	// A known-length decoder trusts the count unchanged.
+	if got := CredibleCount(NewBufferDecoder(make([]byte, 4)), 7, 4); got != 7 {
+		t.Fatalf("CredibleCount(buffer, 7, 4) = %d, want 7", got)
+	}
+	// An unknown-length decoder with a non-positive element size cannot bound the
+	// count from delivered bytes, so it is returned unchanged.
+	unk := NewUnknownStreamDecoder(bytes.NewReader(nil), 8, 0)
+	if unk.LengthKnown() {
+		t.Fatal("precondition: fresh unknown decoder must report LengthKnown()==false")
+	}
+	if got := CredibleCount(unk, 5, 0); got != 5 {
+		t.Fatalf("CredibleCount(unknown, 5, 0) = %d, want 5", got)
+	}
+}


### PR DESCRIPTION
## Fuzzing + spec-audit fixes

A whole-codebase fuzzing + SSZ-spec-audit campaign (differential reflection-vs-codegen, buffer-vs-stream,
generative random-type fuzzing across all flag combos, ~1M+ mutants, full `ssz_generic` conformance,
independent remerkleable/spec oracles, and line-by-line audits vs `ssz/simple-serialize.md` +
`ssz/merkle-proofs.md`). Serialization, merkleization and proof logic were confirmed spec-correct; the
commits below are the concrete defects found — each with a regression test that fails before the fix.

### Fixes

1. **codegen: keep `-without-dynamic-expressions` output free of `*Dyn` buffer calls** — *correctness of the flag's contract*
   Under `-without-fastssz -without-dynamic-expressions`, any parent nesting a generated child container
   forced its static `MarshalSSZTo`/`SizeSSZ`/`UnmarshalSSZ`/`HashTreeRootWith` to forward to the
   `*Dyn` variant (`MarshalSSZDyn(GetGlobalDynSsz())`), because the static path only recognized a
   fastssz-style static method (gated off by `-without-fastssz`) or a dynamic method. The static generators
   now reach a generated child through its own **static** methods (inlining a referenced dyn-only type by
   walking its structure; clean-erroring only when a type is genuinely un-inlinable). The streaming
   `Encoder`/`Decoder` remain the only `ds`-taking methods. Enforcement test asserts **zero `*Dyn` tokens**
   in `-without-dynamic-expressions` output across `-without-fastssz`×`-with-streaming`.

2. **codegen,ssztypes: fix `optional-list` over a pointer-to-slice-vector** — *two bugs: wrong encoding + wrong root* —
   `buildOptionalListDescriptor` dropped the element's `ssz-size` (peeled `sizeHints[1:]`) so the inner
   vector degraded to a variable list → wrong bytes+size on **both** engines; and `hashOptionalList` reused
   a shadowed `vlen` so a present element mixed in length **0** → wrong codegen root. Verified vs remerkleable.

3. **codegen: resolve union fixed-variant size at runtime in the buffer decoder** — *correctness, cross-preset* —
   the generated buffer union decoder baked the static `ssz-size` region size instead of the runtime-resolved
   `dynssz-size`, so off the default preset it rejected valid encodings (reflection≠codegen).

4. **ssztypes: keep array length when an outer `dynssz-size` dimension is `'?'`** — *reflection≠codegen* —
   `buildVectorDescriptor`'s array branch applied a `'?'` size-hint (`{Dynamic,Size:0}`) unconditionally,
   zeroing the array's intrinsic length ("vector … has zero length"); now applied only when concrete.

5. **codegen: reject a view type identical to its data type** — *build breakage* — `views=Outer` on `Outer`
   emitted a duplicate `case *Outer` in the view dispatch switch while reporting success.

6. **codegen: fix two non-compiling outputs** — *build breakage* — streaming fixed-vector offset compared
   `uint32` vs `int`; expression-sized union variant left the asserted `v` unused.

### Notes
- Commits are anonymous by request. `codegen/tests` fixtures are `go generate`d (gitignored, produced
  fresh); `go build ./...` and `go test ./...` are green (10 packages). Rebased onto current `master`.
- Two findings are **not** in this PR: the unknown-size stream over-read (fixed upstream by
  `cb750cd`/`ddc21e2`; verified their fix covers it), and a *test-only* issue — the CI fuzz filler
  (`tests/fuzz/engine/filler.go`) sets **0-based** CompatibleUnion selectors while EIP-8016 selectors are
  **1-based**, silently under-testing unions in the CI fuzzer (worth a one-line fix).
