### PR TITLE
Harden unknown-size stream errors and allocations

### DIFF
--- a/codegen/gen_decoder.go
+++ b/codegen/gen_decoder.go
@@ -910,6 +910,10 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 	default:
 		maxVar = "0"
 	}
+	growthLimit := "-1"
+	if hasMax {
+		growthLimit = maxVar
+	}
 
 	valueVar := varName
 	if desc.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 {
@@ -1019,7 +1023,7 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 		}
 		ctx.appendCode(indent+1, "%s = sszutils.SizeListSlice(dec, %s, itemCount, %s)\n", valueVar, valueVar, fieldSizeVar)
 		ctx.appendCode(indent, "} else {\n")
-		ctx.appendCode(indent+1, "%s = sszutils.GrowSlice(%s, 0)\n", valueVar, valueVar)
+		ctx.appendCode(indent+1, "%s = sszutils.GrowSlice(%s, 0, %s)\n", valueVar, valueVar, growthLimit)
 		ctx.appendCode(indent, "}\n")
 
 		startPosVar := fmt.Sprintf("startPos%d", ctx.startPosVarCounter)
@@ -1042,13 +1046,13 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 			errCode := fmt.Sprintf("sszutils.ErrListLengthFn(%s+1, %s)", indexVar, maxVar)
 			ctx.appendCode(indent+2, "if %s >= %s {\n\treturn %s\n}\n", indexVar, maxVar, typePath.getErrorWith(errCode))
 		}
-		ctx.appendCode(indent+2, "%s = sszutils.GrowSlice(%s, %s+1)\n", valueVar, valueVar, indexVar)
+		ctx.appendCode(indent+2, "%s = sszutils.GrowSlice(%s, %s+1, %s)\n", valueVar, valueVar, indexVar, growthLimit)
 		ctx.appendCode(indent+1, "}\n")
 		// The count was declared rather than witnessed, so the slice was seeded
 		// from delivered bytes; extend it as the rest arrives. When the extent
 		// was known this is already full length and never taken.
 		ctx.appendCode(indent+1, "if %s >= len(%s) {\n", indexVar, indexValueVar)
-		ctx.appendCode(indent+2, "%s = sszutils.GrowSlice(%s, %s+1)\n", valueVar, valueVar, indexVar)
+		ctx.appendCode(indent+2, "%s = sszutils.GrowSlice(%s, %s+1, %s)\n", valueVar, valueVar, indexVar, growthLimit)
 		ctx.appendCode(indent+1, "}\n")
 
 		valVar := fmt.Sprintf("%s[%s]", indexValueVar, indexVar)
@@ -1083,6 +1087,7 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 		startPosVar := fmt.Sprintf("startPos%d", ctx.startPosVarCounter)
 		ctx.startPosVarCounter++
 		ctx.appendCode(indent, "%s := dec.GetPosition()\n", startPosVar)
+		ctx.appendCode(indent, "lengthKnown := dec.LengthKnown()\n")
 		// An empty region means "empty list", so emptiness is a semantic
 		// discriminator and has to be answered by probing the reader when the
 		// region's extent is not yet known. The probe may discover EOF, which
@@ -1128,7 +1133,7 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 		ctx.appendCode(indent+3, "if err != nil {\n")
 		ctx.appendCode(indent+4, "return %s\n", typePath.append("[%d:o]", indexVar).getErrorWith("err"))
 		ctx.appendCode(indent+3, "}\n")
-		ctx.appendCode(indent+3, "offsets = sszutils.GrowSlice(offsets, %s+1)\n", indexVar)
+		ctx.appendCode(indent+3, "offsets = sszutils.GrowSlice(offsets, %s+1, itemCount-1)\n", indexVar)
 		ctx.appendCode(indent+3, "offsets[%s] = offset\n", indexVar)
 		ctx.appendCode(indent+2, "}\n")
 		ctx.appendCode(indent+2, "offsetSlices[%d] = offsets\n", ctx.offsetSliceCounter)
@@ -1140,7 +1145,11 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 			ctx.offsetSliceLimit = ctx.offsetSliceCounter
 		}
 
-		ctx.appendCode(indent, "%s = sszutils.ExpandSlice(%s, itemCount)\n", valueVar, valueVar)
+		ctx.appendCode(indent, "if lengthKnown {\n")
+		ctx.appendCode(indent+1, "%s = sszutils.ExpandSlice(%s, itemCount)\n", valueVar, valueVar)
+		ctx.appendCode(indent, "} else {\n")
+		ctx.appendCode(indent+1, "%s = sszutils.PreallocateDecodeSlice(%s, itemCount)\n", valueVar, valueVar)
+		ctx.appendCode(indent, "}\n")
 
 		fieldPath := typePath.append("[%d]", indexVar)
 		// Bind the last index to a uniquely named variable before the loop. A
@@ -1165,6 +1174,13 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 		ctx.appendCode(indent+1, "if endOffset < startOffset || endOffset > uint32(sszLen) {\n")
 		errCode = "sszutils.ErrElementOffsetOutOfRangeFn(endOffset, startOffset, sszLen)"
 		ctx.appendCode(indent+2, "return %s\n", fieldPath.getErrorWith(errCode))
+		ctx.appendCode(indent+1, "}\n")
+		ctx.appendCode(indent+1, "if %s >= len(%s) {\n", indexVar, indexValueVar)
+		ctx.appendCode(indent+2, "chunkLen := cap(%s)\n", indexValueVar)
+		ctx.appendCode(indent+2, "if chunkLen == len(%s) {\n", indexValueVar)
+		ctx.appendCode(indent+3, "chunkLen = max(%s+1, 8, len(%s)*2)\n", indexVar, indexValueVar)
+		ctx.appendCode(indent+2, "}\n")
+		ctx.appendCode(indent+2, "%s = sszutils.GrowSlice(%s, min(itemCount, chunkLen), itemCount)\n", valueVar, valueVar)
 		ctx.appendCode(indent+1, "}\n")
 
 		// The trailing element runs to the end of the list, so it takes an open

--- a/codegen/tests/codegen_test.go
+++ b/codegen/tests/codegen_test.go
@@ -1776,6 +1776,74 @@ func TestCodegenDecoderEmptyDynListSeekable(t *testing.T) {
 	}
 }
 
+// An unknown-size dynamic-list offset table proves its item count before it
+// proves that any item body exists. A generated stream decoder must not turn a
+// small, body-less table into the full backing array for a very wide Go value.
+func TestCodegenUnknownSizeDynamicListWideValueAllocationIsIncremental(t *testing.T) {
+	if _, generated := any(&WideDynamicList{}).(sszutils.DynamicDecoder); !generated {
+		t.Skip("no generated code present")
+	}
+
+	const itemCount = 512
+	offsetTable := make([]byte, itemCount*4)
+	for pos := 0; pos < len(offsetTable); pos += 4 {
+		binary.LittleEndian.PutUint32(offsetTable[pos:pos+4], uint32(len(offsetTable)))
+	}
+	payload := make([]byte, 4+len(offsetTable))
+	binary.LittleEndian.PutUint32(payload[:4], 4)
+	copy(payload[4:], offsetTable)
+
+	ds := dynssz.NewDynSsz(
+		nil,
+		dynssz.WithStreamReaderBufferSize(8),
+		dynssz.WithMaxStreamSize(128<<20),
+	)
+	if _, err := ds.SizeSSZ(&WideDynamicList{}); err != nil {
+		t.Fatalf("warm generated methods: %v", err)
+	}
+
+	valid := WideDynamicList{Items: make([]WideDynamicElement, 2)}
+	valid.Items[0].Fixed[0] = 1
+	valid.Items[0].Tail = []byte{2}
+	valid.Items[1].Fixed[0] = 3
+	validPayload, err := ds.MarshalSSZ(&valid)
+	if err != nil {
+		t.Fatalf("marshal valid list: %v", err)
+	}
+	var roundTrip WideDynamicList
+	if err := ds.UnmarshalSSZReader(&roundTrip, bytes.NewReader(validPayload), -1); err != nil {
+		t.Fatalf("incrementally decode valid list: %v", err)
+	}
+	if len(roundTrip.Items) != 2 ||
+		cap(roundTrip.Items) != 2 ||
+		roundTrip.Items[0].Fixed[0] != 1 ||
+		!bytes.Equal(roundTrip.Items[0].Tail, []byte{2}) ||
+		roundTrip.Items[1].Fixed[0] != 3 {
+		t.Fatal("incrementally grown list did not round-trip")
+	}
+
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	var out WideDynamicList
+	if err := ds.UnmarshalSSZReader(&out, bytes.NewReader(payload), -1); err == nil {
+		t.Fatal("offset table without element bodies decoded successfully")
+	}
+
+	runtime.ReadMemStats(&after)
+	allocated := after.TotalAlloc - before.TotalAlloc
+	const allocationLimit = 4 << 20
+	if allocated > allocationLimit {
+		t.Fatalf(
+			"%d bytes of malformed input allocated %d bytes, want at most %d",
+			len(payload),
+			allocated,
+			allocationLimit,
+		)
+	}
+}
+
 // The generated decoders enforce the big.Int ssz-max and canonicality rules on
 // both the buffer and stream paths, matching the reflection engine.
 func TestCodegenBigIntDecodeValidation(t *testing.T) {

--- a/codegen/tests/gen_ssz.yaml
+++ b/codegen/tests/gen_ssz.yaml
@@ -177,6 +177,10 @@ types:
     output: gen_compilecorrectness.go
   - name: WrapPtrList
     output: gen_compilecorrectness.go
+  - name: WideDynamicElement
+    output: gen_compilecorrectness.go
+  - name: WideDynamicList
+    output: gen_compilecorrectness.go
 
   # Recursive shapes: generated in one file so the recursive references are
   # emitted as method calls between the members.

--- a/codegen/tests/types.go
+++ b/codegen/tests/types.go
@@ -1823,6 +1823,19 @@ type WrapPtrList struct {
 	}, *[]uint16] `ssz-type:"wrapper"`
 }
 
+// WideDynamicElement makes eager allocation from an offset-table count visible:
+// its SSZ body is dynamic, while every Go value contains substantial inline
+// storage. WideDynamicList is used to pin byte-bounded preallocation in the
+// generated streaming decoder.
+type WideDynamicElement struct {
+	Fixed [64 << 10]byte
+	Tail  []byte `ssz-max:"1"`
+}
+
+type WideDynamicList struct {
+	Items []WideDynamicElement `ssz-max:"512"`
+}
+
 // RecursiveNode is a self-referential container: recursion through a bounded
 // list is a legal, finite SSZ shape. The generated code must call the type's
 // own methods for the recursive reference so emission and encoding terminate.

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -199,7 +199,7 @@ to your typical payload is therefore worth doing:
 ds := dynssz.NewDynSsz(specs, dynssz.WithStreamReaderBufferSize(64*1024))
 ```
 
-### Memory bound
+### Wire-size bound
 
 Unknown-size decoding is **always bounded** and the bound cannot be disabled:
 
@@ -207,12 +207,60 @@ Unknown-size decoding is **always bounded** and the bound cannot be disabled:
 ds := dynssz.NewDynSsz(specs, dynssz.WithMaxStreamSize(16*1024*1024))
 ```
 
-The default is 512 MiB. The bound is what stops a peer that never closes the
-connection from exhausting memory, and it doubles as the remaining-length
-estimate reported to code that predates unknown-size decoding (see
-[Regenerating](#regenerating-generated-code)). `ssz-max` limits are enforced
-incrementally while reading, so an over-long list is rejected before it is
-allocated.
+The default is 512 MiB. This bounds bytes consumed from the wire and doubles as
+the remaining-length estimate reported to code that predates unknown-size
+decoding (see [Regenerating](#regenerating-generated-code)). `ssz-max` limits
+are enforced while reading. Set the smallest value your application protocol
+and schema permit; the default is deliberately general and is usually too
+generous for peer-to-peer messages.
+
+`WithMaxStreamSize` is not:
+
+- a read deadline or cancellation mechanism;
+- a bound on the lifetime of a connection or goroutine;
+- a bound on decoded-object heap. A compact offset table can describe many Go
+  values, and value elements with large inline arrays can occupy much more
+  memory than their table does.
+
+Schema `ssz-max` values and application-level concurrency/memory budgets still
+matter.
+
+### EOF framing, deadlines, and cancellation
+
+In unknown-size mode, **EOF is the message boundary**. Use it only when EOF
+unambiguously ends one SSZ payload, such as a file, a closed pipe, an HTTP
+response body, or a connection dedicated to a single payload. Do not use it
+directly on a long-lived connection carrying multiple messages; use the
+protocol's trusted-and-capped length framing and pass that length instead.
+
+A peer can send fewer than `WithMaxStreamSize` bytes and then withhold EOF
+forever. Network callers must therefore set a deadline or arrange cancellation.
+`io.Reader` has no context-aware read method, so cancellation normally closes
+the response body, pipe, or connection:
+
+```go
+conn, err := net.Dial("tcp", address)
+if err != nil {
+    return err
+}
+defer conn.Close()
+
+if err := conn.SetReadDeadline(time.Now().Add(15 * time.Second)); err != nil {
+    return err
+}
+
+ds := dynssz.NewDynSsz(
+    specs,
+    dynssz.WithMaxStreamSize(4*1024*1024), // protocol-specific maximum
+)
+var message Message
+if err := ds.UnmarshalSSZReader(&message, conn, -1); err != nil {
+    return err
+}
+```
+
+For HTTP, configure the request context and transport/client timeouts. Canceling
+the request closes the response body and unblocks the decoder.
 
 ### What it costs and what it saves
 
@@ -235,7 +283,9 @@ it.
 
 The saving is largest when the trailing region is *not* one huge list of
 fixed-size elements. A list of **dynamic** elements takes its count from the
-first offset, so it is sized exactly and never grows.
+first offset, so it is sized exactly and never grows. That count can still
+materialize the result slice before element bodies are decoded; keep list limits
+realistic when elements contain large inline Go values.
 
 ### Less precise errors
 

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -283,9 +283,12 @@ it.
 
 The saving is largest when the trailing region is *not* one huge list of
 fixed-size elements. A list of **dynamic** elements takes its count from the
-first offset, so it is sized exactly and never grows. That count can still
-materialize the result slice before element bodies are decoded; keep list limits
-realistic when elements contain large inline Go values.
+first offset. In an unknown-size region, the decoder reserves at most 64 KiB of
+destination elements from that count, then grows the slice geometrically as it
+reaches further element bodies. Known-size streams and buffer decoding retain
+their exact allocation. Unusually wide Go value elements therefore no longer
+materialize the schema's entire maximum before the first body arrives. Keep
+list limits realistic: they remain the final result-size bound.
 
 ### Less precise errors
 

--- a/dynssz.go
+++ b/dynssz.go
@@ -715,8 +715,16 @@ func (d *DynSsz) UnmarshalSSZ(target any, ssz []byte, opts ...CallOption) error 
 // Unknown-size mode is possible because SSZ is self-delimiting for every region
 // except the trailing one, so the missing length only ever affects the last
 // dynamic child at each nesting level. It is always bounded by WithMaxStreamSize
-// (512 MiB by default) — the bound cannot be disabled, since it is what keeps a
-// peer that never closes the connection from exhausting memory.
+// (512 MiB by default). That is a wire-byte allowance, not a deadline,
+// cancellation mechanism, or decoded-object heap limit. Use the smallest
+// application-specific cap your schema permits.
+//
+// EOF is the message boundary in unknown-size mode. A raw connection is safe
+// only when it carries one SSZ payload and EOF unambiguously ends that payload.
+// Long-lived network readers need protocol framing instead; every network
+// reader also needs a deadline or cancellation mechanism, since a peer can stay
+// below the byte allowance while withholding EOF forever. io.Reader itself has
+// no context support, so cancellation usually closes the reader/connection.
 //
 // Two caveats apply to unknown-size mode:
 //   - Errors are less precise. Checks that a known length would catch up front —
@@ -759,8 +767,11 @@ func (d *DynSsz) UnmarshalSSZ(target any, ssz []byte, opts ...CallOption) error 
 //	    log.Fatal("Failed to read state:", err)
 //	}
 //
-//	// Read from network with unknown size (streams until EOF)
+//	// Read one EOF-framed payload from a connection. A deadline is required:
+//	// WithMaxStreamSize limits bytes, not how long the peer may withhold EOF.
 //	conn, _ := net.Dial("tcp", "localhost:8080")
+//	defer conn.Close()
+//	_ = conn.SetReadDeadline(time.Now().Add(15 * time.Second))
 //	var block phase0.BeaconBlock
 //	err = ds.UnmarshalSSZReader(&block, conn, -1)
 func (d *DynSsz) UnmarshalSSZReader(target any, r io.Reader, size int, opts ...CallOption) error {

--- a/dynssz_test.go
+++ b/dynssz_test.go
@@ -5217,6 +5217,61 @@ func TestUnknownSizeTrailingProbeReadErrors(t *testing.T) {
 	}
 }
 
+type terminalDataErrorReader struct {
+	data []byte
+	pos  int
+	err  error
+}
+
+func (r *terminalDataErrorReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.data[r.pos:])
+	r.pos += n
+	if r.pos == len(r.data) {
+		return n, r.err
+	}
+	return n, nil
+}
+
+// A reader may return data and an error together. io.EOF means those bytes are
+// the clean end of input, but every other error is part of the reader's result:
+// accepting the SSZ value would discard an integrity or decompression verdict.
+func TestUnmarshalSSZReaderPreservesTerminalDataErrors(t *testing.T) {
+	type fixed struct {
+		Data [16]byte
+	}
+
+	payload := make([]byte, 16)
+	for i := range payload {
+		payload[i] = byte(i + 1)
+	}
+
+	for name, want := range map[string]error{
+		"integrity":      errors.New("checksum failed"),
+		"unexpected EOF": io.ErrUnexpectedEOF,
+	} {
+		t.Run(name, func(t *testing.T) {
+			for _, size := range []int{len(payload), -1} {
+				mode := "known"
+				if size < 0 {
+					mode = "unknown"
+				}
+				t.Run(mode, func(t *testing.T) {
+					reader := &terminalDataErrorReader{data: payload, err: want}
+					ds := NewDynSsz(nil, WithNoFastSsz(), WithStreamReaderBufferSize(8))
+					var out fixed
+					err := ds.UnmarshalSSZReader(&out, reader, size)
+					if !errors.Is(err, want) {
+						t.Fatalf("UnmarshalSSZReader error = %v, want %v", err, want)
+					}
+				})
+			}
+		})
+	}
+}
+
 // A peer that declares a huge field in a tiny payload must not be able to make
 // the decoder allocate from that declaration.
 //
@@ -5369,6 +5424,58 @@ func TestUnknownSizeDoesNotAllocateFromDeclaredElementCount(t *testing.T) {
 	if peak > base.HeapAlloc+limit {
 		t.Fatalf("a declared element count drove a %d byte peak heap from a %d byte payload",
 			peak-base.HeapAlloc, len(payload))
+	}
+}
+
+// A dynamic-list offset table proves only the number of offsets delivered; it
+// does not prove that any element body exists. Wide value elements make that
+// distinction important because allocating the destination slice materialises
+// every element's fixed Go storage before the first body is decoded.
+//
+// The decoder currently allocates that destination eagerly, but the allocation
+// must remain bounded by the schema's maximum result size rather than by an
+// unchecked count from the wire. This accounts for the worst supported shape
+// without using a fragile instantaneous HeapAlloc sample.
+func TestUnknownSizeWideDynamicValueAllocationIsSchemaBounded(t *testing.T) {
+	type wideDynamicElement struct {
+		Fixed [64 << 10]byte
+		Tail  []byte `ssz-max:"1"`
+	}
+	type wideDynamicList struct {
+		Items []wideDynamicElement `ssz-max:"512"`
+	}
+
+	const itemCount = 512
+	offsetTable := make([]byte, itemCount*4)
+	for pos := 0; pos < len(offsetTable); pos += 4 {
+		binary.LittleEndian.PutUint32(offsetTable[pos:pos+4], uint32(len(offsetTable)))
+	}
+	payload := make([]byte, 4+len(offsetTable))
+	binary.LittleEndian.PutUint32(payload[:4], 4)
+	copy(payload[4:], offsetTable)
+
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	ds := NewDynSsz(nil, WithNoFastSsz(), WithStreamReaderBufferSize(8), WithMaxStreamSize(128<<20))
+	var out wideDynamicList
+	err := ds.UnmarshalSSZReader(&out, bytes.NewReader(payload), -1)
+	if err == nil {
+		t.Fatal("offset table without element bodies decoded successfully")
+	}
+
+	runtime.ReadMemStats(&after)
+	allocated := after.TotalAlloc - before.TotalAlloc
+	schemaResultBytes := uint64(itemCount) * uint64(reflect.TypeFor[wideDynamicElement]().Size())
+	const accountingSlack = 16 << 20
+	if allocated > schemaResultBytes+accountingSlack {
+		t.Fatalf(
+			"%d bytes of malformed input allocated %d bytes; schema result bound plus slack is %d",
+			len(payload),
+			allocated,
+			schemaResultBytes+accountingSlack,
+		)
 	}
 }
 

--- a/dynssz_test.go
+++ b/dynssz_test.go
@@ -5427,16 +5427,12 @@ func TestUnknownSizeDoesNotAllocateFromDeclaredElementCount(t *testing.T) {
 	}
 }
 
-// A dynamic-list offset table proves only the number of offsets delivered; it
-// does not prove that any element body exists. Wide value elements make that
-// distinction important because allocating the destination slice materialises
-// every element's fixed Go storage before the first body is decoded.
-//
-// The decoder currently allocates that destination eagerly, but the allocation
-// must remain bounded by the schema's maximum result size rather than by an
-// unchecked count from the wire. This accounts for the worst supported shape
-// without using a fragile instantaneous HeapAlloc sample.
-func TestUnknownSizeWideDynamicValueAllocationIsSchemaBounded(t *testing.T) {
+// In an unknown-size region, a dynamic-list offset table proves the element
+// count but it does not prove that even the first element body exists. The
+// reflection stream decoder must reserve only a small prefix of a wide []T
+// before attempting that body, rather than materialising the schema's entire
+// maximum result.
+func TestUnknownSizeDynamicListWideValueAllocationIsIncremental(t *testing.T) {
 	type wideDynamicElement struct {
 		Fixed [64 << 10]byte
 		Tail  []byte `ssz-max:"1"`
@@ -5454,27 +5450,54 @@ func TestUnknownSizeWideDynamicValueAllocationIsSchemaBounded(t *testing.T) {
 	binary.LittleEndian.PutUint32(payload[:4], 4)
 	copy(payload[4:], offsetTable)
 
+	ds := NewDynSsz(
+		nil,
+		WithNoFastSsz(),
+		WithStreamReaderBufferSize(8),
+		WithMaxStreamSize(128<<20),
+	)
+	if _, err := ds.SizeSSZ(&wideDynamicList{}); err != nil {
+		t.Fatalf("warm type cache: %v", err)
+	}
+
+	valid := wideDynamicList{Items: make([]wideDynamicElement, 2)}
+	valid.Items[0].Fixed[0] = 1
+	valid.Items[0].Tail = []byte{2}
+	valid.Items[1].Fixed[0] = 3
+	validPayload, err := ds.MarshalSSZ(&valid)
+	if err != nil {
+		t.Fatalf("marshal valid list: %v", err)
+	}
+	var roundTrip wideDynamicList
+	if err := ds.UnmarshalSSZReader(&roundTrip, bytes.NewReader(validPayload), -1); err != nil {
+		t.Fatalf("incrementally decode valid list: %v", err)
+	}
+	if len(roundTrip.Items) != 2 ||
+		cap(roundTrip.Items) != 2 ||
+		roundTrip.Items[0].Fixed[0] != 1 ||
+		!bytes.Equal(roundTrip.Items[0].Tail, []byte{2}) ||
+		roundTrip.Items[1].Fixed[0] != 3 {
+		t.Fatal("incrementally grown list did not round-trip")
+	}
+
 	runtime.GC()
 	var before, after runtime.MemStats
 	runtime.ReadMemStats(&before)
 
-	ds := NewDynSsz(nil, WithNoFastSsz(), WithStreamReaderBufferSize(8), WithMaxStreamSize(128<<20))
 	var out wideDynamicList
-	err := ds.UnmarshalSSZReader(&out, bytes.NewReader(payload), -1)
-	if err == nil {
+	if err := ds.UnmarshalSSZReader(&out, bytes.NewReader(payload), -1); err == nil {
 		t.Fatal("offset table without element bodies decoded successfully")
 	}
 
 	runtime.ReadMemStats(&after)
 	allocated := after.TotalAlloc - before.TotalAlloc
-	schemaResultBytes := uint64(itemCount) * uint64(reflect.TypeFor[wideDynamicElement]().Size())
-	const accountingSlack = 16 << 20
-	if allocated > schemaResultBytes+accountingSlack {
+	const allocationLimit = 4 << 20
+	if allocated > allocationLimit {
 		t.Fatalf(
-			"%d bytes of malformed input allocated %d bytes; schema result bound plus slack is %d",
+			"%d bytes of malformed input allocated %d bytes, want at most %d",
 			len(payload),
 			allocated,
-			schemaResultBytes+accountingSlack,
+			allocationLimit,
 		)
 	}
 }

--- a/examples/streaming/README.md
+++ b/examples/streaming/README.md
@@ -38,7 +38,11 @@ go run .
 
 - **Untrusted input**: an unknown-size decode is always bounded by
   `WithMaxStreamSize` (512 MiB by default), and `ssz-max` limits are enforced
-  while reading. Lower the bound for untrusted peers.
+  while reading. Lower the bound to the smallest value your protocol permits.
+  This caps wire bytes, not decoded-object memory or read time.
+- **EOF and cancellation**: EOF is the message boundary in unknown-size mode.
+  Use request contexts/client timeouts for HTTP and read deadlines for raw
+  connections. Canceling must close or otherwise unblock the `io.Reader`.
 - **CPU trade-off**: streaming costs ~1.3x (encode) to ~2x (decode) CPU
   because stream encoders can't seek back to patch offsets. Use it for large
   payloads, not small messages.

--- a/examples/streaming/main.go
+++ b/examples/streaming/main.go
@@ -215,7 +215,9 @@ func run() error {
 //
 // Prefer passing the size when you have it: knowing where the payload ends
 // keeps the fail-fast validation and avoids growing the trailing collection.
-// An unknown-size decode is always bounded by WithMaxStreamSize.
+// An unknown-size decode is byte-bounded by WithMaxStreamSize, but the HTTP
+// caller must still configure a request context/client timeout: the bound does
+// not stop a server from withholding EOF while staying below it.
 func decodeSSZ(ds *dynssz.DynSsz, target any, data io.ReadCloser, size int64) error {
 	defer func() { _ = data.Close() }()
 

--- a/options.go
+++ b/options.go
@@ -109,10 +109,14 @@ func WithStreamReaderBufferSize(size int) DynSszOption {
 // sszutils.DefaultMaxStreamSize (512 MiB) if not set or set to a non-positive
 // value.
 //
-// Unknown-length decoding is always bounded, and deliberately so: the bound is
-// what keeps a peer that never closes the connection from exhausting memory,
-// and it doubles as the remaining-length estimate reported to decode paths that
-// have not been taught about regions of unknown extent. It cannot be disabled.
+// Unknown-length decoding is always byte-bounded, and deliberately so: the
+// allowance prevents an endless input from driving unbounded wire buffering and
+// doubles as the remaining-length estimate reported to decode paths that have
+// not been taught about regions of unknown extent. It cannot be disabled.
+//
+// This is not a deadline, cancellation mechanism, or decoded-object heap limit.
+// Network callers must impose their own lifetime bound, and should choose the
+// smallest maximum their protocol and schema permit.
 func WithMaxStreamSize(size int) DynSszOption {
 	return func(opts *DynSszOptions) {
 		opts.MaxStreamSize = size

--- a/reflection/common_internal_test.go
+++ b/reflection/common_internal_test.go
@@ -137,3 +137,43 @@ func TestMarshalDynamicVectorOverLength(t *testing.T) {
 		t.Fatalf("expected ErrVectorLength, got %v", err)
 	}
 }
+
+// dynamicListPreallocation's degenerate inputs are unreachable through a decode:
+// unmarshalDynamicList rejects a zero first offset before deriving the element
+// count, so the count is always positive, and no SSZ-dynamic element has a
+// zero-size Go representation. Both guards still matter — a negative count would
+// panic reflect.MakeSlice — and the policy must stay identical to
+// sszutils.decodeSlicePreallocation, which the generated decoders use for the
+// same lists, so drive it directly.
+func TestDynamicListPreallocation(t *testing.T) {
+	const budgetBytes = 64 << 10
+
+	tests := []struct {
+		name     string
+		count    int
+		elemSize uint64
+		want     int
+	}{
+		{name: "negative count", count: -1, elemSize: 8, want: 0},
+		{name: "empty", count: 0, elemSize: 8, want: 0},
+		{name: "zero sized element", count: 100_000, elemSize: 0, want: 100_000},
+		{name: "within budget", count: 32, elemSize: 8, want: 32},
+		{name: "clamped to byte budget", count: 10_000, elemSize: 8, want: budgetBytes / 8},
+		{name: "one element exceeds budget", count: 100, elemSize: budgetBytes + 1, want: 1},
+		{name: "large size cannot overflow", count: 100, elemSize: ^uint64(0), want: 1},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := dynamicListPreallocation(test.count, test.elemSize); got != test.want {
+				t.Fatalf(
+					"dynamicListPreallocation(%d, %d) = %d, want %d",
+					test.count,
+					test.elemSize,
+					got,
+					test.want,
+				)
+			}
+		})
+	}
+}

--- a/reflection/unmarshal.go
+++ b/reflection/unmarshal.go
@@ -1081,6 +1081,21 @@ func (ctx *ReflectionCtx) unmarshalListUntilEOF(targetType *ssztypes.TypeDescrip
 	return nil
 }
 
+// dynamicListPreallocation mirrors the 64 KiB policy used by
+// sszutils.PreallocateDecodeSlice. It is local because reflection has only a
+// runtime element size, while the generated-code helper obtains sizeof(T)
+// through its generic type parameter.
+func dynamicListPreallocation(count int, elemSize uint64) int {
+	if count <= 0 {
+		return 0
+	}
+	if elemSize == 0 {
+		return count
+	}
+	maxCount := uint64(64<<10) / elemSize
+	return min(count, max(1, int(maxCount)))
+}
+
 // unmarshalDynamicList decodes lists with variable-size elements from SSZ format.
 //
 // For lists with variable-size elements, SSZ uses an offset-based encoding:
@@ -1183,14 +1198,14 @@ func (ctx *ReflectionCtx) unmarshalDynamicList(targetType *ssztypes.TypeDescript
 		sliceOffsets = sszutils.GetOffsetSlice(sszutils.CredibleCount(decoder, sliceLen, 4))
 		defer func() { sszutils.PutOffsetSlice(sliceOffsets) }()
 
-		sliceOffsets = sszutils.GrowSlice(sliceOffsets, 1)
+		sliceOffsets = sszutils.GrowSlice(sliceOffsets, 1, sliceLen)
 		sliceOffsets[0] = firstOffset
 		for i := 1; i < sliceLen; i++ {
 			offset, err := decoder.DecodeOffset()
 			if err != nil {
 				return sszutils.ErrorWithPathf(err, "[%d:o]", i)
 			}
-			sliceOffsets = sszutils.GrowSlice(sliceOffsets, i+1)
+			sliceOffsets = sszutils.GrowSlice(sliceOffsets, i+1, sliceLen)
 			sliceOffsets[i] = offset
 		}
 	}
@@ -1203,7 +1218,15 @@ func (ctx *ReflectionCtx) unmarshalDynamicList(targetType *ssztypes.TypeDescript
 		fieldT = fieldT.Elem()
 	}
 
-	newValue := reflect.MakeSlice(fieldT, sliceLen, sliceLen)
+	// A known region is already backed by the caller's complete input and keeps
+	// the existing exact-allocation path. For an open stream region, the offset
+	// table proves the element count but not that any element body exists, so
+	// reserve only a byte-bounded prefix and grow as bodies are reached.
+	initialLen := sliceLen
+	if !lengthKnown {
+		initialLen = dynamicListPreallocation(sliceLen, uint64(fieldT.Elem().Size()))
+	}
+	newValue := reflect.MakeSlice(fieldT, initialLen, initialLen)
 
 	if sliceLen > 0 {
 		offset := firstOffset
@@ -1214,17 +1237,6 @@ func (ctx *ReflectionCtx) unmarshalDynamicList(targetType *ssztypes.TypeDescript
 
 		// decode slice items
 		for i := 0; i < sliceLen; i++ {
-			var itemVal reflect.Value
-			if allocPointerElems {
-				// fmt.Printf("new slice item %v\n", fieldType.Name())
-				itemVal = reflect.New(fieldType.Type.Elem())
-				newValue.Index(i).Set(itemVal)
-			} else {
-				// Non-pointer and optional-pointer elements decode in place via the
-				// addressable slot so an absent optional can be set back to nil.
-				itemVal = newValue.Index(i)
-			}
-
 			startOffset := offset
 			var endOffset uint32
 
@@ -1248,6 +1260,28 @@ func (ctx *ReflectionCtx) unmarshalDynamicList(targetType *ssztypes.TypeDescript
 					sszutils.ErrElementOffsetOutOfRangeFn(endOffset, startOffset, sszLen),
 					"[%d:o]", i,
 				)
+			}
+
+			if i >= newValue.Len() {
+				// Make the whole geometric chunk addressable so this branch is
+				// taken only at chunk boundaries. Slots after i remain private
+				// zero values until later loop iterations fill them; the slice is
+				// not committed to targetValue until every declared item decodes.
+				chunkLen := min(sliceLen, max(i+1, newValue.Len()*2))
+				grown := reflect.MakeSlice(fieldT, chunkLen, chunkLen)
+				reflect.Copy(grown, newValue)
+				newValue = grown
+			}
+
+			var itemVal reflect.Value
+			if allocPointerElems {
+				// fmt.Printf("new slice item %v\n", fieldType.Name())
+				itemVal = reflect.New(fieldType.Type.Elem())
+				newValue.Index(i).Set(itemVal)
+			} else {
+				// Non-pointer and optional-pointer elements decode in place via the
+				// addressable slot so an absent optional can be set back to nil.
+				itemVal = newValue.Index(i)
 			}
 
 			if openElem {
@@ -1281,7 +1315,10 @@ func (ctx *ReflectionCtx) unmarshalDynamicList(targetType *ssztypes.TypeDescript
 		}
 	}
 
-	targetValue.Set(newValue)
+	// Every index below sliceLen has decoded successfully at this point. Slice
+	// explicitly to the wire-declared count so the commit invariant remains
+	// obvious even if the chunking policy changes later.
+	targetValue.Set(newValue.Slice(0, sliceLen))
 
 	return nil
 }

--- a/sszutils/decoder_stream.go
+++ b/sszutils/decoder_stream.go
@@ -16,9 +16,9 @@ const DefaultStreamDecoderBufSize = 2 * 1024
 
 // DefaultMaxStreamSize is the default upper bound on the total size of an SSZ
 // payload decoded without a known length. Unknown-length decoding is always
-// bounded: the bound is what keeps a peer that never closes the connection —
-// and any decode site that has not been taught about open regions — from
-// driving an unbounded allocation.
+// byte-bounded: the allowance keeps an endless input — and any decode site that
+// has not been taught about open regions — from driving an unbounded wire
+// allocation. It does not bound read time or decoded-object memory.
 const DefaultMaxStreamSize = 512 * 1024 * 1024
 
 // maxConsecutiveEmptyReads bounds retries of a (0, nil) read. Such a read is a
@@ -397,7 +397,11 @@ func (e *StreamDecoder) readMore() error {
 		}
 
 		if err != nil {
-			if err == io.EOF || err == io.ErrUnexpectedEOF {
+			// Only io.EOF is a clean end-of-stream signal. In particular,
+			// io.ErrUnexpectedEOF is an integrity/truncation failure from the
+			// reader and must not turn an open SSZ region into a valid short
+			// payload merely because the reader returned data with it.
+			if err == io.EOF {
 				e.onEOF()
 				return nil
 			}
@@ -514,9 +518,18 @@ func (e *StreamDecoder) readBytes(buf []byte) error {
 		totalRead += nr
 		e.position += nr
 
-		// A reader may return the final bytes together with io.EOF; once the
-		// request is satisfied the read succeeded regardless of that error.
+		// A reader may return the final bytes together with io.EOF; that is a
+		// successful exact read. Any other terminal error still matters even
+		// when it accompanies enough data: integrity-checking, decompressing,
+		// and authenticated readers commonly report their verdict that way.
 		if totalRead >= remaining {
+			if err != nil {
+				if err == io.EOF {
+					e.onEOF()
+				} else {
+					return err
+				}
+			}
 			break
 		}
 		if err != nil {

--- a/sszutils/stream_test.go
+++ b/sszutils/stream_test.go
@@ -1710,6 +1710,50 @@ func TestStreamDecoder_ReadBytesDataWithEOF(t *testing.T) {
 	}
 }
 
+// EOF is the only error that may be consumed after a reader has supplied all
+// requested bytes. Other terminal errors can be integrity verdicts from a
+// checksumming, decompressing, or authenticated reader and must survive both
+// the direct-read and buffered-fill paths.
+func TestStreamDecoder_PreservesTerminalDataErrors(t *testing.T) {
+	data := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+
+	for name, want := range map[string]error{
+		"integrity":      errors.New("checksum failed"),
+		"unexpected EOF": io.ErrUnexpectedEOF,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Run("direct read", func(t *testing.T) {
+				dec := NewStreamDecoder(
+					&errReader{data: data, errAfter: len(data), err: want},
+					len(data),
+					8,
+				)
+				dec.PushLimit(len(data))
+
+				got := make([]byte, len(data))
+				_, err := dec.DecodeBytes(got)
+				if !errors.Is(err, want) {
+					t.Fatalf("DecodeBytes error = %v, want %v", err, want)
+				}
+				if !bytes.Equal(got, data) {
+					t.Fatalf("reader data was not processed before its error: got %x, want %x", got, data)
+				}
+			})
+
+			t.Run("buffer fill", func(t *testing.T) {
+				dec := NewUnknownStreamDecoder(
+					&errReader{data: data, errAfter: len(data), err: want},
+					64,
+					64,
+				)
+				if err := dec.Prefill(); !errors.Is(err, want) {
+					t.Fatalf("Prefill error = %v, want %v", err, want)
+				}
+			})
+		})
+	}
+}
+
 // A (0, nil) no-op read must be retried, not treated as EOF, on both the
 // buffered (ensureBuffered) and direct (readBytes) paths.
 func TestStreamDecoder_ZeroNilReadRetried(t *testing.T) {

--- a/sszutils/unmarshal.go
+++ b/sszutils/unmarshal.go
@@ -160,6 +160,51 @@ func ExpandSlice[T any](src []T, size int) []T {
 	return src
 }
 
+// maxDecodeSlicePreallocationBytes bounds the destination memory reserved from
+// a dynamic-list offset table before any element body has decoded successfully.
+// The decoder must allocate at least one element in order to decode it, so an
+// individual Go element larger than this bound is still allocated on its own.
+const maxDecodeSlicePreallocationBytes = 64 << 10
+
+// decodeSlicePreallocation returns the number of elements that may be reserved
+// before their bodies have been decoded. A dynamic-list offset table proves the
+// element count but not that any of those bodies exist, and a compact table can
+// otherwise materialize a very large []T when T contains wide inline storage.
+//
+// The multiplication is expressed as a division so hostile counts and large Go
+// element sizes cannot overflow. Zero-sized elements consume no backing-store
+// bytes and may be sized exactly.
+func decodeSlicePreallocation(count int, elemSize uint64) int {
+	if count <= 0 {
+		return 0
+	}
+	if elemSize == 0 {
+		return count
+	}
+
+	maxCount := uint64(maxDecodeSlicePreallocationBytes) / elemSize
+	if maxCount == 0 {
+		return 1 // decoding one element necessarily costs at least elemSize
+	}
+	if uint64(count) > maxCount {
+		return int(maxCount)
+	}
+	return count
+}
+
+// PreallocateDecodeSlice reserves a byte-bounded prefix of a declared dynamic
+// list. Callers extend the result geometrically with GrowSlice as later chunks
+// are reached.
+//
+// ExpandSlice is intentional here: GrowSlice's small-slice capacity floor is a
+// throughput win during incremental growth, but reserving eight wide elements
+// would defeat the byte bound this helper provides.
+func PreallocateDecodeSlice[T any](src []T, count int) []T {
+	var zero T
+	initialCount := decodeSlicePreallocation(count, uint64(unsafe.Sizeof(zero)))
+	return ExpandSlice(src, initialCount)
+}
+
 // CredibleCount clamps a count declared by the input to what the bytes already
 // read can account for, at elemSize bytes per element.
 //
@@ -196,18 +241,25 @@ func SizeListSlice[T any](dec Decoder, dst []T, count, elemSize int) []T {
 	if dec.LengthKnown() {
 		return ExpandSlice(dst, count)
 	}
-	return GrowSlice(dst, CredibleCount(dec, count, elemSize))
+	return GrowSlice(dst, CredibleCount(dec, count, elemSize), count)
 }
 
-// GrowSlice returns src resized to size, growing capacity geometrically.
+// GrowSlice returns src resized to size, growing capacity geometrically. When a
+// new backing array is needed, a non-negative allocationLimit bounds its
+// capacity; a smaller limit is treated as size, and a negative limit permits
+// unbounded growth. Existing caller-owned capacity is reused as-is because
+// hiding it would not release memory and could force a later reallocation.
 //
 // ExpandSlice allocates exactly the requested size, which is right when the
 // element count is known up front. Decoding a list whose count is only
 // discovered at EOF resizes once per element, so it needs amortised growth
 // instead.
-func GrowSlice[T any](src []T, size int) []T {
+func GrowSlice[T any](src []T, size, allocationLimit int) []T {
 	if size < 0 {
 		return make([]T, 0)
+	}
+	if allocationLimit >= 0 && allocationLimit < size {
+		allocationLimit = size
 	}
 	if size <= cap(src) {
 		prevLen := len(src)
@@ -230,6 +282,9 @@ func GrowSlice[T any](src []T, size int) []T {
 	}
 	if newCap < 8 {
 		newCap = 8
+	}
+	if allocationLimit >= 0 && newCap > allocationLimit {
+		newCap = allocationLimit
 	}
 	out := make([]T, size, newCap)
 	copy(out, src)
@@ -285,7 +340,7 @@ func DecodeUint64ListInto[T ~uint64](dec Decoder, dst []T, maxLen int) ([]T, err
 		return dst, nil
 	}
 
-	dst = GrowSlice(dst, 0)
+	dst = GrowSlice(dst, 0, maxLen)
 	for count := 0; ; count++ {
 		more, err := dec.More()
 		if err != nil {
@@ -301,7 +356,7 @@ func DecodeUint64ListInto[T ~uint64](dec Decoder, dst []T, maxLen int) ([]T, err
 		if err != nil {
 			return nil, err
 		}
-		dst = GrowSlice(dst, count+1)
+		dst = GrowSlice(dst, count+1, maxLen)
 		dst[count] = T(v)
 	}
 }

--- a/sszutils/utils_test.go
+++ b/sszutils/utils_test.go
@@ -461,6 +461,80 @@ func TestExpandSlice_GrowWithinCapacityZeroesTail(t *testing.T) {
 	}
 }
 
+func TestDecodeSlicePreallocation(t *testing.T) {
+	tests := []struct {
+		name     string
+		count    int
+		elemSize uint64
+		want     int
+	}{
+		{name: "negative count", count: -1, elemSize: 8, want: 0},
+		{name: "empty", count: 0, elemSize: 8, want: 0},
+		{name: "zero sized element", count: 100_000, elemSize: 0, want: 100_000},
+		{name: "within budget", count: 32, elemSize: 8, want: 32},
+		{
+			name:     "clamped to byte budget",
+			count:    10_000,
+			elemSize: 8,
+			want:     maxDecodeSlicePreallocationBytes / 8,
+		},
+		{
+			name:     "one element exceeds budget",
+			count:    100,
+			elemSize: maxDecodeSlicePreallocationBytes + 1,
+			want:     1,
+		},
+		{
+			name:     "large size cannot overflow",
+			count:    100,
+			elemSize: ^uint64(0),
+			want:     1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := decodeSlicePreallocation(test.count, test.elemSize); got != test.want {
+				t.Fatalf(
+					"decodeSlicePreallocation(%d, %d) = %d, want %d",
+					test.count,
+					test.elemSize,
+					got,
+					test.want,
+				)
+			}
+		})
+	}
+}
+
+func TestPreallocateDecodeSlice(t *testing.T) {
+	type wideElement [maxDecodeSlicePreallocationBytes]byte
+
+	got := PreallocateDecodeSlice([]wideElement(nil), 512)
+	if len(got) != 1 || cap(got) != 1 {
+		t.Fatalf("wide preallocation len/cap = %d/%d, want 1/1", len(got), cap(got))
+	}
+
+	got[0][0] = 42
+	chunkLen := cap(got)
+	if chunkLen == len(got) {
+		chunkLen = max(2, 8, len(got)*2)
+	}
+	got = GrowSlice(got, min(512, chunkLen), 512)
+	if got[0][0] != 42 {
+		t.Fatal("incremental growth lost the preallocated element")
+	}
+	if len(got) != 8 || cap(got) != 8 {
+		t.Fatalf("grown len/cap = %d/%d, want the 8-element geometric chunk", len(got), cap(got))
+	}
+
+	small := PreallocateDecodeSlice([]uint64(nil), 16)
+	if len(small) != 16 || cap(small) != 16 {
+		t.Fatalf("small preallocation len/cap = %d/%d, want 16/16", len(small), cap(small))
+	}
+
+}
+
 // ============================================================================
 // ZeroBytes Tests
 // ============================================================================
@@ -731,13 +805,13 @@ func TestZeroBytesConcurrent(t *testing.T) {
 
 func TestGrowSlice(t *testing.T) {
 	// A negative size yields an empty, non-nil slice rather than panicking.
-	if got := GrowSlice([]int(nil), -1); got == nil || len(got) != 0 {
-		t.Fatalf("GrowSlice(nil, -1) = %v, want empty non-nil", got)
+	if got := GrowSlice([]int(nil), -1, -1); got == nil || len(got) != 0 {
+		t.Fatalf("GrowSlice(nil, -1, -1) = %v, want empty non-nil", got)
 	}
 
 	// Growth is geometric, so repeated single-element growth must not
 	// reallocate every time.
-	s := GrowSlice([]int(nil), 1)
+	s := GrowSlice([]int(nil), 1, -1)
 	if len(s) != 1 {
 		t.Fatalf("len = %d, want 1", len(s))
 	}
@@ -746,13 +820,13 @@ func TestGrowSlice(t *testing.T) {
 	}
 	firstCap := cap(s)
 	for i := 2; i <= firstCap; i++ {
-		s = GrowSlice(s, i)
+		s = GrowSlice(s, i, -1)
 	}
 	if cap(s) != firstCap {
 		t.Fatalf("cap changed to %d while growing within capacity", cap(s))
 	}
 	s[0] = 42
-	s = GrowSlice(s, firstCap+1)
+	s = GrowSlice(s, firstCap+1, -1)
 	if cap(s) < 2*firstCap {
 		t.Fatalf("cap = %d, want at least %d (geometric growth)", cap(s), 2*firstCap)
 	}
@@ -762,14 +836,29 @@ func TestGrowSlice(t *testing.T) {
 
 	// Shrinking re-slices in place; re-growing must zero the reused tail so a
 	// short decode cannot expose the previous contents.
-	s = GrowSlice(s, 4)
+	s = GrowSlice(s, 4, -1)
 	for i := range s {
 		s[i] = 7
 	}
-	s = GrowSlice(s, 2)
-	s = GrowSlice(s, 4)
+	s = GrowSlice(s, 2, -1)
+	s = GrowSlice(s, 4, -1)
 	if s[2] != 0 || s[3] != 0 {
 		t.Fatalf("regrown tail = %v, want zeroed", s[2:4])
+	}
+
+	// An allocation limit clamps newly allocated capacity.
+	bounded := GrowSlice(make([]int, 80), 100, 100)
+	if len(bounded) != 100 || cap(bounded) != 100 {
+		t.Fatalf("bounded growth len/cap = %d/%d, want 100/100", len(bounded), cap(bounded))
+	}
+	floored := GrowSlice(make([]int, 1), 2, 2)
+	if len(floored) != 2 || cap(floored) != 2 {
+		t.Fatalf("bounded floor growth len/cap = %d/%d, want 2/2", len(floored), cap(floored))
+	}
+	storage := make([]int, 1, 160)
+	reused := GrowSlice(storage, 100, 100)
+	if len(reused) != 100 || cap(reused) != 160 || &reused[0] != &storage[0] {
+		t.Fatalf("reuse len/cap = %d/%d, want 100/160 over the existing backing array", len(reused), cap(reused))
 	}
 }
 

--- a/sszutils/utils_test.go
+++ b/sszutils/utils_test.go
@@ -532,7 +532,6 @@ func TestPreallocateDecodeSlice(t *testing.T) {
 	if len(small) != 16 || cap(small) != 16 {
 		t.Fatalf("small preallocation len/cap = %d/%d, want 16/16", len(small), cap(small))
 	}
-
 }
 
 // ============================================================================

--- a/sszutils/utils_test.go
+++ b/sszutils/utils_test.go
@@ -859,6 +859,14 @@ func TestGrowSlice(t *testing.T) {
 	if len(reused) != 100 || cap(reused) != 160 || &reused[0] != &storage[0] {
 		t.Fatalf("reuse len/cap = %d/%d, want 100/160 over the existing backing array", len(reused), cap(reused))
 	}
+
+	// A limit below the requested size cannot be honoured: the result must still
+	// hold size elements, so the limit is raised to size rather than producing a
+	// capacity smaller than the length, which make would reject outright.
+	underLimit := GrowSlice([]int(nil), 4, 2)
+	if len(underLimit) != 4 || cap(underLimit) != 4 {
+		t.Fatalf("under-limit growth len/cap = %d/%d, want 4/4", len(underLimit), cap(underLimit))
+	}
 }
 
 func TestDecodeByteListInto(t *testing.T) {

--- a/tests/fuzz/engine/filler.go
+++ b/tests/fuzz/engine/filler.go
@@ -110,7 +110,7 @@ func (f *Filler) fillPointer(v reflect.Value, tags string) {
 func (f *Filler) fillStructFields(v reflect.Value) {
 	t := v.Type()
 
-	// Detect CompatibleUnion: has Variant (uint8) + Data (interface{})
+	// Detect a union (CompatibleUnion or Union): Variant (uint8) + Data (interface{})
 	if t.NumField() == 2 {
 		variantField, hasVariant := t.FieldByName("Variant")
 		_, hasData := t.FieldByName("Data")
@@ -160,9 +160,21 @@ func (f *Filler) fillUnion(v reflect.Value) {
 	variantVal := reflect.New(variantType).Elem()
 	f.fillValue(variantVal, "")
 
-	// Set Variant and Data
-	v.FieldByName("Variant").SetUint(uint64(variantIdx))
+	// Set Variant and Data. The selector must address the same descriptor field
+	// the data was built from, or the union rejects the value as a type mismatch.
+	v.FieldByName("Variant").SetUint(unionSelectorBase(v.Type()) + uint64(variantIdx))
 	v.FieldByName("Data").Set(variantVal)
+}
+
+// unionSelectorBase returns the selector of the descriptor's first variant.
+// CompatibleUnion numbers its variants from 1 per EIP-8016, while a classic
+// Union addresses them by their 0-based descriptor field positions.
+func unionSelectorBase(unionType reflect.Type) uint64 {
+	if strings.HasPrefix(unionType.Name(), "CompatibleUnion[") {
+		return 1
+	}
+
+	return 0
 }
 
 func (f *Filler) fillArray(v reflect.Value) {

--- a/tests/fuzz/engine/filler_union_test.go
+++ b/tests/fuzz/engine/filler_union_test.go
@@ -1,0 +1,59 @@
+package engine
+
+import (
+	"math/rand"
+	"testing"
+
+	dynssz "github.com/pk910/dynamic-ssz"
+)
+
+type fillerUnion2 struct {
+	U dynssz.CompatibleUnion[struct {
+		Variant0 uint32
+		Variant1 uint64
+	}]
+}
+
+type fillerUnion3 struct {
+	U dynssz.CompatibleUnion[struct {
+		Variant0 uint16
+		Variant1 uint32
+		Variant2 uint64
+	}]
+}
+
+// TestFillerUnionSelectorsAreMarshalable pins that filled unions carry a
+// selector the engines accept and that addresses the descriptor field the data
+// was built from. A filler that numbers variants from 0 produces values that
+// every operation rejects, so both engines agree on the error and the fuzzer
+// reports no issues while covering nothing.
+func TestFillerUnionSelectorsAreMarshalable(t *testing.T) {
+	ds := dynssz.NewDynSsz(nil, dynssz.WithNoFastSsz())
+
+	cases := []struct {
+		name string
+		new  func() any
+	}{
+		{"two-variants", func() any { return &fillerUnion2{} }},
+		{"three-variants", func() any { return &fillerUnion3{} }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for seed := int64(0); seed < 20; seed++ {
+				rng := rand.New(rand.NewSource(seed))
+				filler := NewFiller(rng)
+				instance := tc.new()
+				filler.FillStruct(instance)
+
+				if _, err := ds.MarshalSSZ(instance); err != nil {
+					t.Fatalf("seed %d: marshal: %v", seed, err)
+				}
+
+				if _, err := ds.HashTreeRoot(instance); err != nil {
+					t.Fatalf("seed %d: hash tree root: %v", seed, err)
+				}
+			}
+		})
+	}
+}

--- a/tests/perftests/bench_test.go
+++ b/tests/perftests/bench_test.go
@@ -71,8 +71,8 @@ func init() {
 
 	dynSszCodegenMainnet = ssz.NewDynSsz(nil)
 	dynSszCodegenMinimal = ssz.NewDynSsz(minimalSpecs)
-	dynSszReflMainnet = ssz.NewDynSsz(nil, ssz.WithNoFastSsz())
-	dynSszReflMinimal = ssz.NewDynSsz(minimalSpecs, ssz.WithNoFastSsz())
+	dynSszReflMainnet = ssz.NewDynSsz(nil, ssz.WithNoFastSsz(), ssz.WithNoDelegation())
+	dynSszReflMinimal = ssz.NewDynSsz(minimalSpecs, ssz.WithNoFastSsz(), ssz.WithNoDelegation())
 }
 
 func loadHTR(path string) [32]byte {


### PR DESCRIPTION
## Summary

- preserve terminal reader errors other than `io.EOF`, including `io.ErrUnexpectedEOF`, even when the reader returns the final bytes and error together
- document EOF framing, deadlines and cancellation, and clarify that `WithMaxStreamSize` bounds wire bytes rather than decoded heap or read duration
- limit unknown-size dynamic-list destination preallocation to a 64 KiB prefix, then grow geometrically as element bodies are reached
- bound new geometric allocations by the declared item count or schema maximum while preserving exact allocation for buffers and known-size streams
- cover both generated and reflection decoders with malformed-input allocation regressions and successful incremental round trips

## Security rationale

A compact dynamic-list offset table can declare many elements before any element body has arrived. For Go element types with large inline storage, eagerly materializing the declared destination slice lets a small malformed stream trigger a disproportionately large heap allocation. This change seeds only a byte-bounded prefix and grows as decoding demonstrates progress. New allocations never reserve beyond the declared item count; existing caller-owned capacity is reused without allocating more memory.

Reader errors can also represent checksum, decompression, or authentication failures. Only `io.EOF` is treated as a clean message boundary; other terminal errors are returned even if their read supplied enough bytes to complete the SSZ value.

## API note

`sszutils.GrowSlice` is unreleased and now accepts an allocation-limit argument. Generated callers pass the applicable item count or schema limit, or `-1` only for genuinely unbounded open lists.

## Validation

- `go test ./... -count=1`
- targeted race tests for slice growth and generated/reflection unknown-size allocation paths
- 32-bit compile validation with `GOARCH=386`
- staged diff whitespace validation