### PR TITLE
Async hashing: opt-in background subtree reduction

### DIFF
--- a/dynssz.go
+++ b/dynssz.go
@@ -110,6 +110,10 @@ func NewDynSsz(specs map[string]any, options ...DynSszOption) *DynSsz {
 		option(opts)
 	}
 
+	if opts.AsyncHashing && opts.AsyncHashingWorkers > 0 {
+		hasher.EnableAsyncHashing(opts.AsyncHashingWorkers)
+	}
+
 	dynssz := &DynSsz{
 		specValues:     specs,
 		specValueCache: map[string]*cachedSpecValue{},
@@ -1019,6 +1023,10 @@ func (d *DynSsz) HashTreeRoot(source any, opts ...CallOption) ([32]byte, error) 
 	defer func() {
 		pool.Put(hh)
 	}()
+
+	if d.options.AsyncHashing {
+		hh.SetAsyncHashing(true)
+	}
 
 	err := d.HashTreeRootWith(source, hh, opts...)
 	if err != nil {

--- a/dynssz_test.go
+++ b/dynssz_test.go
@@ -21,6 +21,7 @@ import (
 	"testing/iotest"
 	"time"
 
+	"github.com/pk910/dynamic-ssz/hasher"
 	"github.com/pk910/dynamic-ssz/ssztypes"
 	"github.com/pk910/dynamic-ssz/sszutils"
 )
@@ -6244,5 +6245,68 @@ func TestUnknownSizeBigIntWithoutLimitSurfacesStreamLimit(t *testing.T) {
 	err := ds.UnmarshalSSZReader(&out, &eofWithDataReader{data: payload}, -1)
 	if !errors.Is(err, sszutils.ErrStreamTooLarge) {
 		t.Fatalf("UnmarshalSSZReader = %v, want ErrStreamTooLarge", err)
+	}
+}
+
+type asyncHashingElement struct {
+	A uint64
+	B uint64
+	C [32]byte
+	D [48]byte `ssz-size:"48"`
+}
+
+type asyncHashingContainer struct {
+	Binary      []asyncHashingElement `ssz-max:"1099511627776"`
+	Progressive []asyncHashingElement `ssz-type:"progressive-list"`
+}
+
+// TestWithAsyncHashing verifies the DynSsz-level gate: instances with the
+// option produce identical roots to a plain instance — for the fast and the
+// native hash backend alike — and a plain instance stays ungated while async
+// hashing is enabled process-wide.
+func TestWithAsyncHashing(t *testing.T) {
+	defer hasher.DisableAsyncHashing()
+
+	elements := make([]asyncHashingElement, 20000)
+	for i := range elements {
+		elements[i].A = uint64(i)
+		binary.LittleEndian.PutUint64(elements[i].C[:8], uint64(i))
+		binary.LittleEndian.PutUint64(elements[i].D[:8], uint64(i))
+	}
+	source := &asyncHashingContainer{Binary: elements, Progressive: elements}
+
+	plain := NewDynSsz(nil)
+	want, err := plain.HashTreeRoot(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	async := NewDynSsz(nil, WithAsyncHashing(4))
+	got, err := async.HashTreeRoot(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("async root %x != plain root %x", got, want)
+	}
+
+	// The plain instance keeps hashing synchronously while async hashing is
+	// enabled process-wide.
+	if got, err := plain.HashTreeRoot(source); err != nil || got != want {
+		t.Errorf("ungated instance root %x (err %v) != %x", got, err, want)
+	}
+
+	// Gate-only variant: workers == 0 must not reconfigure the process-wide
+	// state, only opt the instance in.
+	gateOnly := NewDynSsz(nil, WithAsyncHashing(0))
+	if got, err := gateOnly.HashTreeRoot(source); err != nil || got != want {
+		t.Errorf("gate-only instance root %x (err %v) != %x", got, err, want)
+	}
+
+	// The native hash backend participates too: its hash function draws
+	// per-call instances from a pool, making it safe for the workers.
+	native := NewDynSsz(nil, WithAsyncHashing(4), WithNoFastHash())
+	if got, err := native.HashTreeRoot(source); err != nil || got != want {
+		t.Errorf("native-hash instance root %x (err %v) != %x", got, err, want)
 	}
 }

--- a/hasher/async.go
+++ b/hasher/async.go
@@ -52,10 +52,16 @@ const (
 	// background, so the drain at finalization rarely waits.
 	asyncActiveChunks = 131072
 
-	// asyncBufSize is the size of the pre-sized job input buffers in the
-	// free list. Jobs wider than this (large progressive groups) use a
-	// one-off allocation that is not retained.
+	// asyncBufSize is the size of every job input buffer. Jobs are capped
+	// at lazyFlushChunks, so all buffers are interchangeable and no other
+	// size ever needs allocating: wider regions reduce as a sequence of
+	// cap-sized jobs whose remainder carries over to the next round.
 	asyncBufSize = lazyFlushChunks * 32
+
+	// asyncCapDepth is the subtree depth a full cap-sized reduction
+	// produces: a lazyFlushChunks-wide run of leaves becomes one node at
+	// this depth.
+	asyncCapDepth = 15
 
 	// asyncRingInline is the job-ring size served by the hasher's inline
 	// backing array; larger rings (workers > 8) allocate once.
@@ -66,8 +72,8 @@ const (
 // reductions; a slot is held from before the job input is copied until the
 // reduction finishes. bufs is a token free list with one token per job-ring
 // slot (twice the worker count): a token is either a reusable input buffer
-// or nil before the buffer is first materialized (or after an oversized
-// one-off was dropped), so job input memory is strictly bounded.
+// or nil before the buffer is first materialized, so job input memory is
+// strictly bounded.
 type asyncShared struct {
 	sem  chan struct{}
 	bufs chan []byte
@@ -77,6 +83,37 @@ type asyncShared struct {
 // disabled. In-flight jobs keep a reference to the state they started with,
 // so reconfiguration never disturbs them.
 var asyncState atomic.Pointer[asyncShared]
+
+// asyncRunners counts the persistent runner goroutines and asyncIdle the
+// ones parked on the handoff channel. Runners start on demand: enabling
+// spawns the first, and an enqueue that finds no idle runner adds one until
+// the worker limit is reached. Runners are never stopped — the semaphore
+// bounds how many are actually working, and the count stays at the highest
+// demand ever seen (at most the highest worker limit configured).
+var (
+	asyncRunners atomic.Int64
+	asyncIdle    atomic.Int64
+)
+
+// ensureAsyncRunner spawns a runner goroutine when none is idle and the
+// worker limit of the given state allows another. The idle check is
+// approximate: in the worst case a send waits for a busy runner to finish
+// its current job, and the next enqueue tops the pool up.
+func ensureAsyncRunner(st *asyncShared) {
+	if asyncIdle.Load() > 0 {
+		return
+	}
+	for {
+		cur := asyncRunners.Load()
+		if cur >= int64(cap(st.sem)) {
+			return
+		}
+		if asyncRunners.CompareAndSwap(cur, cur+1) {
+			go asyncJobRunner()
+			return
+		}
+	}
+}
 
 // EnableAsyncHashing enables background subtree reduction for all hashers
 // whose hash function is safe for concurrent use (hashers created via
@@ -100,6 +137,7 @@ func EnableAsyncHashing(workers int) {
 		st.bufs <- nil
 	}
 	asyncState.Store(st)
+	ensureAsyncRunner(st)
 }
 
 // DisableAsyncHashing turns background subtree reduction off. Reductions
@@ -108,11 +146,11 @@ func DisableAsyncHashing() {
 	asyncState.Store(nil)
 }
 
-// asyncShared returns the shared state when async hashing is enabled and
-// this hasher's hash function may be called from other goroutines, nil
+// asyncShared returns the shared state when async hashing is enabled
+// process-wide and this hasher is gated in via SetAsyncHashing, nil
 // otherwise.
 func (h *Hasher) asyncShared() *asyncShared {
-	if !h.asyncSafe {
+	if !h.async {
 		return nil
 	}
 	return asyncState.Load()
@@ -124,6 +162,7 @@ func (h *Hasher) asyncShared() *asyncShared {
 // the job holds a free-list token to restore at drain.
 type asyncJob struct {
 	st      *asyncShared
+	fn      HashFn
 	in      []byte
 	done    chan struct{}
 	dstOff  int
@@ -131,10 +170,17 @@ type asyncJob struct {
 	tokened bool
 }
 
+// asyncHandoff passes fully-prepared job slots to the persistent runner
+// goroutines. It is never closed — reconfiguration just adjusts how many
+// runners exist and how many may work at once, so senders never race a
+// shutdown. A send parks at most until a runner finishes its current job:
+// the semaphore admits no more jobs than there are runners.
+var asyncHandoff = make(chan *asyncJob, 64)
+
 // enqueueReduce copies buf[start:start+width*32] into an input buffer and
-// spawns a goroutine that reduces it pairwise, level by level, down to
-// outChunks chunks. The claimed job-ring slot records where drainJobs must
-// copy the result. width and outChunks must be powers of two with
+// spawns a runner goroutine that reduces it pairwise, level by level, down
+// to outChunks chunks. The claimed job-ring slot records where drainJobs
+// must copy the result. width and outChunks must be powers of two with
 // outChunks < width. Blocks while all worker slots are busy.
 func (h *Hasher) enqueueReduce(st *asyncShared, start, width, outChunks, dstOff int) {
 	st.sem <- struct{}{}
@@ -146,12 +192,35 @@ func (h *Hasher) enqueueReduce(st *asyncShared, start, width, outChunks, dstOff 
 
 	slot := h.claimJobSlot(st)
 	slot.st = st
+	slot.fn = h.hash
 	slot.in = in
 	slot.dstOff = dstOff
 	slot.outLen = outChunks * 32
 	slot.tokened = tokened
 
-	go h.runAsyncJob(slot, width, outChunks)
+	ensureAsyncRunner(st)
+	asyncHandoff <- slot
+}
+
+// asyncJobRunner is a persistent worker goroutine: it reduces handed-off
+// jobs level by level down to their output size, releases the worker slot,
+// and signals completion. The result stays at the front of the input buffer
+// for drainJobs to consume. Jobs are self-contained, so which runner picks
+// which slot does not matter.
+func asyncJobRunner() {
+	for {
+		asyncIdle.Add(1)
+		slot := <-asyncHandoff
+		asyncIdle.Add(-1)
+
+		in := slot.in
+		outChunks := slot.outLen / 32
+		for w := len(in) / 32; w > outChunks; w /= 2 {
+			_ = slot.fn(in[:w/2*32], in[:w*32])
+		}
+		<-slot.st.sem
+		slot.done <- struct{}{}
+	}
 }
 
 // getJobBuf obtains a job input buffer of at least need bytes. It never
@@ -168,10 +237,9 @@ func (h *Hasher) getJobBuf(st *asyncShared, need int) ([]byte, bool) {
 			if cap(in) >= need {
 				return in, true
 			}
-			// Unmaterialized or undersized token: allocate the pre-sized
-			// buffer so it joins the reuse cycle at drain. Oversized jobs
-			// get a one-off instead, restored as a nil token at drain.
-			return make([]byte, max(need, asyncBufSize)), true
+			// Unmaterialized token: allocate the pre-sized buffer so it
+			// joins the reuse cycle at drain.
+			return make([]byte, asyncBufSize), true
 		default:
 		}
 		if h.jobCount == 0 {
@@ -204,25 +272,11 @@ func (h *Hasher) claimJobSlot(st *asyncShared) *asyncJob {
 	return slot
 }
 
-// runAsyncJob reduces the slot's input buffer level by level down to
-// outChunks chunks, releases the worker slot, and signals completion. The
-// result stays at the front of the input buffer for drainJobs to consume.
-// Runs as its own goroutine.
-func (h *Hasher) runAsyncJob(slot *asyncJob, width, outChunks int) {
-	fn := h.hash
-	in := slot.in
-	for w := width; w > outChunks; w /= 2 {
-		_ = fn(in[:w/2*32], in[:w*32])
-	}
-	<-slot.st.sem
-	slot.done <- struct{}{}
-}
-
 // drainOldestJob waits for the ring's oldest job, writes its result into the
 // hole it was carved from, and restores the job's free-list token if it
-// holds one: pre-sized buffers are returned for reuse, oversized one-offs
-// are replaced by a nil token. Tokenless buffers (taken when every token was
-// held by other hashers) are simply dropped.
+// holds one: pre-sized buffers are returned for reuse, anything else becomes
+// a nil token. Tokenless buffers (taken when every token was held by other
+// hashers) are simply dropped.
 func (h *Hasher) drainOldestJob() {
 	slot := &h.jobRing[h.jobHead]
 	<-slot.done
@@ -230,13 +284,13 @@ func (h *Hasher) drainOldestJob() {
 		copy(h.buf[slot.dstOff:end], slot.in[:slot.outLen])
 	}
 	if slot.tokened {
-		if cap(slot.in) == asyncBufSize {
-			slot.st.bufs <- slot.in[:0]
-		} else {
-			slot.st.bufs <- nil
-		}
+		// Tokened buffers always carry the pre-sized capacity: jobs are
+		// capped at the buffer size and tokens materialize at exactly that
+		// size, so the buffer itself is the token.
+		slot.st.bufs <- slot.in[:0]
 	}
 	slot.st = nil
+	slot.fn = nil
 	slot.in = nil
 	h.jobHead = (h.jobHead + 1) % len(h.jobRing)
 	h.jobCount--
@@ -267,38 +321,87 @@ func (h *Hasher) layerLeaves(layer *treeLayer, pendStart int) uint64 {
 	return leaves
 }
 
-// flushPendingAsyncRoot hands a complete power-of-two run of deferred
-// subtrees to a background job that reduces it to a single subtree root. The
-// run must be leaf-aligned in the layer's tree (the caller checks). A
-// one-chunk hole replaces the run and the completed subtree is recorded in
-// the layer's collapse state at depth log2(count) — the layer's leaves are
-// element roots, so the intra-element levels do not count.
-func (h *Hasher) flushPendingAsyncRoot(st *asyncShared, layer *treeLayer, start, width, count int) {
-	h.enqueueReduce(st, start, width, 1, start)
-	h.compactAsyncRun(start, width, 1)
-
-	d := 0
-	for c := count; c > 1; c >>= 1 {
-		d++
+// flushPendingAsync reduces the layer's deferred run in cap-sized background
+// jobs and leaves any sub-cap remainder pending for the next round, so every
+// job matches the pre-sized input buffers exactly. A binary layer gets one
+// completed subtree node per job, recorded at depth log2(elements-per-cap) —
+// the layer's leaves are element roots, so the intra-element levels do not
+// count. A progressive layer gets one root per element instead: group
+// boundaries are not aligned to run boundaries, so completed subtrees cannot
+// span them. Reports whether at least one job was emitted; if not (a binary
+// run that is not leaf-aligned), the caller reduces synchronously.
+func (h *Hasher) flushPendingAsync(st *asyncShared, layer *treeLayer) bool {
+	elem := layer.pendElemChunks
+	batchElems := lazyFlushChunks / elem
+	emitted := false
+	for layer.pendCount >= batchElems {
+		start := layer.pendStart
+		if layer.progressive {
+			h.enqueueReduce(st, start, lazyFlushChunks, batchElems, start)
+			h.compactAsyncRun(start, lazyFlushChunks, batchElems)
+			layer.pendStart = start + batchElems*32
+		} else {
+			if h.layerLeaves(layer, start)%uint64(batchElems) != 0 {
+				break
+			}
+			h.enqueueReduce(st, start, lazyFlushChunks, 1, start)
+			h.compactAsyncRun(start, lazyFlushChunks, 1)
+			d := 0
+			for c := batchElems; c > 1; c >>= 1 {
+				d++
+			}
+			if !layer.collapsed {
+				layer.collapsed = true
+				layer.counts = [maxTreeDepth]uint32{}
+				layer.maxDepth = 0
+			}
+			layer.counts[d]++
+			if d > layer.maxDepth {
+				layer.maxDepth = d
+			}
+			layer.pendStart = start + 32
+		}
+		layer.pendCount -= batchElems
+		emitted = true
 	}
-	if !layer.collapsed {
-		layer.collapsed = true
-		layer.counts = [maxTreeDepth]uint32{}
-		layer.maxDepth = 0
-	}
-	layer.counts[d]++
-	if d > layer.maxDepth {
-		layer.maxDepth = d
-	}
+	return emitted
 }
 
-// flushPendingAsyncRoots hands a run of deferred subtrees to a background
-// job that reduces it to one root per element. A count-chunk hole replaces
-// the run; the roots are plain depth-0 leaves, so the collapse state needs
-// no update (the next state sync accounts them).
-func (h *Hasher) flushPendingAsyncRoots(st *asyncShared, start, width, count int) {
-	h.enqueueReduce(st, start, width, count, start)
-	h.compactAsyncRun(start, width, count)
+// precollapseProgressiveRun replaces cap-aligned spans of a progressive
+// layer's trailing depth-0 run with cap-depth nodes reduced in the
+// background, so groups wider than one job buffer are later consumed from a
+// handful of nodes instead of one oversized reduction. Only meaningful from
+// progressive level 8 up (the caller checks): every group in the active
+// region is then a multiple of the cap, so cap-aligned nodes never straddle
+// a group boundary. Reports whether jobs were emitted — the caller must
+// then leave the active region untouched for the round, because the node
+// holes are only stable while nothing consumes or compacts around them.
+func (h *Hasher) precollapseProgressiveRun(st *asyncShared, layer *treeLayer) bool {
+	// Everything deeper than the run must itself be a cap-depth node: that
+	// guarantees the run starts cap-aligned, and it keeps the buffer's
+	// deepest-first node order intact when the new nodes are recorded at
+	// cap depth (nodes at depths in between would sit left of the new ones
+	// positionally but be consumed after them).
+	for d := 1; d <= layer.maxDepth; d++ {
+		if d != asyncCapDepth && layer.counts[d] != 0 {
+			return false
+		}
+	}
+	emitted := false
+	runStart := h.activeSubtreeStart(layer) + int(layer.counts[asyncCapDepth])*32
+	for layer.counts[0] >= lazyFlushChunks {
+		h.enqueueReduce(st, runStart, lazyFlushChunks, 1, runStart)
+		h.compactAsyncRun(runStart, lazyFlushChunks, 1)
+		layer.counts[0] -= lazyFlushChunks
+		layer.counts[asyncCapDepth]++
+		if asyncCapDepth > layer.maxDepth {
+			layer.maxDepth = asyncCapDepth
+		}
+		layer.collapsed = true
+		runStart += 32
+		emitted = true
+	}
+	return emitted
 }
 
 // compactAsyncRun shrinks a width-chunk run at start down to outChunks hole

--- a/hasher/async.go
+++ b/hasher/async.go
@@ -1,0 +1,222 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+
+package hasher
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Async hashing offloads large, self-contained subtree reductions to
+// background goroutines while the main goroutine keeps walking the value and
+// appending chunks. It is disabled by default and enabled process-wide via
+// EnableAsyncHashing.
+//
+// The unit of background work is a contiguous, power-of-two-chunk region of
+// the buffer whose reduction result has a known size: either a complete
+// aligned subtree (reduced to a single root) or a run of deferred element
+// subtrees (reduced to one root per element). The region's bytes are copied
+// into a pooled job buffer, a single-chunk (or per-element) hole is left in
+// the hasher's buffer, and a goroutine reduces the copy level by level with
+// wide hash calls. drainJobs fills the holes with the results and runs before
+// any operation that reads or restructures a region that may contain holes.
+//
+// Because each job is reduced sequentially inside one goroutine, there are no
+// per-level synchronization barriers; the only waits are the semaphore
+// acquisition when all workers are busy (which bounds live job memory) and
+// the drains at finalization points.
+const (
+	// asyncMinChunks is the minimum region width (in 32-byte chunks) worth
+	// handing to a background reduction; smaller regions reduce inline.
+	asyncMinChunks = 8192
+
+	// lazyFlushChunks is the pending-run width at which Collapse flushes
+	// deferred subtrees when async hashing is enabled. Runs this wide reduce
+	// in a single background job. With async hashing disabled, Collapse
+	// flushes on every call and the pending run stays at the cadence the
+	// caller collapses with.
+	lazyFlushChunks = 32768
+
+	// asyncActiveChunks is the active-region width at which Collapse runs
+	// progressive group finalization when async hashing is enabled.
+	// Deferring finalization gives element-root jobs time to complete in the
+	// background, so the drain at finalization rarely waits.
+	asyncActiveChunks = 131072
+)
+
+// asyncSem limits concurrent background reductions. A nil pointer means async
+// hashing is disabled. Slots are acquired before a job's input is copied, so
+// at most cap(sem) job input buffers are live at any moment.
+var asyncSem atomic.Pointer[chan struct{}]
+
+// EnableAsyncHashing enables background subtree reduction for all hashers
+// whose hash function is safe for concurrent use (hashers created via
+// NewHasherWithHashFn, including the FastHasherPool). At most workers
+// reductions run concurrently. workers <= 0 disables async hashing.
+//
+// Roots are unaffected: async and synchronous hashing produce identical
+// results. Peak buffer usage grows by up to a few megabytes per hasher
+// because deferred subtrees accumulate into wider runs before reduction.
+func EnableAsyncHashing(workers int) {
+	if workers <= 0 {
+		DisableAsyncHashing()
+		return
+	}
+	sem := make(chan struct{}, workers)
+	asyncSem.Store(&sem)
+}
+
+// DisableAsyncHashing turns background subtree reduction off. Reductions
+// already in flight complete independently; only new work is affected.
+func DisableAsyncHashing() {
+	asyncSem.Store(nil)
+}
+
+// asyncSlots returns the semaphore when async hashing is enabled and this
+// hasher's hash function may be called from other goroutines, nil otherwise.
+func (h *Hasher) asyncSlots() chan struct{} {
+	if !h.asyncSafe {
+		return nil
+	}
+	if sem := asyncSem.Load(); sem != nil {
+		return *sem
+	}
+	return nil
+}
+
+// hashJob is one background reduction. out is written before done closes.
+type hashJob struct {
+	out  []byte
+	done chan struct{}
+}
+
+// pendingJob tracks an in-flight job and the buffer offset its result
+// belongs at. The offset is stable while the job is outstanding: every path
+// that moves bytes at or below a hole drains first.
+type pendingJob struct {
+	job    *hashJob
+	dstOff int
+}
+
+// jobBufPool holds job input buffers. Buffers are returned by the worker
+// goroutine as soon as the reduction result is copied out, so pool residency
+// is bounded by the semaphore, not by drain timing.
+var jobBufPool = sync.Pool{New: func() any {
+	b := make([]byte, 0, lazyFlushChunks*32)
+	return &b
+}}
+
+// enqueueReduce copies buf[start:start+width*32] into a job buffer and
+// spawns a goroutine that reduces it pairwise, level by level, down to
+// outChunks chunks. The result is recorded for drainJobs to copy to
+// buf[dstOff:]. width and outChunks must be powers of two with
+// outChunks < width. Blocks while all worker slots are busy.
+func (h *Hasher) enqueueReduce(slots chan struct{}, start, width, outChunks, dstOff int) {
+	slots <- struct{}{}
+
+	bp, _ := jobBufPool.Get().(*[]byte)
+	if cap(*bp) < width*32 {
+		*bp = make([]byte, 0, width*32)
+	}
+	in := (*bp)[:width*32]
+	copy(in, h.buf[start:start+width*32])
+
+	job := &hashJob{
+		out:  make([]byte, outChunks*32),
+		done: make(chan struct{}),
+	}
+	h.pendingJobs = append(h.pendingJobs, pendingJob{job: job, dstOff: dstOff})
+
+	fn := h.hash
+	go func() {
+		for w := width; w > outChunks; w /= 2 {
+			_ = fn(in[:w/2*32], in[:w*32])
+		}
+		copy(job.out, in[:outChunks*32])
+		jobBufPool.Put(bp)
+		<-slots
+		close(job.done)
+	}()
+}
+
+// drainJobs waits for all outstanding reductions and writes their results
+// into the holes they were carved from. Must run before anything reads or
+// restructures a buffer region that may contain holes.
+func (h *Hasher) drainJobs() {
+	if len(h.pendingJobs) == 0 {
+		return
+	}
+	for i := range h.pendingJobs {
+		pj := &h.pendingJobs[i]
+		<-pj.job.done
+		if end := pj.dstOff + len(pj.job.out); end <= len(h.buf) {
+			copy(h.buf[pj.dstOff:end], pj.job.out)
+		}
+		h.pendingJobs[i] = pendingJob{}
+	}
+	h.pendingJobs = h.pendingJobs[:0]
+}
+
+// layerLeaves returns the number of leaves the layer has accumulated before
+// the current pending run: nodes tracked in counts contribute 2^depth leaves
+// each, and chunks not yet accounted (appended since the last state sync,
+// excluding the pending run itself) contribute one leaf each.
+func (h *Hasher) layerLeaves(layer *treeLayer, pendStart int) uint64 {
+	var leaves, accounted uint64
+	for d := 0; d <= layer.maxDepth; d++ {
+		leaves += uint64(layer.counts[d]) << uint(d)
+		accounted += uint64(layer.counts[d])
+	}
+	if chunks := uint64(pendStart-h.binaryRegionStart(layer)) / 32; chunks > accounted {
+		leaves += chunks - accounted
+	}
+	return leaves
+}
+
+// flushPendingAsyncRoot hands a complete power-of-two run of deferred
+// subtrees to a background job that reduces it to a single subtree root. The
+// run must be leaf-aligned in the layer's tree (the caller checks). A
+// one-chunk hole replaces the run and the completed subtree is recorded in
+// the layer's collapse state at depth log2(count) — the layer's leaves are
+// element roots, so the intra-element levels do not count.
+func (h *Hasher) flushPendingAsyncRoot(slots chan struct{}, layer *treeLayer, start, width, count int) {
+	h.enqueueReduce(slots, start, width, 1, start)
+	h.compactAsyncRun(start, width, 1)
+
+	d := 0
+	for c := count; c > 1; c >>= 1 {
+		d++
+	}
+	if !layer.collapsed {
+		layer.collapsed = true
+		layer.counts = [maxTreeDepth]uint32{}
+		layer.maxDepth = 0
+	}
+	layer.counts[d]++
+	if d > layer.maxDepth {
+		layer.maxDepth = d
+	}
+}
+
+// flushPendingAsyncRoots hands a run of deferred subtrees to a background
+// job that reduces it to one root per element. A count-chunk hole replaces
+// the run; the roots are plain depth-0 leaves, so the collapse state needs
+// no update (the next state sync accounts them).
+func (h *Hasher) flushPendingAsyncRoots(slots chan struct{}, start, width, count int) {
+	h.enqueueReduce(slots, start, width, count, start)
+	h.compactAsyncRun(start, width, count)
+}
+
+// compactAsyncRun shrinks a width-chunk run at start down to outChunks hole
+// chunks, moving any bytes appended after the run down to stay contiguous.
+func (h *Hasher) compactAsyncRun(start, width, outChunks int) {
+	runEnd := start + width*32
+	holeEnd := start + outChunks*32
+	if tail := len(h.buf) - runEnd; tail > 0 {
+		copy(h.buf[holeEnd:], h.buf[runEnd:])
+		h.buf = h.buf[:holeEnd+tail]
+	} else {
+		h.buf = h.buf[:holeEnd]
+	}
+}

--- a/hasher/async.go
+++ b/hasher/async.go
@@ -415,13 +415,28 @@ func (h *Hasher) flushPendingAsync(st *asyncShared, layer *treeLayer) bool {
 // precollapseProgressiveRun replaces cap-aligned spans of a progressive
 // layer's trailing depth-0 run with cap-depth nodes reduced in the
 // background, so groups wider than one job buffer are later consumed from a
-// handful of nodes instead of one oversized reduction. Only meaningful from
-// progressive level 8 up (the caller checks): every group in the active
-// region is then a multiple of the cap, so cap-aligned nodes never straddle
-// a group boundary. Reports whether jobs were emitted — the caller must
-// then leave the active region untouched for the round, because the node
-// holes are only stable while nothing consumes or compacts around them.
-func (h *Hasher) precollapseProgressiveRun(st *asyncShared, layer *treeLayer) bool {
+// handful of nodes instead of one oversized reduction. Progressive callers
+// may only use this from level 8 up: every group in the active region is
+// then a multiple of the cap, so cap-aligned nodes never straddle a group
+// boundary. Binary layers (raw packed lists and vectors) have no group
+// boundaries and use it at any size. Reports whether jobs were emitted —
+// the caller must then leave the region untouched for the round, because
+// the node holes are only stable while nothing consumes or compacts around
+// them.
+func (h *Hasher) precollapseCapRun(st *asyncShared, layer *treeLayer) bool {
+	// Account chunks appended since the last state sync. A layer that never
+	// collapsed carries stale counts from a previous scope in its reused
+	// slot, so its state is rebuilt from the buffer instead.
+	if layer.collapsed {
+		h.syncCollapseState(layer)
+	} else {
+		layer.counts = [maxTreeDepth]uint32{}
+		layer.maxDepth = 0
+		if chunks := (len(h.buf) - h.binaryRegionStart(layer)) / 32; chunks > 0 {
+			layer.counts[0] = uint32(chunks)
+		}
+	}
+
 	// Everything deeper than the run must itself be a cap-depth node: that
 	// guarantees the run starts cap-aligned, and it keeps the buffer's
 	// deepest-first node order intact when the new nodes are recorded at
@@ -433,7 +448,7 @@ func (h *Hasher) precollapseProgressiveRun(st *asyncShared, layer *treeLayer) bo
 		}
 	}
 	emitted := false
-	runStart := h.activeSubtreeStart(layer) + int(layer.counts[asyncCapDepth])*32
+	runStart := h.binaryRegionStart(layer) + int(layer.counts[asyncCapDepth])*32
 	for layer.counts[0] >= lazyFlushChunks {
 		h.enqueueReduce(st, runStart, lazyFlushChunks, 1, runStart)
 		h.compactAsyncRun(runStart, lazyFlushChunks, 1)

--- a/hasher/async.go
+++ b/hasher/async.go
@@ -198,8 +198,8 @@ func (h *Hasher) enqueueReduce(st *asyncShared, start, width, outChunks, dstOff 
 	slot.outLen = outChunks * 32
 	slot.tokened = tokened
 
-	if dstOff > h.jobMaxDst {
-		h.jobMaxDst = dstOff
+	if end := dstOff + outChunks*32; end > h.jobMaxEnd {
+		h.jobMaxEnd = end
 	}
 
 	ensureAsyncRunner(st)
@@ -276,15 +276,20 @@ func (h *Hasher) claimJobSlot(st *asyncShared) *asyncJob {
 	return slot
 }
 
-// drainOldestJob waits for the ring's oldest job, writes its result into the
-// hole it was carved from, and restores the job's free-list token if it
-// holds one: pre-sized buffers are returned for reuse, anything else becomes
-// a nil token. Tokenless buffers (taken when every token was held by other
-// hashers) are simply dropped.
-func (h *Hasher) drainOldestJob() {
+// finishOldestJob waits for the ring's oldest job, optionally copies its
+// result into the hole it was carved from, and restores the job's free-list
+// token if it holds one: pre-sized buffers are returned for reuse, anything
+// else becomes a nil token. Tokenless buffers (taken when every token was
+// held by other hashers) are simply dropped.
+func (h *Hasher) finishOldestJob(copyResult bool) {
 	slot := &h.jobRing[h.jobHead]
 	<-slot.done
-	if end := slot.dstOff + slot.outLen; end <= len(h.buf) {
+	if copyResult {
+		// The destination is expected to exist: every path that shrinks the
+		// buffer below a hole drains or discards first, so an out-of-range
+		// copy is an invariant violation and panics via the bounds check
+		// rather than silently producing a wrong root.
+		end := slot.dstOff + slot.outLen
 		copy(h.buf[slot.dstOff:end], slot.in[:slot.outLen])
 	}
 	if slot.tokened {
@@ -300,6 +305,12 @@ func (h *Hasher) drainOldestJob() {
 	h.jobCount--
 }
 
+// drainOldestJob waits for the ring's oldest job and writes its result into
+// the hole it was carved from.
+func (h *Hasher) drainOldestJob() {
+	h.finishOldestJob(true)
+}
+
 // drainJobs waits for all outstanding reductions and writes their results
 // into the holes they were carved from. Must run before anything reads or
 // restructures a buffer region that may contain holes.
@@ -307,16 +318,26 @@ func (h *Hasher) drainJobs() {
 	for h.jobCount > 0 {
 		h.drainOldestJob()
 	}
-	h.jobMaxDst = -1
+	h.jobMaxEnd = 0
+}
+
+// discardJobs awaits outstanding reductions and drops their results. This is
+// for abandoning a computation (Reset): the buffer regions the jobs were
+// destined for no longer exist.
+func (h *Hasher) discardJobs() {
+	for h.jobCount > 0 {
+		h.finishOldestJob(false)
+	}
+	h.jobMaxEnd = 0
 }
 
 // drainJobsFor drains outstanding reductions only when the region starting
-// at indx can overlap a hole. Holes only exist at or below the highest
-// outstanding job offset, so scopes that operate entirely above it — every
-// child scope opened after its parents' flushes — skip the wait and keep
-// the background reductions overlapped with the walk.
+// at indx can overlap a hole. Holes only exist below the highest outstanding
+// hole end, so scopes that operate entirely above it — every child scope
+// opened after its parents' flushes — skip the wait and keep the background
+// reductions overlapped with the walk.
 func (h *Hasher) drainJobsFor(indx int) {
-	if h.jobCount > 0 && indx <= h.jobMaxDst {
+	if h.jobCount > 0 && indx < h.jobMaxEnd {
 		h.drainJobs()
 	}
 }

--- a/hasher/async.go
+++ b/hasher/async.go
@@ -198,6 +198,10 @@ func (h *Hasher) enqueueReduce(st *asyncShared, start, width, outChunks, dstOff 
 	slot.outLen = outChunks * 32
 	slot.tokened = tokened
 
+	if dstOff > h.jobMaxDst {
+		h.jobMaxDst = dstOff
+	}
+
 	ensureAsyncRunner(st)
 	asyncHandoff <- slot
 }
@@ -302,6 +306,18 @@ func (h *Hasher) drainOldestJob() {
 func (h *Hasher) drainJobs() {
 	for h.jobCount > 0 {
 		h.drainOldestJob()
+	}
+	h.jobMaxDst = -1
+}
+
+// drainJobsFor drains outstanding reductions only when the region starting
+// at indx can overlap a hole. Holes only exist at or below the highest
+// outstanding job offset, so scopes that operate entirely above it — every
+// child scope opened after its parents' flushes — skip the wait and keep
+// the background reductions overlapped with the walk.
+func (h *Hasher) drainJobsFor(indx int) {
+	if h.jobCount > 0 && indx <= h.jobMaxDst {
+		h.drainJobs()
 	}
 }
 

--- a/hasher/async.go
+++ b/hasher/async.go
@@ -305,20 +305,27 @@ func (h *Hasher) drainJobs() {
 	}
 }
 
-// layerLeaves returns the number of leaves the layer has accumulated before
-// the current pending run: nodes tracked in counts contribute 2^depth leaves
-// each, and chunks not yet accounted (appended since the last state sync,
-// excluding the pending run itself) contribute one leaf each.
-func (h *Hasher) layerLeaves(layer *treeLayer, pendStart int) uint64 {
-	var leaves, accounted uint64
+// asyncRootCompatible reports whether a completed subtree node of nodeDepth
+// may be appended for the run starting at pendStart: every leaf before the
+// run must already be represented by nodes at least that deep. That both
+// keeps the buffer's deepest-first node order (which the depth-driven
+// collapse pairing depends on) and makes the run leaf-aligned for its node.
+// counts are only meaningful once the layer has collapsed — a reused layer
+// slot carries stale counts until then — so an uncollapsed layer is only
+// compatible while nothing precedes the run at all.
+func (h *Hasher) asyncRootCompatible(layer *treeLayer, pendStart, nodeDepth int) bool {
+	before := (pendStart - h.binaryRegionStart(layer)) / 32
+	if !layer.collapsed {
+		return before == 0
+	}
+	accounted := 0
 	for d := 0; d <= layer.maxDepth; d++ {
-		leaves += uint64(layer.counts[d]) << uint(d)
-		accounted += uint64(layer.counts[d])
+		if d < nodeDepth && layer.counts[d] != 0 {
+			return false
+		}
+		accounted += int(layer.counts[d])
 	}
-	if chunks := uint64(pendStart-h.binaryRegionStart(layer)) / 32; chunks > accounted {
-		leaves += chunks - accounted
-	}
-	return leaves
+	return before == accounted
 }
 
 // flushPendingAsync reduces the layer's deferred run in cap-sized background
@@ -329,10 +336,15 @@ func (h *Hasher) layerLeaves(layer *treeLayer, pendStart int) uint64 {
 // count. A progressive layer gets one root per element instead: group
 // boundaries are not aligned to run boundaries, so completed subtrees cannot
 // span them. Reports whether at least one job was emitted; if not (a binary
-// run that is not leaf-aligned), the caller reduces synchronously.
+// run whose node would not be compatible with what precedes it), the caller
+// reduces synchronously.
 func (h *Hasher) flushPendingAsync(st *asyncShared, layer *treeLayer) bool {
 	elem := layer.pendElemChunks
 	batchElems := lazyFlushChunks / elem
+	nodeDepth := 0
+	for c := batchElems; c > 1; c >>= 1 {
+		nodeDepth++
+	}
 	emitted := false
 	for layer.pendCount >= batchElems {
 		start := layer.pendStart
@@ -341,23 +353,19 @@ func (h *Hasher) flushPendingAsync(st *asyncShared, layer *treeLayer) bool {
 			h.compactAsyncRun(start, lazyFlushChunks, batchElems)
 			layer.pendStart = start + batchElems*32
 		} else {
-			if h.layerLeaves(layer, start)%uint64(batchElems) != 0 {
+			if !h.asyncRootCompatible(layer, start, nodeDepth) {
 				break
 			}
 			h.enqueueReduce(st, start, lazyFlushChunks, 1, start)
 			h.compactAsyncRun(start, lazyFlushChunks, 1)
-			d := 0
-			for c := batchElems; c > 1; c >>= 1 {
-				d++
-			}
 			if !layer.collapsed {
 				layer.collapsed = true
 				layer.counts = [maxTreeDepth]uint32{}
 				layer.maxDepth = 0
 			}
-			layer.counts[d]++
-			if d > layer.maxDepth {
-				layer.maxDepth = d
+			layer.counts[nodeDepth]++
+			if nodeDepth > layer.maxDepth {
+				layer.maxDepth = nodeDepth
 			}
 			layer.pendStart = start + 32
 		}

--- a/hasher/async.go
+++ b/hasher/async.go
@@ -4,7 +4,6 @@
 package hasher
 
 import (
-	"sync"
 	"sync/atomic"
 )
 
@@ -17,15 +16,24 @@ import (
 // the buffer whose reduction result has a known size: either a complete
 // aligned subtree (reduced to a single root) or a run of deferred element
 // subtrees (reduced to one root per element). The region's bytes are copied
-// into a pooled job buffer, a single-chunk (or per-element) hole is left in
-// the hasher's buffer, and a goroutine reduces the copy level by level with
-// wide hash calls. drainJobs fills the holes with the results and runs before
-// any operation that reads or restructures a region that may contain holes.
+// into an input buffer from a bounded free list, a single-chunk (or
+// per-element) hole is left in the hasher's buffer, and a goroutine reduces
+// the copy level by level with wide hash calls. The reduction result lands
+// at the front of the input buffer; the worker cannot write it into the
+// hasher's buffer directly because appends may reallocate the backing array
+// while the job runs — only the hole's offset is stable, not its address.
+// drainJobs copies the results into the holes and runs before any operation
+// that reads or restructures a region that may contain holes.
 //
-// Because each job is reduced sequentially inside one goroutine, there are no
-// per-level synchronization barriers; the only waits are the semaphore
-// acquisition when all workers are busy (which bounds live job memory) and
-// the drains at finalization points.
+// All per-job state lives in a fixed FIFO ring of slots owned by the hasher,
+// so steady-state hashing allocates nothing: slots and their done channels
+// are reused, input buffers cycle through the free list, and jobs are
+// spawned as plain method goroutines. A slot is occupied from enqueue until
+// drain and the ring drains its oldest entry when full, so outstanding jobs
+// are bounded by the ring size (twice the worker count). At most workers of
+// them are incomplete at any moment (the semaphore is held for the duration
+// of the reduction), which keeps the oldest entry of a full ring cheap to
+// wait on.
 const (
 	// asyncMinChunks is the minimum region width (in 32-byte chunks) worth
 	// handing to a background reduction; smaller regions reduce inline.
@@ -43,17 +51,38 @@ const (
 	// Deferring finalization gives element-root jobs time to complete in the
 	// background, so the drain at finalization rarely waits.
 	asyncActiveChunks = 131072
+
+	// asyncBufSize is the size of the pre-sized job input buffers in the
+	// free list. Jobs wider than this (large progressive groups) use a
+	// one-off allocation that is not retained.
+	asyncBufSize = lazyFlushChunks * 32
+
+	// asyncRingInline is the job-ring size served by the hasher's inline
+	// backing array; larger rings (workers > 8) allocate once.
+	asyncRingInline = 16
 )
 
-// asyncSem limits concurrent background reductions. A nil pointer means async
-// hashing is disabled. Slots are acquired before a job's input is copied, so
-// at most cap(sem) job input buffers are live at any moment.
-var asyncSem atomic.Pointer[chan struct{}]
+// asyncShared is the process-wide async hashing state. sem bounds concurrent
+// reductions; a slot is held from before the job input is copied until the
+// reduction finishes. bufs is a token free list with one token per job-ring
+// slot (twice the worker count): a token is either a reusable input buffer
+// or nil before the buffer is first materialized (or after an oversized
+// one-off was dropped), so job input memory is strictly bounded.
+type asyncShared struct {
+	sem  chan struct{}
+	bufs chan []byte
+}
+
+// asyncState points to the current shared state; nil means async hashing is
+// disabled. In-flight jobs keep a reference to the state they started with,
+// so reconfiguration never disturbs them.
+var asyncState atomic.Pointer[asyncShared]
 
 // EnableAsyncHashing enables background subtree reduction for all hashers
 // whose hash function is safe for concurrent use (hashers created via
 // NewHasherWithHashFn, including the FastHasherPool). At most workers
-// reductions run concurrently. workers <= 0 disables async hashing.
+// reductions run concurrently, and job input memory is bounded by twice
+// workers pre-sized buffers. workers <= 0 disables async hashing.
 //
 // Roots are unaffected: async and synchronous hashing produce identical
 // results. Peak buffer usage grows by up to a few megabytes per hasher
@@ -63,99 +92,163 @@ func EnableAsyncHashing(workers int) {
 		DisableAsyncHashing()
 		return
 	}
-	sem := make(chan struct{}, workers)
-	asyncSem.Store(&sem)
+	st := &asyncShared{
+		sem:  make(chan struct{}, workers),
+		bufs: make(chan []byte, 2*workers),
+	}
+	for range cap(st.bufs) {
+		st.bufs <- nil
+	}
+	asyncState.Store(st)
 }
 
 // DisableAsyncHashing turns background subtree reduction off. Reductions
 // already in flight complete independently; only new work is affected.
 func DisableAsyncHashing() {
-	asyncSem.Store(nil)
+	asyncState.Store(nil)
 }
 
-// asyncSlots returns the semaphore when async hashing is enabled and this
-// hasher's hash function may be called from other goroutines, nil otherwise.
-func (h *Hasher) asyncSlots() chan struct{} {
+// asyncShared returns the shared state when async hashing is enabled and
+// this hasher's hash function may be called from other goroutines, nil
+// otherwise.
+func (h *Hasher) asyncShared() *asyncShared {
 	if !h.asyncSafe {
 		return nil
 	}
-	if sem := asyncSem.Load(); sem != nil {
-		return *sem
-	}
-	return nil
+	return asyncState.Load()
 }
 
-// hashJob is one background reduction. out is written before done closes.
-type hashJob struct {
-	out  []byte
-	done chan struct{}
+// asyncJob is one job-ring slot. done is allocated once and reused across
+// jobs. in is the job's input buffer; after the done token arrived it holds
+// the reduction result in its first outLen bytes. tokened records whether
+// the job holds a free-list token to restore at drain.
+type asyncJob struct {
+	st      *asyncShared
+	in      []byte
+	done    chan struct{}
+	dstOff  int
+	outLen  int
+	tokened bool
 }
 
-// pendingJob tracks an in-flight job and the buffer offset its result
-// belongs at. The offset is stable while the job is outstanding: every path
-// that moves bytes at or below a hole drains first.
-type pendingJob struct {
-	job    *hashJob
-	dstOff int
-}
-
-// jobBufPool holds job input buffers. Buffers are returned by the worker
-// goroutine as soon as the reduction result is copied out, so pool residency
-// is bounded by the semaphore, not by drain timing.
-var jobBufPool = sync.Pool{New: func() any {
-	b := make([]byte, 0, lazyFlushChunks*32)
-	return &b
-}}
-
-// enqueueReduce copies buf[start:start+width*32] into a job buffer and
+// enqueueReduce copies buf[start:start+width*32] into an input buffer and
 // spawns a goroutine that reduces it pairwise, level by level, down to
-// outChunks chunks. The result is recorded for drainJobs to copy to
-// buf[dstOff:]. width and outChunks must be powers of two with
+// outChunks chunks. The claimed job-ring slot records where drainJobs must
+// copy the result. width and outChunks must be powers of two with
 // outChunks < width. Blocks while all worker slots are busy.
-func (h *Hasher) enqueueReduce(slots chan struct{}, start, width, outChunks, dstOff int) {
-	slots <- struct{}{}
+func (h *Hasher) enqueueReduce(st *asyncShared, start, width, outChunks, dstOff int) {
+	st.sem <- struct{}{}
 
-	bp, _ := jobBufPool.Get().(*[]byte)
-	if cap(*bp) < width*32 {
-		*bp = make([]byte, 0, width*32)
-	}
-	in := (*bp)[:width*32]
-	copy(in, h.buf[start:start+width*32])
+	need := width * 32
+	in, tokened := h.getJobBuf(st, need)
+	in = in[:need]
+	copy(in, h.buf[start:start+need])
 
-	job := &hashJob{
-		out:  make([]byte, outChunks*32),
-		done: make(chan struct{}),
-	}
-	h.pendingJobs = append(h.pendingJobs, pendingJob{job: job, dstOff: dstOff})
+	slot := h.claimJobSlot(st)
+	slot.st = st
+	slot.in = in
+	slot.dstOff = dstOff
+	slot.outLen = outChunks * 32
+	slot.tokened = tokened
 
-	fn := h.hash
-	go func() {
-		for w := width; w > outChunks; w /= 2 {
-			_ = fn(in[:w/2*32], in[:w*32])
+	go h.runAsyncJob(slot, width, outChunks)
+}
+
+// getJobBuf obtains a job input buffer of at least need bytes. It never
+// blocks on the free list — hashers share it, and blocking while every
+// hasher's tokens sit in completed-but-undrained jobs would deadlock.
+// Instead it drains this hasher's own oldest job to recover a token, and as
+// a last resort (all tokens held by other hashers) takes an untracked
+// one-off buffer. An undersized token (oversized job) is also swapped for a
+// one-off, with the token restored as nil at drain.
+func (h *Hasher) getJobBuf(st *asyncShared, need int) ([]byte, bool) {
+	for {
+		select {
+		case in := <-st.bufs:
+			if cap(in) >= need {
+				return in, true
+			}
+			// Unmaterialized or undersized token: allocate the pre-sized
+			// buffer so it joins the reuse cycle at drain. Oversized jobs
+			// get a one-off instead, restored as a nil token at drain.
+			return make([]byte, max(need, asyncBufSize)), true
+		default:
 		}
-		copy(job.out, in[:outChunks*32])
-		jobBufPool.Put(bp)
-		<-slots
-		close(job.done)
-	}()
+		if h.jobCount == 0 {
+			return make([]byte, need), false
+		}
+		h.drainOldestJob()
+	}
+}
+
+// claimJobSlot returns the next free ring slot, draining the oldest job
+// first when the ring is full. The ring is sized to twice the worker count
+// and only (re)sized while empty, so slot pointers held by running jobs
+// stay valid.
+func (h *Hasher) claimJobSlot(st *asyncShared) *asyncJob {
+	if h.jobCount == 0 && len(h.jobRing) < cap(st.bufs) {
+		if size := cap(st.bufs); size <= asyncRingInline {
+			h.jobRing = h.jobRingBuf[:size]
+		} else {
+			h.jobRing = make([]asyncJob, size)
+		}
+	}
+	for h.jobCount >= len(h.jobRing) {
+		h.drainOldestJob()
+	}
+	slot := &h.jobRing[(h.jobHead+h.jobCount)%len(h.jobRing)]
+	h.jobCount++
+	if slot.done == nil {
+		slot.done = make(chan struct{}, 1)
+	}
+	return slot
+}
+
+// runAsyncJob reduces the slot's input buffer level by level down to
+// outChunks chunks, releases the worker slot, and signals completion. The
+// result stays at the front of the input buffer for drainJobs to consume.
+// Runs as its own goroutine.
+func (h *Hasher) runAsyncJob(slot *asyncJob, width, outChunks int) {
+	fn := h.hash
+	in := slot.in
+	for w := width; w > outChunks; w /= 2 {
+		_ = fn(in[:w/2*32], in[:w*32])
+	}
+	<-slot.st.sem
+	slot.done <- struct{}{}
+}
+
+// drainOldestJob waits for the ring's oldest job, writes its result into the
+// hole it was carved from, and restores the job's free-list token if it
+// holds one: pre-sized buffers are returned for reuse, oversized one-offs
+// are replaced by a nil token. Tokenless buffers (taken when every token was
+// held by other hashers) are simply dropped.
+func (h *Hasher) drainOldestJob() {
+	slot := &h.jobRing[h.jobHead]
+	<-slot.done
+	if end := slot.dstOff + slot.outLen; end <= len(h.buf) {
+		copy(h.buf[slot.dstOff:end], slot.in[:slot.outLen])
+	}
+	if slot.tokened {
+		if cap(slot.in) == asyncBufSize {
+			slot.st.bufs <- slot.in[:0]
+		} else {
+			slot.st.bufs <- nil
+		}
+	}
+	slot.st = nil
+	slot.in = nil
+	h.jobHead = (h.jobHead + 1) % len(h.jobRing)
+	h.jobCount--
 }
 
 // drainJobs waits for all outstanding reductions and writes their results
 // into the holes they were carved from. Must run before anything reads or
 // restructures a buffer region that may contain holes.
 func (h *Hasher) drainJobs() {
-	if len(h.pendingJobs) == 0 {
-		return
+	for h.jobCount > 0 {
+		h.drainOldestJob()
 	}
-	for i := range h.pendingJobs {
-		pj := &h.pendingJobs[i]
-		<-pj.job.done
-		if end := pj.dstOff + len(pj.job.out); end <= len(h.buf) {
-			copy(h.buf[pj.dstOff:end], pj.job.out)
-		}
-		h.pendingJobs[i] = pendingJob{}
-	}
-	h.pendingJobs = h.pendingJobs[:0]
 }
 
 // layerLeaves returns the number of leaves the layer has accumulated before
@@ -180,8 +273,8 @@ func (h *Hasher) layerLeaves(layer *treeLayer, pendStart int) uint64 {
 // one-chunk hole replaces the run and the completed subtree is recorded in
 // the layer's collapse state at depth log2(count) — the layer's leaves are
 // element roots, so the intra-element levels do not count.
-func (h *Hasher) flushPendingAsyncRoot(slots chan struct{}, layer *treeLayer, start, width, count int) {
-	h.enqueueReduce(slots, start, width, 1, start)
+func (h *Hasher) flushPendingAsyncRoot(st *asyncShared, layer *treeLayer, start, width, count int) {
+	h.enqueueReduce(st, start, width, 1, start)
 	h.compactAsyncRun(start, width, 1)
 
 	d := 0
@@ -203,8 +296,8 @@ func (h *Hasher) flushPendingAsyncRoot(slots chan struct{}, layer *treeLayer, st
 // job that reduces it to one root per element. A count-chunk hole replaces
 // the run; the roots are plain depth-0 leaves, so the collapse state needs
 // no update (the next state sync accounts them).
-func (h *Hasher) flushPendingAsyncRoots(slots chan struct{}, start, width, count int) {
-	h.enqueueReduce(slots, start, width, count, start)
+func (h *Hasher) flushPendingAsyncRoots(st *asyncShared, start, width, count int) {
+	h.enqueueReduce(st, start, width, count, start)
 	h.compactAsyncRun(start, width, count)
 }
 

--- a/hasher/async_test.go
+++ b/hasher/async_test.go
@@ -130,6 +130,12 @@ func TestAsyncMatchesSync(t *testing.T) {
 		// Collapse never called: everything reduces at finalization.
 		asyncSequence{elemChunks: 8, n: 10000, cadence: 0, limit: 1 << 40},
 		asyncSequence{progressive: true, elemChunks: 8, n: 10000, cadence: 0},
+		// The partial last group left at finalization exceeds one job cap
+		// (60000 - 21845 > lazyFlushChunks), so the finalization rounds
+		// emit pre-collapse jobs whose holes the partial-remainder collapse
+		// must drain before reading.
+		asyncSequence{progressive: true, elemChunks: 8, n: 60000, cadence: 256},
+		asyncSequence{progressive: true, elemChunks: 4, n: 60000, cadence: 100},
 	)
 
 	for i, s := range cases {

--- a/hasher/async_test.go
+++ b/hasher/async_test.go
@@ -136,6 +136,10 @@ func TestAsyncMatchesSync(t *testing.T) {
 		// must drain before reading.
 		asyncSequence{progressive: true, elemChunks: 8, n: 60000, cadence: 256},
 		asyncSequence{progressive: true, elemChunks: 4, n: 60000, cadence: 100},
+		// A raw prefix that happens to be node-aligned: a completed subtree
+		// node must still not be appended behind plain depth-0 chunks — the
+		// whole run has to reduce synchronously.
+		asyncSequence{rawPrefix: 4096, elemChunks: 8, n: 8192, cadence: 256, limit: 1 << 40},
 	)
 
 	for i, s := range cases {
@@ -418,6 +422,64 @@ func TestAsyncLargeWorkerCount(t *testing.T) {
 	got := runAsyncSequence(t, hh, s, 61)
 	if got != want {
 		t.Errorf("large-worker async root %x != sync root %x", got, want)
+	}
+}
+
+// TestAsyncStaleSiblingLayer runs two sibling scopes at the same stack depth
+// inside one walk: the first (a collapsed raw-chunk vector of non-aligned
+// length) leaves stale counts in the reused layer slot, and the second (a
+// large deferred-element list) must not let that stale state influence its
+// async flush decisions. Mirrors a beacon state where historical roots
+// precede the validator registry.
+func TestAsyncStaleSiblingLayer(t *testing.T) {
+	defer DisableAsyncHashing()
+
+	run := func() [32]byte {
+		hh := NewHasherWithHashFn(hashtree.HashByteSlice)
+		hh.SetAsyncHashing(true)
+		rng := rand.New(rand.NewSource(23))
+		chunk := make([]byte, 32)
+
+		outer := hh.StartTree(sszutils.TreeTypeNone)
+
+		vec := hh.StartTree(sszutils.TreeTypeBinary)
+		for i := 0; i < 758; i++ {
+			rng.Read(chunk)
+			hh.Append(chunk)
+			if (i+1)%256 == 0 {
+				hh.Collapse()
+			}
+		}
+		hh.Merkleize(vec)
+
+		list := hh.StartTree(sszutils.TreeTypeBinary)
+		for i := 0; i < 12288; i++ {
+			ci := hh.StartTree(sszutils.TreeTypeNone)
+			for c := 0; c < 8; c++ {
+				rng.Read(chunk)
+				hh.Append(chunk)
+			}
+			hh.Merkleize(ci)
+			if (i+1)%256 == 0 {
+				hh.Collapse()
+			}
+		}
+		hh.MerkleizeWithMixin(list, 12288, 1<<40)
+
+		hh.Merkleize(outer)
+		root, err := hh.HashRoot()
+		if err != nil {
+			t.Fatalf("HashRoot: %v", err)
+		}
+		return root
+	}
+
+	DisableAsyncHashing()
+	want := run()
+	EnableAsyncHashing(4)
+	got := run()
+	if got != want {
+		t.Errorf("stale-sibling async root %x != sync root %x", got, want)
 	}
 }
 

--- a/hasher/async_test.go
+++ b/hasher/async_test.go
@@ -32,9 +32,12 @@ func (s asyncSequence) String() string {
 		s.progressive, s.activeFields, s.rawPrefix, s.elemChunks, s.n, s.cadence, s.limit)
 }
 
-// runAsyncSequence drives hh through the sequence and returns the root.
+// runAsyncSequence drives hh through the sequence and returns the root. The
+// hasher is gated into async hashing; whether reductions actually run in the
+// background is controlled by the process-wide Enable/Disable toggle.
 func runAsyncSequence(t *testing.T, hh *Hasher, s asyncSequence, seed int64) [32]byte {
 	t.Helper()
+	hh.SetAsyncHashing(true)
 	rng := rand.New(rand.NewSource(seed))
 	chunk := make([]byte, 32)
 
@@ -153,6 +156,7 @@ func TestAsyncTailAfterRun(t *testing.T) {
 
 	run := func() [32]byte {
 		hh := NewHasherWithHashFn(hashtree.HashByteSlice)
+		hh.SetAsyncHashing(true)
 		rng := rand.New(rand.NewSource(11))
 		chunk := make([]byte, 32)
 
@@ -193,6 +197,7 @@ func TestAsyncResetInFlight(t *testing.T) {
 	defer DisableAsyncHashing()
 
 	hh := NewHasherWithHashFn(hashtree.HashByteSlice)
+	hh.SetAsyncHashing(true)
 	rng := rand.New(rand.NewSource(7))
 	chunk := make([]byte, 32)
 
@@ -224,26 +229,44 @@ func TestAsyncResetInFlight(t *testing.T) {
 	}
 }
 
-// TestAsyncNativeHasherExcluded verifies that hashers wrapping a stateful
-// hash.Hash never take the async path (their hash function is not safe for
-// concurrent use) and still produce correct roots while async hashing is
-// enabled globally.
-func TestAsyncNativeHasherExcluded(t *testing.T) {
-	EnableAsyncHashing(4)
+// TestAsyncGate verifies the two-level gating: the process-wide toggle and
+// the per-hasher SetAsyncHashing flag must both be set, and Reset clears the
+// per-hasher flag so pooled hashers never leak the setting to another user.
+func TestAsyncGate(t *testing.T) {
 	defer DisableAsyncHashing()
 
-	hh := NewHasher()
+	hh := NewHasherWithHashFn(hashtree.HashByteSlice)
+	DisableAsyncHashing()
 	if hh.asyncShared() != nil {
-		t.Fatal("native-hash hasher must not participate in async hashing")
+		t.Error("hasher must be gated out by default")
+	}
+	hh.SetAsyncHashing(true)
+	if hh.asyncShared() != nil {
+		t.Error("process-wide disable must override the per-hasher gate")
+	}
+	EnableAsyncHashing(4)
+	if hh.asyncShared() == nil {
+		t.Error("gated-in hasher must see the shared state")
+	}
+	hh.SetAsyncHashing(false)
+	if hh.asyncShared() != nil {
+		t.Error("gated-out hasher must not see the shared state")
+	}
+	hh.SetAsyncHashing(true)
+	hh.Reset()
+	if hh.asyncShared() != nil {
+		t.Error("Reset must clear the per-hasher gate")
 	}
 
+	// An ungated hasher hashes synchronously while async is enabled, with
+	// identical roots.
 	s := asyncSequence{elemChunks: 8, n: 5000, cadence: 256, limit: 1 << 40}
 	got := runAsyncSequence(t, hh, s, 9)
 
 	DisableAsyncHashing()
 	want := runAsyncSequence(t, NewHasherWithHashFn(hashtree.HashByteSlice), s, 9)
 	if got != want {
-		t.Errorf("native root %x != reference root %x", got, want)
+		t.Errorf("root %x != reference root %x", got, want)
 	}
 }
 
@@ -337,7 +360,9 @@ func TestAsyncRingOverflow(t *testing.T) {
 
 	rng := rand.New(rand.NewSource(51))
 	parker := NewHasherWithHashFn(hashtree.HashByteSlice)
+	parker.SetAsyncHashing(true)
 	worker := NewHasherWithHashFn(hashtree.HashByteSlice)
+	worker.SetAsyncHashing(true)
 
 	// parker takes all 16 tokens and parks.
 	parker.StartTree(sszutils.TreeTypeBinary)
@@ -387,6 +412,72 @@ func TestAsyncLargeWorkerCount(t *testing.T) {
 	got := runAsyncSequence(t, hh, s, 61)
 	if got != want {
 		t.Errorf("large-worker async root %x != sync root %x", got, want)
+	}
+}
+
+// TestAsyncNativeFactory runs async hashing on the default native-hash
+// hasher: NativeHashWrapperFactory draws per-call instances from a pool, so
+// workers and walker never share hash state.
+func TestAsyncNativeFactory(t *testing.T) {
+	defer DisableAsyncHashing()
+
+	s := asyncSequence{elemChunks: 8, n: 12288, cadence: 256, limit: 1 << 40}
+
+	DisableAsyncHashing()
+	want := runAsyncSequence(t, NewHasher(), s, 13)
+
+	EnableAsyncHashing(4)
+	got := runAsyncSequence(t, NewHasher(), s, 13)
+	if got != want {
+		t.Errorf("native async root %x != sync root %x", got, want)
+	}
+
+	DisableAsyncHashing()
+	if ref := runAsyncSequence(t, NewHasherWithHashFn(hashtree.HashByteSlice), s, 13); ref != want {
+		t.Errorf("native root %x != fast root %x", want, ref)
+	}
+}
+
+// TestAsyncMidStreamEnable toggles the process-wide switch on in the middle
+// of a progressive computation: the synchronous rounds leave pair-compacted
+// nodes at depths the pre-collapse pass cannot mix with cap-depth nodes, so
+// its shape guard must reject the run and the root must still match.
+func TestAsyncMidStreamEnable(t *testing.T) {
+	defer DisableAsyncHashing()
+
+	const n = 400000
+	run := func(enableAt int) [32]byte {
+		hh := NewHasherWithHashFn(hashtree.HashByteSlice)
+		hh.SetAsyncHashing(true)
+		rng := rand.New(rand.NewSource(77))
+		chunk := make([]byte, 32)
+
+		idx := hh.StartTree(sszutils.TreeTypeProgressive)
+		for i := 0; i < n; i++ {
+			rng.Read(chunk)
+			hh.Append(chunk)
+			if (i+1)%64 == 0 {
+				hh.Collapse()
+			}
+			if i == enableAt {
+				EnableAsyncHashing(4)
+			}
+		}
+		hh.MerkleizeProgressiveWithMixin(idx, n)
+		root, err := hh.HashRoot()
+		if err != nil {
+			t.Fatalf("HashRoot: %v", err)
+		}
+		hh.Reset()
+		return root
+	}
+
+	DisableAsyncHashing()
+	want := run(-1)
+	DisableAsyncHashing()
+	got := run(200000)
+	if got != want {
+		t.Errorf("mid-stream enable root %x != sync root %x", got, want)
 	}
 }
 

--- a/hasher/async_test.go
+++ b/hasher/async_test.go
@@ -483,6 +483,50 @@ func TestAsyncStaleSiblingLayer(t *testing.T) {
 	}
 }
 
+// TestAsyncLegacyIndexDriven drives scopes the way fastssz-generated code
+// does — Index/Merkleize with no Collapse hints — and verifies the deferral
+// path batches and self-flushes those runs with identical roots in both
+// modes, matching the StartTree-driven root.
+func TestAsyncLegacyIndexDriven(t *testing.T) {
+	defer DisableAsyncHashing()
+
+	const n = 20000
+	legacy := func() [32]byte {
+		hh := NewHasherWithHashFn(hashtree.HashByteSlice)
+		hh.SetAsyncHashing(true)
+		rng := rand.New(rand.NewSource(29))
+		chunk := make([]byte, 32)
+
+		idx := hh.Index()
+		for i := 0; i < n; i++ {
+			ci := hh.Index()
+			for c := 0; c < 8; c++ {
+				rng.Read(chunk)
+				hh.Append(chunk)
+			}
+			hh.Merkleize(ci)
+		}
+		hh.MerkleizeWithMixin(idx, n, 1<<40)
+		root, err := hh.HashRoot()
+		if err != nil {
+			t.Fatalf("HashRoot: %v", err)
+		}
+		return root
+	}
+
+	DisableAsyncHashing()
+	want := legacy()
+	s := asyncSequence{elemChunks: 8, n: n, cadence: 256, limit: 1 << 40}
+	if ref := runAsyncSequence(t, NewHasherWithHashFn(hashtree.HashByteSlice), s, 29); ref != want {
+		t.Errorf("legacy sync root %x != StartTree-driven root %x", want, ref)
+	}
+
+	EnableAsyncHashing(4)
+	if got := legacy(); got != want {
+		t.Errorf("legacy async root %x != sync root %x", got, want)
+	}
+}
+
 // TestAsyncNativeFactory runs async hashing on the default native-hash
 // hasher: NativeHashWrapperFactory draws per-call instances from a pool, so
 // workers and walker never share hash state.

--- a/hasher/async_test.go
+++ b/hasher/async_test.go
@@ -4,6 +4,7 @@
 package hasher
 
 import (
+	"bytes"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -481,6 +482,66 @@ func TestAsyncStaleSiblingLayer(t *testing.T) {
 	if got != want {
 		t.Errorf("stale-sibling async root %x != sync root %x", got, want)
 	}
+}
+
+// TestAsyncAccessorsDrain covers the accessor boundary: after an async flush
+// compacts a run to a single placeholder chunk, a mid-scope HashRoot must
+// not mistake the 32-byte buffer for a finished computation, and Hash must
+// never expose unfilled hole bytes.
+func TestAsyncAccessorsDrain(t *testing.T) {
+	EnableAsyncHashing(4)
+	defer DisableAsyncHashing()
+
+	hh := NewHasherWithHashFn(hashtree.HashByteSlice)
+	hh.SetAsyncHashing(true)
+	rng := rand.New(rand.NewSource(37))
+	chunk := make([]byte, 32)
+
+	elems := make([][]byte, 4096)
+	idx := hh.Index()
+	for i := range elems {
+		ci := hh.Index()
+		elems[i] = make([]byte, 0, 8*32)
+		for c := 0; c < 8; c++ {
+			rng.Read(chunk)
+			elems[i] = append(elems[i], chunk...)
+			hh.Append(chunk)
+		}
+		hh.Merkleize(ci)
+	}
+	if hh.jobCount == 0 {
+		t.Fatal("expected an async reduction in flight")
+	}
+
+	// Mid-scope: the buffer holds exactly one placeholder chunk, but the
+	// computation is not finished — HashRoot must refuse.
+	if _, err := hh.HashRoot(); err == nil {
+		t.Error("HashRoot must reject unfinished scopes")
+	}
+
+	// Hash drains before reading, so it returns the completed subtree root,
+	// not the stale first chunk of the reduced run.
+	got := make([]byte, 32)
+	copy(got, hh.Hash())
+
+	ref := NewHasherWithHashFn(hashtree.HashByteSlice)
+	refIdx := ref.StartTree(sszutils.TreeTypeBinary)
+	for _, e := range elems {
+		ci := ref.StartTree(sszutils.TreeTypeNone)
+		ref.Append(e)
+		ref.Merkleize(ci)
+	}
+	ref.Merkleize(refIdx)
+	if !bytes.Equal(got, ref.Hash()) {
+		t.Errorf("mid-scope Hash %x != subtree root %x", got, ref.Hash())
+	}
+
+	// Finishing the scope still yields a valid root.
+	hh.MerkleizeWithMixin(idx, 4096, 1<<40)
+	if _, err := hh.HashRoot(); err != nil {
+		t.Errorf("finished HashRoot: %v", err)
+	}
+	hh.Reset()
 }
 
 // TestAsyncLegacyIndexDriven drives scopes the way fastssz-generated code

--- a/hasher/async_test.go
+++ b/hasher/async_test.go
@@ -1,0 +1,297 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+
+package hasher
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	hashtree "github.com/pk910/hashtree-bindings"
+
+	"github.com/pk910/dynamic-ssz/sszutils"
+)
+
+// asyncSequence describes one engine-style hashing sequence: a list of
+// uniform container elements (elemChunks each), optionally preceded by raw
+// chunks appended directly into the list scope, closed with the given
+// merkleization. It mirrors what the reflection and codegen engines emit.
+type asyncSequence struct {
+	progressive  bool
+	activeFields bool // progressive container closed with active-fields mixin
+	rawPrefix    int  // raw chunks appended before the first element
+	elemChunks   int  // chunks per element (0 = raw chunks instead of elements)
+	n            int  // element count (or raw chunk count when elemChunks==0)
+	cadence      int  // Collapse() every cadence elements; 0 = never
+	limit        uint64
+}
+
+func (s asyncSequence) String() string {
+	return fmt.Sprintf("prog=%v af=%v raw=%d elem=%d n=%d cadence=%d limit=%d",
+		s.progressive, s.activeFields, s.rawPrefix, s.elemChunks, s.n, s.cadence, s.limit)
+}
+
+// runAsyncSequence drives hh through the sequence and returns the root.
+func runAsyncSequence(t *testing.T, hh *Hasher, s asyncSequence, seed int64) [32]byte {
+	t.Helper()
+	rng := rand.New(rand.NewSource(seed))
+	chunk := make([]byte, 32)
+
+	treeType := sszutils.TreeTypeBinary
+	if s.progressive || s.activeFields {
+		treeType = sszutils.TreeTypeProgressive
+	}
+	idx := hh.StartTree(treeType)
+
+	for i := 0; i < s.rawPrefix; i++ {
+		rng.Read(chunk)
+		hh.Append(chunk)
+	}
+	for i := 0; i < s.n; i++ {
+		if s.elemChunks == 0 {
+			rng.Read(chunk)
+			hh.Append(chunk)
+		} else {
+			ci := hh.StartTree(sszutils.TreeTypeNone)
+			for c := 0; c < s.elemChunks; c++ {
+				rng.Read(chunk)
+				hh.Append(chunk)
+			}
+			hh.Merkleize(ci)
+		}
+		if s.cadence > 0 && (i+1)%s.cadence == 0 {
+			hh.Collapse()
+		}
+	}
+
+	switch {
+	case s.activeFields:
+		hh.MerkleizeProgressiveWithActiveFields(idx, []byte{0xff, 0xff})
+	case s.progressive:
+		hh.MerkleizeProgressiveWithMixin(idx, uint64(s.n))
+	default:
+		hh.MerkleizeWithMixin(idx, uint64(s.n), s.limit)
+	}
+
+	root, err := hh.HashRoot()
+	if err != nil {
+		t.Fatalf("%s: HashRoot: %v", s, err)
+	}
+	hh.Reset()
+	return root
+}
+
+// TestAsyncMatchesSync verifies that background reduction produces exactly
+// the roots the synchronous path produces, across list kinds, element
+// widths, batch and progressive-group boundaries, and collapse cadences.
+func TestAsyncMatchesSync(t *testing.T) {
+	defer DisableAsyncHashing()
+
+	cases := make([]asyncSequence, 0, 170)
+	for _, prog := range []bool{false, true} {
+		for _, elemChunks := range []int{8, 4, 2} {
+			for _, n := range []int{0, 1, 255, 4095, 4096, 4097, 5460, 5461, 5462,
+				8192, 16384, 21845, 50000} {
+				for _, cadence := range []int{256, 100} {
+					cases = append(cases, asyncSequence{
+						progressive: prog,
+						elemChunks:  elemChunks,
+						n:           n,
+						cadence:     cadence,
+						limit:       1 << 40,
+					})
+				}
+			}
+		}
+		// Raw packed chunks (uint64/byte lists): no deferred runs, but the
+		// progressive variant exercises deferred group finalization and
+		// background group reductions.
+		for _, n := range []int{4096, 21845, 87381, 200000} {
+			cases = append(cases, asyncSequence{
+				progressive: prog,
+				n:           n,
+				cadence:     64,
+				limit:       1 << 40,
+			})
+		}
+	}
+	// Raw chunks appended before the first element break run alignment in
+	// the layer's leaf space; the async root flush must fall back to the
+	// synchronous path for correctness.
+	cases = append(cases,
+		asyncSequence{rawPrefix: 3, elemChunks: 8, n: 8192, cadence: 256, limit: 1 << 40},
+		asyncSequence{progressive: true, rawPrefix: 3, elemChunks: 8, n: 8192, cadence: 256, limit: 1 << 40},
+		// Progressive container with an active-fields mixin.
+		asyncSequence{activeFields: true, elemChunks: 4, n: 12000, cadence: 256},
+		// Collapse never called: everything reduces at finalization.
+		asyncSequence{elemChunks: 8, n: 10000, cadence: 0, limit: 1 << 40},
+		asyncSequence{progressive: true, elemChunks: 8, n: 10000, cadence: 0},
+	)
+
+	for i, s := range cases {
+		seed := int64(i + 1)
+
+		DisableAsyncHashing()
+		hh := NewHasherWithHashFn(hashtree.HashByteSlice)
+		want := runAsyncSequence(t, hh, s, seed)
+
+		EnableAsyncHashing(4)
+		got := runAsyncSequence(t, hh, s, seed)
+
+		if got != want {
+			t.Errorf("%s: async root %x != sync root %x", s, got, want)
+		}
+	}
+}
+
+// TestAsyncTailAfterRun appends a raw chunk after the deferred run before
+// Collapse fires, so the async compaction has to move trailing bytes down
+// behind the hole.
+func TestAsyncTailAfterRun(t *testing.T) {
+	defer DisableAsyncHashing()
+
+	run := func() [32]byte {
+		hh := NewHasherWithHashFn(hashtree.HashByteSlice)
+		rng := rand.New(rand.NewSource(11))
+		chunk := make([]byte, 32)
+
+		idx := hh.StartTree(sszutils.TreeTypeBinary)
+		for i := 0; i < 4096; i++ {
+			ci := hh.StartTree(sszutils.TreeTypeNone)
+			for c := 0; c < 8; c++ {
+				rng.Read(chunk)
+				hh.Append(chunk)
+			}
+			hh.Merkleize(ci)
+		}
+		rng.Read(chunk)
+		hh.Append(chunk)
+		hh.Collapse()
+		hh.MerkleizeWithMixin(idx, 4097, 1<<40)
+		root, err := hh.HashRoot()
+		if err != nil {
+			t.Fatalf("HashRoot: %v", err)
+		}
+		return root
+	}
+
+	DisableAsyncHashing()
+	want := run()
+	EnableAsyncHashing(4)
+	got := run()
+	if got != want {
+		t.Errorf("async root %x != sync root %x", got, want)
+	}
+}
+
+// TestAsyncResetInFlight resets a hasher while background reductions are
+// outstanding and verifies it is reusable and leaks nothing into the next
+// computation.
+func TestAsyncResetInFlight(t *testing.T) {
+	EnableAsyncHashing(4)
+	defer DisableAsyncHashing()
+
+	hh := NewHasherWithHashFn(hashtree.HashByteSlice)
+	rng := rand.New(rand.NewSource(7))
+	chunk := make([]byte, 32)
+
+	hh.StartTree(sszutils.TreeTypeBinary)
+	for i := 0; i < 5000; i++ {
+		ci := hh.StartTree(sszutils.TreeTypeNone)
+		for c := 0; c < 8; c++ {
+			rng.Read(chunk)
+			hh.Append(chunk)
+		}
+		hh.Merkleize(ci)
+		if (i+1)%256 == 0 {
+			hh.Collapse()
+		}
+	}
+	// Abandon the computation with jobs likely in flight.
+	hh.Reset()
+	if len(hh.pendingJobs) != 0 {
+		t.Fatalf("pendingJobs not drained by Reset: %d", len(hh.pendingJobs))
+	}
+
+	s := asyncSequence{elemChunks: 8, n: 8192, cadence: 256, limit: 1 << 40}
+	got := runAsyncSequence(t, hh, s, 42)
+
+	DisableAsyncHashing()
+	want := runAsyncSequence(t, NewHasherWithHashFn(hashtree.HashByteSlice), s, 42)
+	if got != want {
+		t.Errorf("root after in-flight Reset %x != sync root %x", got, want)
+	}
+}
+
+// TestAsyncNativeHasherExcluded verifies that hashers wrapping a stateful
+// hash.Hash never take the async path (their hash function is not safe for
+// concurrent use) and still produce correct roots while async hashing is
+// enabled globally.
+func TestAsyncNativeHasherExcluded(t *testing.T) {
+	EnableAsyncHashing(4)
+	defer DisableAsyncHashing()
+
+	hh := NewHasher()
+	if hh.asyncSlots() != nil {
+		t.Fatal("native-hash hasher must not participate in async hashing")
+	}
+
+	s := asyncSequence{elemChunks: 8, n: 5000, cadence: 256, limit: 1 << 40}
+	got := runAsyncSequence(t, hh, s, 9)
+
+	DisableAsyncHashing()
+	want := runAsyncSequence(t, NewHasherWithHashFn(hashtree.HashByteSlice), s, 9)
+	if got != want {
+		t.Errorf("native root %x != reference root %x", got, want)
+	}
+}
+
+// TestAsyncEnableDisable covers the toggle edge cases.
+func TestAsyncEnableDisable(t *testing.T) {
+	defer DisableAsyncHashing()
+
+	EnableAsyncHashing(0)
+	if asyncSem.Load() != nil {
+		t.Error("EnableAsyncHashing(0) must disable async hashing")
+	}
+	EnableAsyncHashing(-1)
+	if asyncSem.Load() != nil {
+		t.Error("EnableAsyncHashing(-1) must disable async hashing")
+	}
+	EnableAsyncHashing(2)
+	if sem := asyncSem.Load(); sem == nil || cap(*sem) != 2 {
+		t.Error("EnableAsyncHashing(2) must install a 2-slot limiter")
+	}
+	DisableAsyncHashing()
+	if asyncSem.Load() != nil {
+		t.Error("DisableAsyncHashing must remove the limiter")
+	}
+}
+
+// TestAsyncConcurrentHashers runs several hashers concurrently with async
+// hashing enabled, sharing the global worker limit.
+func TestAsyncConcurrentHashers(t *testing.T) {
+	EnableAsyncHashing(4)
+	defer DisableAsyncHashing()
+
+	s := asyncSequence{progressive: true, elemChunks: 8, n: 21845, cadence: 256}
+
+	DisableAsyncHashing()
+	want := runAsyncSequence(t, NewHasherWithHashFn(hashtree.HashByteSlice), s, 5)
+	EnableAsyncHashing(4)
+
+	done := make(chan [32]byte, 8)
+	for i := 0; i < 8; i++ {
+		go func() {
+			hh := FastHasherPool.Get()
+			defer FastHasherPool.Put(hh)
+			done <- runAsyncSequence(t, hh, s, 5)
+		}()
+	}
+	for i := 0; i < 8; i++ {
+		if got := <-done; got != want {
+			t.Errorf("concurrent hasher root %x != sync root %x", got, want)
+		}
+	}
+}

--- a/hasher/async_test.go
+++ b/hasher/async_test.go
@@ -210,8 +210,8 @@ func TestAsyncResetInFlight(t *testing.T) {
 	}
 	// Abandon the computation with jobs likely in flight.
 	hh.Reset()
-	if len(hh.pendingJobs) != 0 {
-		t.Fatalf("pendingJobs not drained by Reset: %d", len(hh.pendingJobs))
+	if hh.jobCount != 0 {
+		t.Fatalf("job ring not drained by Reset: %d", hh.jobCount)
 	}
 
 	s := asyncSequence{elemChunks: 8, n: 8192, cadence: 256, limit: 1 << 40}
@@ -233,7 +233,7 @@ func TestAsyncNativeHasherExcluded(t *testing.T) {
 	defer DisableAsyncHashing()
 
 	hh := NewHasher()
-	if hh.asyncSlots() != nil {
+	if hh.asyncShared() != nil {
 		t.Fatal("native-hash hasher must not participate in async hashing")
 	}
 
@@ -252,20 +252,141 @@ func TestAsyncEnableDisable(t *testing.T) {
 	defer DisableAsyncHashing()
 
 	EnableAsyncHashing(0)
-	if asyncSem.Load() != nil {
+	if asyncState.Load() != nil {
 		t.Error("EnableAsyncHashing(0) must disable async hashing")
 	}
 	EnableAsyncHashing(-1)
-	if asyncSem.Load() != nil {
+	if asyncState.Load() != nil {
 		t.Error("EnableAsyncHashing(-1) must disable async hashing")
 	}
 	EnableAsyncHashing(2)
-	if sem := asyncSem.Load(); sem == nil || cap(*sem) != 2 {
-		t.Error("EnableAsyncHashing(2) must install a 2-slot limiter")
+	if st := asyncState.Load(); st == nil || cap(st.sem) != 2 || cap(st.bufs) != 4 {
+		t.Error("EnableAsyncHashing(2) must install a 2-worker limiter with 4 buffer tokens")
 	}
 	DisableAsyncHashing()
-	if asyncSem.Load() != nil {
+	if asyncState.Load() != nil {
 		t.Error("DisableAsyncHashing must remove the limiter")
+	}
+}
+
+// TestAsyncRingFull runs enough flushes past a tiny worker limit that the
+// job ring fills and enqueueing drains the oldest job to reuse its slot.
+func TestAsyncRingFull(t *testing.T) {
+	defer DisableAsyncHashing()
+
+	s := asyncSequence{elemChunks: 8, n: 40960, cadence: 256, limit: 1 << 40}
+
+	DisableAsyncHashing()
+	want := runAsyncSequence(t, NewHasherWithHashFn(hashtree.HashByteSlice), s, 21)
+
+	EnableAsyncHashing(1)
+	hh := NewHasherWithHashFn(hashtree.HashByteSlice)
+	got := runAsyncSequence(t, hh, s, 21)
+	if got != want {
+		t.Errorf("ring-full async root %x != sync root %x", got, want)
+	}
+}
+
+// TestAsyncReconfigure shrinks the worker count between computations, so a
+// hasher whose ring was sized for the larger configuration must respect the
+// smaller free list of the new shared state.
+func TestAsyncReconfigure(t *testing.T) {
+	defer DisableAsyncHashing()
+
+	s := asyncSequence{elemChunks: 8, n: 40960, cadence: 256, limit: 1 << 40}
+
+	DisableAsyncHashing()
+	want := runAsyncSequence(t, NewHasherWithHashFn(hashtree.HashByteSlice), s, 33)
+
+	EnableAsyncHashing(8)
+	hh := NewHasherWithHashFn(hashtree.HashByteSlice)
+	if got := runAsyncSequence(t, hh, s, 33); got != want {
+		t.Errorf("root with 8 workers %x != sync root %x", got, want)
+	}
+	EnableAsyncHashing(1)
+	if got := runAsyncSequence(t, hh, s, 33); got != want {
+		t.Errorf("root after shrink to 1 worker %x != sync root %x", got, want)
+	}
+}
+
+// driveFlushes drives hh through count async flushes of 4096 8-chunk
+// elements each inside an open binary list scope, without finalizing.
+func driveFlushes(hh *Hasher, rng *rand.Rand, count int) {
+	chunk := make([]byte, 32)
+	for i := 0; i < count*4096; i++ {
+		ci := hh.StartTree(sszutils.TreeTypeNone)
+		for c := 0; c < 8; c++ {
+			rng.Read(chunk)
+			hh.Append(chunk)
+		}
+		hh.Merkleize(ci)
+		if (i+1)%256 == 0 {
+			hh.Collapse()
+		}
+	}
+}
+
+// TestAsyncRingOverflow drives a hasher into a full ring that still finds a
+// free token (possible when a tokenless job sits under tokened ones), so
+// claiming the next slot has to drain the oldest job for ring space rather
+// than for a token. The token distribution is orchestrated through a second
+// hasher that parks while holding tokens.
+func TestAsyncRingOverflow(t *testing.T) {
+	EnableAsyncHashing(8) // ring and token count: 16
+	defer DisableAsyncHashing()
+
+	rng := rand.New(rand.NewSource(51))
+	parker := NewHasherWithHashFn(hashtree.HashByteSlice)
+	worker := NewHasherWithHashFn(hashtree.HashByteSlice)
+
+	// parker takes all 16 tokens and parks.
+	parker.StartTree(sszutils.TreeTypeBinary)
+	driveFlushes(parker, rng, 16)
+
+	// worker's first job finds no token: tokenless path.
+	worker.StartTree(sszutils.TreeTypeBinary)
+	driveFlushes(worker, rng, 1)
+
+	// 15 tokens come free; worker stacks 15 tokened jobs on the tokenless
+	// one, filling its ring.
+	for i := 0; i < 15; i++ {
+		parker.drainOldestJob()
+	}
+	driveFlushes(worker, rng, 15)
+	if worker.jobCount != 16 {
+		t.Fatalf("worker ring not full: %d", worker.jobCount)
+	}
+
+	// One more free token: the next enqueue gets it on the first try with a
+	// full ring, forcing the ring-space drain in claimJobSlot.
+	parker.drainOldestJob()
+	driveFlushes(worker, rng, 1)
+
+	parker.Reset()
+	worker.Reset()
+	if parker.jobCount != 0 || worker.jobCount != 0 {
+		t.Fatalf("rings not drained: parker=%d worker=%d", parker.jobCount, worker.jobCount)
+	}
+}
+
+// TestAsyncLargeWorkerCount exercises the ring allocation beyond the inline
+// backing array.
+func TestAsyncLargeWorkerCount(t *testing.T) {
+	defer DisableAsyncHashing()
+
+	s := asyncSequence{elemChunks: 8, n: 40960, cadence: 256, limit: 1 << 40}
+
+	DisableAsyncHashing()
+	want := runAsyncSequence(t, NewHasherWithHashFn(hashtree.HashByteSlice), s, 61)
+
+	EnableAsyncHashing(9) // ring size 18 > asyncRingInline
+	hh := NewHasherWithHashFn(hashtree.HashByteSlice)
+	if len(hh.jobRingBuf) >= 18 {
+		t.Fatal("test requires ring larger than the inline backing")
+	}
+	got := runAsyncSequence(t, hh, s, 61)
+	if got != want {
+		t.Errorf("large-worker async root %x != sync root %x", got, want)
 	}
 }
 

--- a/hasher/async_test.go
+++ b/hasher/async_test.go
@@ -94,7 +94,7 @@ func TestAsyncMatchesSync(t *testing.T) {
 
 	cases := make([]asyncSequence, 0, 170)
 	for _, prog := range []bool{false, true} {
-		for _, elemChunks := range []int{8, 4, 2} {
+		for _, elemChunks := range []int{8, 4, 2, 3, 5, 7, 12} {
 			for _, n := range []int{0, 1, 255, 4095, 4096, 4097, 5460, 5461, 5462,
 				8192, 16384, 21845, 50000} {
 				for _, cadence := range []int{256, 100} {

--- a/hasher/async_test.go
+++ b/hasher/async_test.go
@@ -51,6 +51,9 @@ func runAsyncSequence(t *testing.T, hh *Hasher, s asyncSequence, seed int64) [32
 	for i := 0; i < s.rawPrefix; i++ {
 		rng.Read(chunk)
 		hh.Append(chunk)
+		if s.cadence > 0 && (i+1)%s.cadence == 0 {
+			hh.Collapse()
+		}
 	}
 	for i := 0; i < s.n; i++ {
 		if s.elemChunks == 0 {
@@ -141,6 +144,17 @@ func TestAsyncMatchesSync(t *testing.T) {
 		// node must still not be appended behind plain depth-0 chunks — the
 		// whole run has to reduce synchronously.
 		asyncSequence{rawPrefix: 4096, elemChunks: 8, n: 8192, cadence: 256, limit: 1 << 40},
+		// Element sizes outside the deferral bounds: a single-chunk scope is
+		// below the two-chunk minimum and a 257-chunk scope exceeds
+		// incrementalBatchSize, so both merkleize immediately instead of
+		// joining a deferred run.
+		asyncSequence{elemChunks: 1, n: 300, cadence: 64, limit: 1 << 40},
+		asyncSequence{elemChunks: 257, n: 300, cadence: 64, limit: 1 << 40},
+		// A raw prefix wide enough that its collapse emits a cap-depth node
+		// and leaves depth-0 chunks in front of the element run: the run's
+		// completed-subtree node is incompatible with those shallower leaves,
+		// so the async flush must reject it and reduce synchronously.
+		asyncSequence{rawPrefix: 33024, elemChunks: 8, n: 4200, cadence: 256, limit: 1 << 40},
 	)
 
 	for i, s := range cases {
@@ -301,6 +315,116 @@ func TestAsyncEnableDisable(t *testing.T) {
 	if asyncState.Load() != nil {
 		t.Error("DisableAsyncHashing must remove the limiter")
 	}
+
+	// Worker-limit backstop: occupy every runner with a blocking job so none
+	// is parked idle, then enable with a worker limit the pool has already
+	// reached — no additional runner may spawn.
+	release := make(chan struct{})
+	started := make(chan struct{})
+	blockFn := func(dst []byte, input []byte) error {
+		started <- struct{}{}
+		<-release
+		return nil
+	}
+	EnableAsyncHashing(int(asyncRunners.Load()) + 8)
+	st := asyncState.Load()
+	jobs := make([]*asyncJob, 0, asyncRunners.Load())
+	for int64(len(jobs)) < asyncRunners.Load() {
+		st.sem <- struct{}{}
+		job := &asyncJob{st: st, fn: blockFn, in: make([]byte, 64), outLen: 32,
+			done: make(chan struct{}, 1)}
+		asyncHandoff <- job
+		<-started
+		jobs = append(jobs, job)
+	}
+	runners := asyncRunners.Load()
+	EnableAsyncHashing(1)
+	if got := asyncRunners.Load(); got != runners {
+		t.Errorf("runner spawned past the worker limit: %d != %d", got, runners)
+	}
+	close(release)
+	for _, job := range jobs {
+		<-job.done
+	}
+}
+
+// TestAsyncCollapseSubCapRemainder drives Collapse over deferred runs wider
+// than one job cap but not a multiple of it, so the capped async flush
+// leaves a sub-cap remainder pending: a binary layer keeps the remainder
+// pending for the next round, while a progressive layer reduces it
+// synchronously before group finalization. The runs are registered on the
+// layer directly, mirroring the state the Merkleize deferral path builds —
+// that path self-flushes at exactly the cap, so it never presents an
+// over-cap run to Collapse itself.
+func TestAsyncCollapseSubCapRemainder(t *testing.T) {
+	defer DisableAsyncHashing()
+
+	registerRun := func(hh *Hasher, rng *rand.Rand, idx, elemChunks, n int) {
+		chunk := make([]byte, 32)
+		for i := 0; i < n*elemChunks; i++ {
+			rng.Read(chunk)
+			hh.Append(chunk)
+		}
+		layer := &hh.layers[hh.layerCount]
+		layer.pendStart = idx
+		layer.pendElemChunks = elemChunks
+		layer.pendCount = n
+	}
+
+	t.Run("binary", func(t *testing.T) {
+		const n = 4100 // one cap-sized job of 4096 elements plus a remainder of 4
+		s := asyncSequence{elemChunks: 8, n: n, limit: 1 << 40}
+		DisableAsyncHashing()
+		want := runAsyncSequence(t, NewHasherWithHashFn(hashtree.HashByteSlice), s, 83)
+
+		EnableAsyncHashing(4)
+		hh := NewHasherWithHashFn(hashtree.HashByteSlice)
+		hh.SetAsyncHashing(true)
+		idx := hh.StartTree(sszutils.TreeTypeBinary)
+		registerRun(hh, rand.New(rand.NewSource(83)), idx, 8, n)
+		hh.Collapse()
+		if pend := hh.layers[hh.layerCount].pendCount; pend != 4 {
+			t.Fatalf("remainder not kept pending after Collapse: %d != 4", pend)
+		}
+		hh.MerkleizeWithMixin(idx, n, 1<<40)
+		got, err := hh.HashRoot()
+		if err != nil {
+			t.Fatalf("HashRoot: %v", err)
+		}
+		if got != want {
+			t.Errorf("binary remainder root %x != sync root %x", got, want)
+		}
+	})
+
+	t.Run("progressive", func(t *testing.T) {
+		// Eight cap-sized jobs of 16384 two-chunk elements plus a remainder
+		// of 4: the flush compacts the run to 131080 chunks of element
+		// roots, just past the deferred-finalization bound
+		// (asyncActiveChunks), so Collapse reduces the remainder and
+		// finalizes instead of returning early.
+		const n = 8*16384 + 4
+		s := asyncSequence{progressive: true, elemChunks: 2, n: n}
+		DisableAsyncHashing()
+		want := runAsyncSequence(t, NewHasherWithHashFn(hashtree.HashByteSlice), s, 89)
+
+		EnableAsyncHashing(4)
+		hh := NewHasherWithHashFn(hashtree.HashByteSlice)
+		hh.SetAsyncHashing(true)
+		idx := hh.StartTree(sszutils.TreeTypeProgressive)
+		registerRun(hh, rand.New(rand.NewSource(89)), idx, 2, n)
+		hh.Collapse()
+		if pend := hh.layers[hh.layerCount].pendCount; pend != 0 {
+			t.Fatalf("remainder not reduced before finalization: %d != 0", pend)
+		}
+		hh.MerkleizeProgressiveWithMixin(idx, n)
+		got, err := hh.HashRoot()
+		if err != nil {
+			t.Fatalf("HashRoot: %v", err)
+		}
+		if got != want {
+			t.Errorf("progressive remainder root %x != sync root %x", got, want)
+		}
+	})
 }
 
 // TestAsyncRingFull runs enough flushes past a tiny worker limit that the

--- a/hasher/common.go
+++ b/hasher/common.go
@@ -104,23 +104,41 @@ func logfn(format string, a ...any) {
 // hash result into dst.
 type HashFn func(dst []byte, input []byte) error
 
-// NativeHashWrapper wraps a hash.Hash function into a HashFn
+// nativeHashPairs hashes input as consecutive 64-byte pairs into dst using
+// the given hash.Hash instance.
+func nativeHashPairs(hashFn hash.Hash, dst, input []byte) {
+	layerLen := len(input) / 32
+	if layerLen%2 == 1 {
+		layerLen++
+	}
+	for i := 0; i < layerLen; i += 2 {
+		hashFn.Write(input[i*32 : i*32+32])
+		hashFn.Write(input[i*32+32 : i*32+64])
+		hashFn.Sum(dst[(i / 2 * 32):][:0])
+		hashFn.Reset()
+	}
+}
+
+// NativeHashWrapper wraps a hash.Hash instance into a HashFn. The instance
+// is stateful, so the returned function is NOT safe for concurrent use and
+// the hasher carrying it must stay gated out of async hashing; use
+// NativeHashWrapperFactory when that is needed.
 func NativeHashWrapper(hashFn hash.Hash) HashFn {
 	return func(dst []byte, input []byte) error {
-		hash := func(dst []byte, src []byte) {
-			hashFn.Write(src[:32])
-			hashFn.Write(src[32:64])
-			hashFn.Sum(dst)
-			hashFn.Reset()
-		}
+		nativeHashPairs(hashFn, dst, input)
+		return nil
+	}
+}
 
-		layerLen := len(input) / 32
-		if layerLen%2 == 1 {
-			layerLen++
-		}
-		for i := 0; i < layerLen; i += 2 {
-			hash(dst[(i/2)*32:][:0], input[i*32:])
-		}
+// NativeHashWrapperFactory wraps a hash.Hash constructor into a HashFn that
+// is safe for concurrent use: every call draws its own instance from a pool.
+// This is what makes the native-hash path eligible for async hashing.
+func NativeHashWrapperFactory(newHash func() hash.Hash) HashFn {
+	pool := &sync.Pool{New: func() any { return newHash() }}
+	return func(dst []byte, input []byte) error {
+		hashFn, _ := pool.Get().(hash.Hash)
+		nativeHashPairs(hashFn, dst, input)
+		pool.Put(hashFn)
 		return nil
 	}
 }

--- a/hasher/hasher.go
+++ b/hasher/hasher.go
@@ -536,7 +536,8 @@ func (h *Hasher) Collapse() {
 		return
 	}
 
-	async := h.asyncShared() != nil
+	ast := h.asyncShared()
+	async := ast != nil
 
 	if layer.pendCount > 0 {
 		// With async hashing, Collapse is treated as a hint: the pending run
@@ -565,6 +566,14 @@ func (h *Hasher) Collapse() {
 		if layer.pendCount > 0 {
 			// Sub-cap remainder from the capped async flush; it accumulates
 			// toward the next cap-sized job.
+			return
+		}
+		if async {
+			// Raw chunk runs (packed primitive lists and vectors) reduce as
+			// cap-sized background jobs too. The synchronous batch collapse
+			// stays out of the way: its shallower nodes would break the cap
+			// alignment, and acting on the region would stall on the holes.
+			h.precollapseCapRun(ast, layer)
 			return
 		}
 		h.maybeCollapseBinary(layer)
@@ -687,7 +696,7 @@ func (h *Hasher) maybeCollapseProgressive(layer *treeLayer) {
 	// consumption waits for a later round: it would move (or read) the node
 	// holes while the reductions are still in flight.
 	ast := h.asyncShared()
-	if ast != nil && layer.progressiveLevel >= 8 && h.precollapseProgressiveRun(ast, layer) {
+	if ast != nil && layer.progressiveLevel >= 8 && h.precollapseCapRun(ast, layer) {
 		return
 	}
 

--- a/hasher/hasher.go
+++ b/hasher/hasher.go
@@ -409,6 +409,12 @@ func (h *Hasher) pushLayer() *treeLayer {
 	layer.pendCount = 0
 	layer.pendElemChunks = 0
 	layer.pendStart = 0
+	// Progressive root bookkeeping is read by scope-position helpers before
+	// the first collapse initializes it, so a reused slot must not carry the
+	// previous scope's values. counts/maxDepth stay lazily initialized:
+	// everything reading them is gated on the collapsed flag.
+	layer.progressiveCount = 0
+	layer.progressiveLevel = 0
 	return layer
 }
 

--- a/hasher/hasher.go
+++ b/hasher/hasher.go
@@ -98,8 +98,14 @@ type Hasher struct {
 	// goroutines. Hashers wrapping a stateful hash.Hash are not async-safe.
 	asyncSafe bool
 
-	// pendingJobs are in-flight background subtree reductions (see async.go).
-	pendingJobs []pendingJob
+	// jobRing is the FIFO of in-flight background subtree reductions (see
+	// async.go). Slots are reused across jobs; the ring only resizes while
+	// empty. jobHead indexes the oldest occupied slot, jobCount the number
+	// of occupied slots.
+	jobRing    []asyncJob
+	jobHead    int
+	jobCount   int
+	jobRingBuf [asyncRingInline]asyncJob // inline backing to avoid heap allocation
 }
 
 // NewHasher creates a new Hasher with the default sha256 hash function.
@@ -438,13 +444,13 @@ func (h *Hasher) flushPending(layer *treeLayer, allowAsync bool) {
 	width := count * elem
 	if allowAsync && width >= asyncMinChunks &&
 		width&(width-1) == 0 && count&(count-1) == 0 && width < 1<<(maxTreeDepth-1) {
-		if slots := h.asyncSlots(); slots != nil {
+		if st := h.asyncShared(); st != nil {
 			if layer.progressive {
-				h.flushPendingAsyncRoots(slots, start, width, count)
+				h.flushPendingAsyncRoots(st, start, width, count)
 				return
 			}
 			if h.layerLeaves(layer, start)%uint64(count) == 0 {
-				h.flushPendingAsyncRoot(slots, layer, start, width, count)
+				h.flushPendingAsyncRoot(st, layer, start, width, count)
 				return
 			}
 		}
@@ -520,7 +526,7 @@ func (h *Hasher) Collapse() {
 		return
 	}
 
-	async := h.asyncSlots() != nil
+	async := h.asyncShared() != nil
 
 	if layer.pendCount > 0 {
 		// With async hashing, Collapse is treated as a hint: the pending run
@@ -691,9 +697,9 @@ func (h *Hasher) maybeCollapseProgressive(layer *treeLayer) {
 		// plain depth-0 leaves is a complete power-of-two subtree whose
 		// reduction can run in the background; the group root slot at
 		// writePos is only read by the final fold, which drains first.
-		if slots := h.asyncSlots(); slots != nil && consumedMaxDepth == 0 &&
+		if st := h.asyncShared(); st != nil && consumedMaxDepth == 0 &&
 			consumed == baseSize && baseSize >= asyncMinChunks {
-			h.enqueueReduce(slots, readPos, int(baseSize), 1, writePos)
+			h.enqueueReduce(st, readPos, int(baseSize), 1, writePos)
 		} else {
 			// collapseAllDepths works within buf[readPos:consumePos] only,
 			// leaving the unconsumed tail untouched. Root lands at

--- a/hasher/hasher.go
+++ b/hasher/hasher.go
@@ -93,6 +93,13 @@ type Hasher struct {
 	layers     []treeLayer
 	layerCount int           // index of the current top layer, -1 when empty
 	layerBuf   [16]treeLayer // inline backing to avoid heap allocation
+
+	// asyncSafe reports whether the hash function may be called from other
+	// goroutines. Hashers wrapping a stateful hash.Hash are not async-safe.
+	asyncSafe bool
+
+	// pendingJobs are in-flight background subtree reductions (see async.go).
+	pendingJobs []pendingJob
 }
 
 // NewHasher creates a new Hasher with the default sha256 hash function.
@@ -101,11 +108,17 @@ func NewHasher() *Hasher {
 }
 
 // NewHasherWithHash creates a new Hasher with a custom hash.Hash function.
+// hash.Hash instances are stateful, so the hasher never participates in
+// async hashing.
 func NewHasherWithHash(hh hash.Hash) *Hasher {
-	return NewHasherWithHashFn(NativeHashWrapper(hh))
+	h := NewHasherWithHashFn(NativeHashWrapper(hh))
+	h.asyncSafe = false
+	return h
 }
 
 // NewHasherWithHashFn creates a new Hasher with a custom HashFn function.
+// The function must be safe for concurrent use; when async hashing is
+// enabled (EnableAsyncHashing), background goroutines call it too.
 func NewHasherWithHashFn(hh HashFn) *Hasher {
 	initHasher()
 
@@ -113,6 +126,7 @@ func NewHasherWithHashFn(hh HashFn) *Hasher {
 		hash:       hh,
 		buf:        make([]byte, 0, 32*1024), // 32KB default buffer size
 		layerCount: -1,
+		asyncSafe:  true,
 	}
 	h.tmp = h.tmpBuf[:]
 	h.layers = h.layerBuf[:0]
@@ -126,9 +140,11 @@ func (h *Hasher) WithTemp(fn func(tmp []byte) []byte) {
 	h.tmp = fn(h.tmp)
 }
 
-// Reset clears the buffer and layer stack for reuse.
+// Reset clears the buffer and layer stack for reuse. Outstanding background
+// reductions are awaited and their results discarded.
 func (h *Hasher) Reset() {
 	h.buf = h.buf[:0]
+	h.drainJobs()
 	h.layerCount = -1
 }
 
@@ -402,7 +418,14 @@ func deferrableElemChunks(scopeBytes int) (int, bool) {
 // element. The roots replace the raw chunks in place; any bytes appended after
 // the pending run (e.g. raw chunks of later siblings) are moved down to stay
 // adjacent to the reduced roots.
-func (h *Hasher) flushPending(layer *treeLayer) {
+//
+// When allowAsync is set (only from Collapse: other callers depend on the
+// run shrinking to exactly pendCount roots) and async hashing is enabled,
+// a wide power-of-two run is reduced in the background instead: to a single
+// subtree root for binary layers when the run is leaf-aligned, or to
+// per-element roots for progressive layers (group boundaries are not
+// aligned to run boundaries, so completed subtrees cannot span them).
+func (h *Hasher) flushPending(layer *treeLayer, allowAsync bool) {
 	count := layer.pendCount
 	elem := layer.pendElemChunks
 	start := layer.pendStart
@@ -413,6 +436,19 @@ func (h *Hasher) flushPending(layer *treeLayer) {
 		return
 	}
 	width := count * elem
+	if allowAsync && width >= asyncMinChunks &&
+		width&(width-1) == 0 && count&(count-1) == 0 && width < 1<<(maxTreeDepth-1) {
+		if slots := h.asyncSlots(); slots != nil {
+			if layer.progressive {
+				h.flushPendingAsyncRoots(slots, start, width, count)
+				return
+			}
+			if h.layerLeaves(layer, start)%uint64(count) == 0 {
+				h.flushPendingAsyncRoot(slots, layer, start, width, count)
+				return
+			}
+		}
+	}
 	for width > count {
 		half := (width / 2) * 32
 		_ = h.hash(h.buf[start:start+half], h.buf[start:start+width*32])
@@ -441,7 +477,7 @@ func (h *Hasher) StartTree(treeType sszutils.TreeType) int {
 	// so batching is unaffected; it only guards interleaved API usage.
 	if treeType != sszutils.TreeTypeNone && h.layerCount >= 0 {
 		if top := &h.layers[h.layerCount]; top.pendCount > 0 {
-			h.flushPending(top)
+			h.flushPending(top, false)
 		}
 	}
 
@@ -484,11 +520,25 @@ func (h *Hasher) Collapse() {
 		return
 	}
 
+	async := h.asyncSlots() != nil
+
 	if layer.pendCount > 0 {
-		h.flushPending(layer)
+		// With async hashing, Collapse is treated as a hint: the pending run
+		// keeps accumulating until it is wide enough that its reduction is
+		// worth a background job.
+		if async && layer.pendCount*layer.pendElemChunks < lazyFlushChunks {
+			return
+		}
+		h.flushPending(layer, async)
 	}
 
 	if layer.progressive {
+		// With async hashing, group finalization is deferred so element-root
+		// jobs complete in the background before the finalization drain.
+		// The active region is bounded by asyncActiveChunks.
+		if async && (len(h.buf)-h.activeSubtreeStart(layer))/32 < asyncActiveChunks {
+			return
+		}
 		h.maybeCollapseProgressive(layer)
 	} else {
 		h.maybeCollapseBinary(layer)
@@ -520,6 +570,9 @@ func (h *Hasher) maybeCollapseBinary(layer *treeLayer) {
 	if totalChunks < incrementalBatchSize {
 		return
 	}
+
+	// About to hash and shift regions that may contain async holes.
+	h.drainJobs()
 
 	if !layer.collapsed {
 		layer.collapsed = true
@@ -569,6 +622,10 @@ func (h *Hasher) maybeCollapseBinary(layer *treeLayer) {
 // back to binary collapse for any remainder. On first call (collapsed==false),
 // clears stale state from a reused layer slot.
 func (h *Hasher) maybeCollapseProgressive(layer *treeLayer) {
+	// Group finalization reads and compacts the active region; any holes
+	// from element-root jobs must be filled first.
+	h.drainJobs()
+
 	// Sync collapse state so counts reflect all buffer data
 	if layer.collapsed {
 		h.syncCollapseState(layer)
@@ -630,18 +687,27 @@ func (h *Hasher) maybeCollapseProgressive(layer *treeLayer) {
 			break // safety
 		}
 
-		// Merkleize the consumed entries to a single root using collapseAllDepths.
-		// It works within buf[readPos:consumePos] only, leaving the unconsumed
-		// tail untouched. Root lands at buf[readPos].
-		tmpLayer := treeLayer{
-			bufIdx:    readPos,
-			collapsed: consumedMaxDepth > 0,
-			counts:    consumedCounts,
-			maxDepth:  consumedMaxDepth,
-		}
-		h.collapseAllDepths(&tmpLayer, readPos, consumePos, baseSize)
-		if writePos != readPos {
-			copy(h.buf[writePos:writePos+32], h.buf[readPos:readPos+32])
+		// Merkleize the consumed entries to a single root. A full group of
+		// plain depth-0 leaves is a complete power-of-two subtree whose
+		// reduction can run in the background; the group root slot at
+		// writePos is only read by the final fold, which drains first.
+		if slots := h.asyncSlots(); slots != nil && consumedMaxDepth == 0 &&
+			consumed == baseSize && baseSize >= asyncMinChunks {
+			h.enqueueReduce(slots, readPos, int(baseSize), 1, writePos)
+		} else {
+			// collapseAllDepths works within buf[readPos:consumePos] only,
+			// leaving the unconsumed tail untouched. Root lands at
+			// buf[readPos].
+			tmpLayer := treeLayer{
+				bufIdx:    readPos,
+				collapsed: consumedMaxDepth > 0,
+				counts:    consumedCounts,
+				maxDepth:  consumedMaxDepth,
+			}
+			h.collapseAllDepths(&tmpLayer, readPos, consumePos, baseSize)
+			if writePos != readPos {
+				copy(h.buf[writePos:writePos+32], h.buf[readPos:readPos+32])
+			}
 		}
 		writePos += 32
 		readPos = consumePos
@@ -865,7 +931,10 @@ func (h *Hasher) collapseProgressiveLayer(layer *treeLayer, indx int) {
 		layer.progressiveCount++
 	}
 
-	// 3. Fold progressive roots right-to-left.
+	// 3. Fold progressive roots right-to-left. The fold reads the group-root
+	// region, so any background group reductions must land first.
+	h.drainJobs()
+
 	nRoots := layer.progressiveCount
 	if nRoots == 0 {
 		h.buf = h.buf[:indx]
@@ -921,7 +990,7 @@ func (h *Hasher) Merkleize(indx int) {
 					if parent.pendCount > 0 &&
 						(parent.pendElemChunks != c || parent.pendStart+parent.pendCount*c*32 != indx) {
 						shift := parent.pendCount * (parent.pendElemChunks - 1) * 32
-						h.flushPending(parent)
+						h.flushPending(parent, false)
 						indx -= shift
 					}
 					if parent.pendCount == 0 {
@@ -936,8 +1005,9 @@ func (h *Hasher) Merkleize(indx int) {
 		}
 
 		if layer.pendCount > 0 {
-			h.flushPending(layer)
+			h.flushPending(layer, false)
 		}
+		h.drainJobs()
 
 		if layer.collapsed {
 			h.collapseAllDepths(layer, indx, len(h.buf), 0)
@@ -947,6 +1017,7 @@ func (h *Hasher) Merkleize(indx int) {
 		}
 		h.popTopLayer()
 	}
+	h.drainJobs()
 
 	// merkleizeImpl treats the region as whole 32-byte chunks (a single chunk
 	// is returned via input[:32]), so the region must be zero-padded to a chunk
@@ -978,8 +1049,9 @@ func (h *Hasher) MerkleizeWithMixin(indx int, num, limit uint64) {
 	layer := h.getMatchingLayer(indx)
 
 	if layer != nil && layer.pendCount > 0 {
-		h.flushPending(layer)
+		h.flushPending(layer, false)
 	}
+	h.drainJobs()
 
 	if layer != nil && layer.collapsed {
 		h.collapseAllDepths(layer, indx, len(h.buf), limit)
@@ -1022,8 +1094,9 @@ func (h *Hasher) MerkleizeProgressive(indx int) {
 	layer := h.getMatchingLayer(indx)
 
 	if layer != nil && layer.pendCount > 0 {
-		h.flushPending(layer)
+		h.flushPending(layer, false)
 	}
+	h.drainJobs()
 
 	if layer != nil && layer.progressive {
 		// Pad an unaligned partial chunk before collapsing, like the mixin
@@ -1063,8 +1136,9 @@ func (h *Hasher) MerkleizeProgressiveWithMixin(indx int, num uint64) {
 	layer := h.getMatchingLayer(indx)
 
 	if layer != nil && layer.pendCount > 0 {
-		h.flushPending(layer)
+		h.flushPending(layer, false)
 	}
+	h.drainJobs()
 
 	if layer != nil && layer.progressive && layer.progressiveCount > 0 {
 		h.FillUpTo32()
@@ -1109,8 +1183,9 @@ func (h *Hasher) MerkleizeProgressiveWithActiveFields(indx int, activeFields []b
 	layer := h.getMatchingLayer(indx)
 
 	if layer != nil && layer.pendCount > 0 {
-		h.flushPending(layer)
+		h.flushPending(layer, false)
 	}
+	h.drainJobs()
 
 	if layer != nil && layer.progressive && layer.progressiveCount > 0 {
 		h.FillUpTo32()

--- a/hasher/hasher.go
+++ b/hasher/hasher.go
@@ -94,9 +94,10 @@ type Hasher struct {
 	layerCount int           // index of the current top layer, -1 when empty
 	layerBuf   [16]treeLayer // inline backing to avoid heap allocation
 
-	// asyncSafe reports whether the hash function may be called from other
-	// goroutines. Hashers wrapping a stateful hash.Hash are not async-safe.
-	asyncSafe bool
+	// async gates this hasher into background subtree reduction (see
+	// SetAsyncHashing). Cleared on Reset so pooled hashers never carry the
+	// setting to their next user.
+	async bool
 
 	// jobRing is the FIFO of in-flight background subtree reductions (see
 	// async.go). Slots are reused across jobs; the ring only resizes while
@@ -108,23 +109,21 @@ type Hasher struct {
 	jobRingBuf [asyncRingInline]asyncJob // inline backing to avoid heap allocation
 }
 
-// NewHasher creates a new Hasher with the default sha256 hash function.
+// NewHasher creates a new Hasher with the default sha256 hash function. The
+// hash function draws per-call instances from a pool, so the hasher may be
+// gated into async hashing.
 func NewHasher() *Hasher {
-	return NewHasherWithHash(sha256.New())
+	return NewHasherWithHashFn(NativeHashWrapperFactory(sha256.New))
 }
 
 // NewHasherWithHash creates a new Hasher with a custom hash.Hash function.
-// hash.Hash instances are stateful, so the hasher never participates in
-// async hashing.
+// hash.Hash instances are stateful and not safe for concurrent use, so such
+// a hasher must not be gated into async hashing (see SetAsyncHashing).
 func NewHasherWithHash(hh hash.Hash) *Hasher {
-	h := NewHasherWithHashFn(NativeHashWrapper(hh))
-	h.asyncSafe = false
-	return h
+	return NewHasherWithHashFn(NativeHashWrapper(hh))
 }
 
 // NewHasherWithHashFn creates a new Hasher with a custom HashFn function.
-// The function must be safe for concurrent use; when async hashing is
-// enabled (EnableAsyncHashing), background goroutines call it too.
 func NewHasherWithHashFn(hh HashFn) *Hasher {
 	initHasher()
 
@@ -132,11 +131,20 @@ func NewHasherWithHashFn(hh HashFn) *Hasher {
 		hash:       hh,
 		buf:        make([]byte, 0, 32*1024), // 32KB default buffer size
 		layerCount: -1,
-		asyncSafe:  true,
 	}
 	h.tmp = h.tmpBuf[:]
 	h.layers = h.layerBuf[:0]
 	return h
+}
+
+// SetAsyncHashing gates this hasher into (or out of) background subtree
+// reduction. It only takes effect while async hashing is enabled process-wide
+// via EnableAsyncHashing. The hash function must be safe for concurrent use —
+// background goroutines call it alongside the walker; hashers wrapping a
+// stateful hash.Hash (NewHasher, NewHasherWithHash) must stay gated out.
+// Reset clears the gate, so pool users re-apply it per acquisition.
+func (h *Hasher) SetAsyncHashing(enabled bool) {
+	h.async = enabled
 }
 
 // WithTemp provides access to the hasher's temporary buffer via a callback.
@@ -146,12 +154,13 @@ func (h *Hasher) WithTemp(fn func(tmp []byte) []byte) {
 	h.tmp = fn(h.tmp)
 }
 
-// Reset clears the buffer and layer stack for reuse. Outstanding background
-// reductions are awaited and their results discarded.
+// Reset clears the buffer, layer stack and async gate for reuse. Outstanding
+// background reductions are awaited and their results discarded.
 func (h *Hasher) Reset() {
 	h.buf = h.buf[:0]
 	h.drainJobs()
 	h.layerCount = -1
+	h.async = false
 }
 
 // AppendBytes32 appends b to the buffer, right-padding with zeros until the
@@ -427,13 +436,17 @@ func deferrableElemChunks(scopeBytes int) (int, bool) {
 //
 // When allowAsync is set (only from Collapse: other callers depend on the
 // run shrinking to exactly pendCount roots) and async hashing is enabled,
-// a wide power-of-two run is reduced in the background instead: to a single
-// subtree root for binary layers when the run is leaf-aligned, or to
-// per-element roots for progressive layers (group boundaries are not
-// aligned to run boundaries, so completed subtrees cannot span them).
+// the run is reduced in cap-sized background jobs instead, with any sub-cap
+// remainder left pending for the next round.
 func (h *Hasher) flushPending(layer *treeLayer, allowAsync bool) {
-	count := layer.pendCount
 	elem := layer.pendElemChunks
+	if allowAsync && layer.pendCount > 0 &&
+		elem > 0 && elem <= lazyFlushChunks && elem&(elem-1) == 0 {
+		if st := h.asyncShared(); st != nil && h.flushPendingAsync(st, layer) {
+			return
+		}
+	}
+	count := layer.pendCount
 	start := layer.pendStart
 	layer.pendCount = 0
 	layer.pendElemChunks = 0
@@ -442,19 +455,6 @@ func (h *Hasher) flushPending(layer *treeLayer, allowAsync bool) {
 		return
 	}
 	width := count * elem
-	if allowAsync && width >= asyncMinChunks &&
-		width&(width-1) == 0 && count&(count-1) == 0 && width < 1<<(maxTreeDepth-1) {
-		if st := h.asyncShared(); st != nil {
-			if layer.progressive {
-				h.flushPendingAsyncRoots(st, start, width, count)
-				return
-			}
-			if h.layerLeaves(layer, start)%uint64(count) == 0 {
-				h.flushPendingAsyncRoot(st, layer, start, width, count)
-				return
-			}
-		}
-	}
 	for width > count {
 		half := (width / 2) * 32
 		_ = h.hash(h.buf[start:start+half], h.buf[start:start+width*32])
@@ -545,8 +545,18 @@ func (h *Hasher) Collapse() {
 		if async && (len(h.buf)-h.activeSubtreeStart(layer))/32 < asyncActiveChunks {
 			return
 		}
+		if layer.pendCount > 0 {
+			// A sub-cap remainder from the capped async flush reduces
+			// synchronously: finalization must only see completed roots.
+			h.flushPending(layer, false)
+		}
 		h.maybeCollapseProgressive(layer)
 	} else {
+		if layer.pendCount > 0 {
+			// Sub-cap remainder from the capped async flush; it accumulates
+			// toward the next cap-sized job.
+			return
+		}
 		h.maybeCollapseBinary(layer)
 	}
 }
@@ -650,6 +660,18 @@ func (h *Hasher) maybeCollapseProgressive(layer *treeLayer) {
 		}
 	}
 
+	// A group wider than one job buffer is never reduced as a single job:
+	// the pre-collapse pass turns the trailing depth-0 run into cap-depth
+	// nodes first, so consumption later needs only a handful of small
+	// hashes. Below level 8 the groups themselves are narrower than the
+	// cap, so nothing needs pre-collapsing there. When jobs were emitted,
+	// consumption waits for a later round: it would move (or read) the node
+	// holes while the reductions are still in flight.
+	ast := h.asyncShared()
+	if ast != nil && layer.progressiveLevel >= 8 && h.precollapseProgressiveRun(ast, layer) {
+		return
+	}
+
 	readPos := h.activeSubtreeStart(layer)
 	writePos := readPos
 	finalized := false
@@ -693,13 +715,15 @@ func (h *Hasher) maybeCollapseProgressive(layer *treeLayer) {
 			break // safety
 		}
 
-		// Merkleize the consumed entries to a single root. A full group of
-		// plain depth-0 leaves is a complete power-of-two subtree whose
-		// reduction can run in the background; the group root slot at
+		// Merkleize the consumed entries to a single root. A cap-or-smaller
+		// group of plain depth-0 leaves is a complete power-of-two subtree
+		// whose reduction can run in the background; the group root slot at
 		// writePos is only read by the final fold, which drains first.
-		if st := h.asyncShared(); st != nil && consumedMaxDepth == 0 &&
-			consumed == baseSize && baseSize >= asyncMinChunks {
-			h.enqueueReduce(st, readPos, int(baseSize), 1, writePos)
+		// Wider groups reach this point as pre-collapsed cap-depth nodes
+		// and reduce synchronously in a few hashes.
+		if ast != nil && consumedMaxDepth == 0 && consumed == baseSize &&
+			baseSize >= asyncMinChunks && baseSize <= lazyFlushChunks {
+			h.enqueueReduce(ast, readPos, int(baseSize), 1, writePos)
 		} else {
 			// collapseAllDepths works within buf[readPos:consumePos] only,
 			// leaving the unconsumed tail untouched. Root lands at
@@ -728,8 +752,25 @@ func (h *Hasher) maybeCollapseProgressive(layer *treeLayer) {
 	}
 
 	if !finalized {
-		// No groups finalized — try binary collapse directly
-		h.maybeCollapseBinary(layer)
+		// No groups finalized — try binary collapse directly. With async
+		// hashing the pre-collapse pass already bounds the depth-0 run, and
+		// binary batching would break its cap alignment.
+		if ast == nil {
+			h.maybeCollapseBinary(layer)
+		}
+		return
+	}
+
+	if ast != nil {
+		// Step 2, async variant: move the remainder down unchanged.
+		// Pair-compaction would break the cap alignment the pre-collapse
+		// pass relies on, and cap-sized runs reduce in the background
+		// anyway.
+		if writePos != readPos {
+			copy(h.buf[writePos:], h.buf[readPos:])
+			h.buf = h.buf[:len(h.buf)-(readPos-writePos)]
+		}
+		layer.collapsed = true
 		return
 	}
 
@@ -920,6 +961,13 @@ func (h *Hasher) collapseAllDepths(layer *treeLayer, indx, bufEnd int, limit uin
 func (h *Hasher) collapseProgressiveLayer(layer *treeLayer, indx int) {
 	// 1. Finalize all complete progressive groups and compact remainder.
 	h.maybeCollapseProgressive(layer)
+	if h.jobCount > 0 {
+		// The round emitted pre-collapse jobs and skipped consumption (or
+		// left group reductions in flight); with the results drained,
+		// consumption can complete.
+		h.drainJobs()
+		h.maybeCollapseProgressive(layer)
+	}
 
 	// 2. Handle the partial remainder (the last unfilled group).
 	subtreeStart := h.activeSubtreeStart(layer)

--- a/hasher/hasher.go
+++ b/hasher/hasher.go
@@ -503,16 +503,18 @@ func (h *Hasher) StartTree(treeType sszutils.TreeType) int {
 	return idx
 }
 
-// Index returns the current buffer position and pushes a non-incremental
-// layer. This is for legacy/external code that doesn't use StartTree.
-// The non-incremental layer blocks Collapse on this scope but is properly
-// popped by Merkleize. Collapse on the parent layer is unaffected — it
-// only sees completed child roots after the child's Merkleize pops this layer.
+// Index returns the current buffer position and pushes a binary incremental
+// layer. This is how legacy/external code (fastssz-generated methods) opens
+// scopes: such callers never send Collapse hints, so the deferral path in
+// Merkleize batches their uniform children and flushes the pending run
+// itself once it reaches the job cap. Unlike StartTree, no pending flush is
+// forced on the enclosing scope — a scope opened via Index may itself end
+// up deferred into its parent.
 func (h *Hasher) Index() int {
 	idx := len(h.buf)
 	layer := h.pushLayer()
 	layer.bufIdx = idx
-	layer.incremental = false
+	layer.incremental = true
 	return idx
 }
 
@@ -1051,8 +1053,13 @@ func (h *Hasher) Merkleize(indx int) {
 	if layer != nil {
 		// Defer a container scope into its incremental parent so it batches with
 		// its siblings (single getMatchingLayer keeps the hot path cheap for the
-		// many small containers in a block).
-		if !layer.incremental && h.layerCount >= 1 {
+		// many small containers in a block). A scope holds plain chunks — and is
+		// therefore deferrable — when it is non-incremental, or incremental but
+		// still untouched by any collapse or deferral of its own; the latter is
+		// how legacy Index-driven scopes (fastssz-generated code) batch.
+		deferrable := !layer.incremental ||
+			(!layer.progressive && !layer.collapsed && layer.pendCount == 0)
+		if deferrable && h.layerCount >= 1 {
 			parent := &h.layers[h.layerCount-1]
 			if parent.incremental {
 				if c, ok := deferrableElemChunks(len(h.buf) - indx); ok {
@@ -1073,6 +1080,14 @@ func (h *Hasher) Merkleize(indx int) {
 					parent.pendElemChunks = c
 					parent.pendCount++
 					h.popTopLayer()
+					// Legacy callers never send Collapse hints, so the run is
+					// bounded here: once it reaches the job cap it flushes —
+					// in the background when async hashing is on, otherwise as
+					// one wide synchronous pass. Collapse-driven engines flush
+					// before this ever fires in synchronous mode.
+					if parent.pendCount*c >= lazyFlushChunks {
+						h.flushPending(parent, true)
+					}
 					return
 				}
 			}

--- a/hasher/hasher.go
+++ b/hasher/hasher.go
@@ -583,7 +583,16 @@ func (h *Hasher) popTopLayer() {
 func (h *Hasher) maybeCollapseBinary(layer *treeLayer) {
 	regionStart := h.binaryRegionStart(layer)
 	totalChunks := (len(h.buf) - regionStart) / 32
-	if totalChunks < incrementalBatchSize {
+	// Only depth-0 chunks count toward the batch trigger: batching bounds the
+	// raw-chunk backlog, while completed deeper nodes are 32 bytes each and
+	// collapsing them early would stall on their in-flight reductions.
+	d0Chunks := totalChunks
+	if layer.collapsed {
+		for d := 1; d <= layer.maxDepth; d++ {
+			d0Chunks -= int(layer.counts[d])
+		}
+	}
+	if d0Chunks < incrementalBatchSize {
 		return
 	}
 
@@ -969,7 +978,10 @@ func (h *Hasher) collapseProgressiveLayer(layer *treeLayer, indx int) {
 		h.maybeCollapseProgressive(layer)
 	}
 
-	// 2. Handle the partial remainder (the last unfilled group).
+	// 2. Handle the partial remainder (the last unfilled group). The
+	// consumption rounds above may have emitted pre-collapse jobs over the
+	// remainder; their holes must be filled before the region is read.
+	h.drainJobs()
 	subtreeStart := h.activeSubtreeStart(layer)
 	activeChunks := (len(h.buf) - subtreeStart) / 32
 

--- a/hasher/hasher.go
+++ b/hasher/hasher.go
@@ -102,10 +102,12 @@ type Hasher struct {
 	// jobRing is the FIFO of in-flight background subtree reductions (see
 	// async.go). Slots are reused across jobs; the ring only resizes while
 	// empty. jobHead indexes the oldest occupied slot, jobCount the number
-	// of occupied slots.
+	// of occupied slots. jobMaxDst tracks the highest outstanding hole
+	// offset, so drains can be skipped for regions above every hole.
 	jobRing    []asyncJob
 	jobHead    int
 	jobCount   int
+	jobMaxDst  int
 	jobRingBuf [asyncRingInline]asyncJob // inline backing to avoid heap allocation
 }
 
@@ -603,7 +605,7 @@ func (h *Hasher) maybeCollapseBinary(layer *treeLayer) {
 	}
 
 	// About to hash and shift regions that may contain async holes.
-	h.drainJobs()
+	h.drainJobsFor(regionStart)
 
 	if !layer.collapsed {
 		layer.collapsed = true
@@ -655,7 +657,7 @@ func (h *Hasher) maybeCollapseBinary(layer *treeLayer) {
 func (h *Hasher) maybeCollapseProgressive(layer *treeLayer) {
 	// Group finalization reads and compacts the active region; any holes
 	// from element-root jobs must be filled first.
-	h.drainJobs()
+	h.drainJobsFor(layer.bufIdx)
 
 	// Sync collapse state so counts reflect all buffer data
 	if layer.collapsed {
@@ -1079,7 +1081,7 @@ func (h *Hasher) Merkleize(indx int) {
 		if layer.pendCount > 0 {
 			h.flushPending(layer, false)
 		}
-		h.drainJobs()
+		h.drainJobsFor(indx)
 
 		if layer.collapsed {
 			h.collapseAllDepths(layer, indx, len(h.buf), 0)
@@ -1089,7 +1091,7 @@ func (h *Hasher) Merkleize(indx int) {
 		}
 		h.popTopLayer()
 	}
-	h.drainJobs()
+	h.drainJobsFor(indx)
 
 	// merkleizeImpl treats the region as whole 32-byte chunks (a single chunk
 	// is returned via input[:32]), so the region must be zero-padded to a chunk
@@ -1123,7 +1125,7 @@ func (h *Hasher) MerkleizeWithMixin(indx int, num, limit uint64) {
 	if layer != nil && layer.pendCount > 0 {
 		h.flushPending(layer, false)
 	}
-	h.drainJobs()
+	h.drainJobsFor(indx)
 
 	if layer != nil && layer.collapsed {
 		h.collapseAllDepths(layer, indx, len(h.buf), limit)
@@ -1168,7 +1170,7 @@ func (h *Hasher) MerkleizeProgressive(indx int) {
 	if layer != nil && layer.pendCount > 0 {
 		h.flushPending(layer, false)
 	}
-	h.drainJobs()
+	h.drainJobsFor(indx)
 
 	if layer != nil && layer.progressive {
 		// Pad an unaligned partial chunk before collapsing, like the mixin
@@ -1210,7 +1212,7 @@ func (h *Hasher) MerkleizeProgressiveWithMixin(indx int, num uint64) {
 	if layer != nil && layer.pendCount > 0 {
 		h.flushPending(layer, false)
 	}
-	h.drainJobs()
+	h.drainJobsFor(indx)
 
 	if layer != nil && layer.progressive && layer.progressiveCount > 0 {
 		h.FillUpTo32()
@@ -1257,7 +1259,7 @@ func (h *Hasher) MerkleizeProgressiveWithActiveFields(indx int, activeFields []b
 	if layer != nil && layer.pendCount > 0 {
 		h.flushPending(layer, false)
 	}
-	h.drainJobs()
+	h.drainJobsFor(indx)
 
 	if layer != nil && layer.progressive && layer.progressiveCount > 0 {
 		h.FillUpTo32()

--- a/hasher/hasher.go
+++ b/hasher/hasher.go
@@ -102,12 +102,12 @@ type Hasher struct {
 	// jobRing is the FIFO of in-flight background subtree reductions (see
 	// async.go). Slots are reused across jobs; the ring only resizes while
 	// empty. jobHead indexes the oldest occupied slot, jobCount the number
-	// of occupied slots. jobMaxDst tracks the highest outstanding hole
-	// offset, so drains can be skipped for regions above every hole.
+	// of occupied slots. jobMaxEnd tracks the end of the highest outstanding
+	// hole, so drains can be skipped for regions above every hole.
 	jobRing    []asyncJob
 	jobHead    int
 	jobCount   int
-	jobMaxDst  int
+	jobMaxEnd  int
 	jobRingBuf [asyncRingInline]asyncJob // inline backing to avoid heap allocation
 }
 
@@ -160,7 +160,7 @@ func (h *Hasher) WithTemp(fn func(tmp []byte) []byte) {
 // background reductions are awaited and their results discarded.
 func (h *Hasher) Reset() {
 	h.buf = h.buf[:0]
-	h.drainJobs()
+	h.discardJobs()
 	h.layerCount = -1
 	h.async = false
 }
@@ -1483,8 +1483,10 @@ func (h *Hasher) merkleizeProgressiveImpl(dst, chunks []byte, depth uint8) []byt
 	return append(dst, h.tmp[:32]...)
 }
 
-// Hash returns the last 32 bytes of the buffer.
+// Hash returns the last 32 bytes of the buffer. Outstanding background
+// reductions are drained first so no unfilled hole can be exposed.
 func (h *Hasher) Hash() []byte {
+	h.drainJobs()
 	start := 0
 	if len(h.buf) > 32 {
 		start = len(h.buf) - 32
@@ -1492,9 +1494,17 @@ func (h *Hasher) Hash() []byte {
 	return h.buf[start:]
 }
 
-// HashRoot returns the final 32-byte hash root, or an error if the buffer
-// is not exactly 32 bytes.
+// HashRoot returns the final 32-byte hash root, or an error if scopes are
+// still open or the buffer is not exactly 32 bytes. Outstanding background
+// reductions are drained first so no unfilled hole can be exposed — with
+// async hashing, a buffer of the right length is not otherwise evidence of
+// a finished computation.
 func (h *Hasher) HashRoot() (res [32]byte, err error) {
+	h.drainJobs()
+	if h.layerCount >= 0 {
+		err = fmt.Errorf("unfinished hashing scopes")
+		return
+	}
 	if len(h.buf) != 32 {
 		err = fmt.Errorf("expected 32 byte size")
 		return

--- a/hasher/hasher.go
+++ b/hasher/hasher.go
@@ -420,16 +420,23 @@ func (h *Hasher) pushLayer() *treeLayer {
 	return layer
 }
 
-// deferrableElemChunks reports whether a just-closed scope of scopeBytes bytes is
-// a uniform binary subtree eligible for deferred batched reduction: a whole,
-// power-of-two number of chunks in [2, incrementalBatchSize].
+// deferrableElemChunks reports whether a just-closed scope of scopeBytes
+// bytes is eligible for deferred batched reduction, returning the complete
+// subtree width the scope occupies once padded: a whole number of chunks in
+// [2, incrementalBatchSize], rounded up to the next power of two. A scope
+// with a non-power-of-two chunk count zero-pads to that width — the merkle
+// root over zero-padded leaves is identical, because a zero subtree hashes
+// to exactly the zero hash the per-level padding would use.
 func deferrableElemChunks(scopeBytes int) (int, bool) {
 	if scopeBytes < 64 || scopeBytes%32 != 0 {
 		return 0, false
 	}
 	c := scopeBytes / 32
-	if c > incrementalBatchSize || c&(c-1) != 0 {
+	if c > incrementalBatchSize {
 		return 0, false
+	}
+	if c&(c-1) != 0 {
+		c = 1 << bits.Len(uint(c))
 	}
 	return c, true
 }
@@ -1072,6 +1079,12 @@ func (h *Hasher) Merkleize(indx int) {
 			parent := &h.layers[h.layerCount-1]
 			if parent.incremental {
 				if c, ok := deferrableElemChunks(len(h.buf) - indx); ok {
+					// Pad a non-power-of-two scope up to its complete subtree
+					// width so the run stays uniform (elements share one
+					// type, so they all pad identically).
+					if pad := indx + c*32 - len(h.buf); pad > 0 {
+						h.buf = sszutils.AppendZeroPadding(h.buf, pad)
+					}
 					// The pending run must stay one contiguous region of uniform
 					// subtrees. If this scope does not extend the current run
 					// (different chunk count, or raw chunks were appended in

--- a/hasher/hasher_test.go
+++ b/hasher/hasher_test.go
@@ -1732,7 +1732,7 @@ func TestFlushPendingNoPending(t *testing.T) {
 	before := h.CurrentIndex()
 
 	var layer treeLayer // pendCount == 0
-	h.flushPending(&layer)
+	h.flushPending(&layer, false)
 
 	if h.CurrentIndex() != before {
 		t.Fatalf("flushPending with no pending changed the buffer: %d != %d", h.CurrentIndex(), before)

--- a/hasher/hasher_test.go
+++ b/hasher/hasher_test.go
@@ -1085,6 +1085,7 @@ func TestHasherInterfaceCompliance(t *testing.T) {
 		t.Error("Index should not be 0 after adding data")
 	}
 
+	h.Merkleize(idx)
 	h.Merkleize(0)
 	h.Hash()
 

--- a/options.go
+++ b/options.go
@@ -13,6 +13,8 @@ type DynSszOptions struct {
 	NoFastSsz              bool
 	NoDelegation           bool
 	NoFastHash             bool
+	AsyncHashing           bool
+	AsyncHashingWorkers    int
 	ExtendedTypes          bool
 	Verbose                bool
 	LogCb                  func(format string, args ...any)
@@ -55,6 +57,24 @@ func WithNoDelegation() DynSszOption {
 func WithNoFastHash() DynSszOption {
 	return func(opts *DynSszOptions) {
 		opts.NoFastHash = true
+	}
+}
+
+// WithAsyncHashing gates this instance's HashTreeRoot computations into
+// background subtree reduction: large subtrees hash on worker goroutines
+// while the walker keeps serializing, which speeds up large lists (such as
+// a beacon state's validator registry) severalfold. Roots are identical to
+// synchronous hashing.
+//
+// workers > 0 also configures the process-wide worker limit (shared by all
+// instances, see hasher.EnableAsyncHashing); workers == 0 only gates this
+// instance in and leaves the process-wide configuration untouched.
+// HashTreeRootWith is unaffected: the caller owns that hasher and gates it
+// explicitly via its SetAsyncHashing method.
+func WithAsyncHashing(workers int) DynSszOption {
+	return func(opts *DynSszOptions) {
+		opts.AsyncHashing = true
+		opts.AsyncHashingWorkers = workers
 	}
 }
 


### PR DESCRIPTION
## Async hashing: background subtree reduction

Hash tree root computation is dominated by large, self-contained subtree reductions — most prominently a beacon state's validator registry, where every element is a complete power-of-two subtree. This PR lets those reductions run on background goroutines while the walker keeps serializing, cutting large-state HTR wall time by 2-3.5x. It is **disabled by default** and fully opt-in.

### API

- `hasher.EnableAsyncHashing(workers)` / `DisableAsyncHashing()` — process-wide worker limit.
- `Hasher.SetAsyncHashing(bool)` — per-hasher gate, cleared by `Reset` so pooled hashers never leak the setting.
- `dynssz.WithAsyncHashing(workers)` — gates a `DynSsz` instance's `HashTreeRoot` calls in; other instances stay fully synchronous even though the worker pool is shared. `workers == 0` gates in without touching the process-wide configuration.

Roots are identical to synchronous hashing in every mode and engine.

### Design

- **Unit of work**: a contiguous power-of-two chunk region whose reduction result has a known size — a cap-aligned run of deferred sibling subtrees (reduced to one completed node, or one root per element for progressive layers), or a complete progressive group. The region is copied into a pooled input buffer, a placeholder hole stays in the hasher's buffer, and one goroutine reduces the copy level by level with wide hash calls — no per-level barriers.
- **Jobs are capped at one buffer size** (1 MB): wider regions reduce as a sequence of cap-sized jobs with the remainder carried to the next round, and progressive groups wider than the cap are pre-collapsed into cap-depth nodes. All input buffers are interchangeable; nothing else is ever allocated.
- **Strictly bounded, allocation-free steady state**: per-job state lives in a fixed ring owned by the hasher (inline backing like the layer stack), input buffers cycle through a token free list sized to the ring, and persistent runner goroutines consume prepared slots from a never-closed handoff channel (started on demand, one at a time, up to the worker limit — reconfiguration needs no shutdown protocol). A 1M-element registry hashes at 0 allocs/op.
- **Drains only where holes can be read**: every path that reads or restructures a buffer region drains outstanding jobs first, gated on the highest outstanding hole end so child scopes above all holes never wait. `Hash`/`HashRoot` drain too, and `HashRoot` rejects unfinished scopes — with async, buffer length alone is no evidence of a finished computation.
- **Legacy `Index()`-driven scopes batch as well**: fastssz-generated methods (the delegation target for types carrying static presets) never send `Collapse` hints, so the deferral path bounds their runs itself, flushing at the cap. Collapse-driven engines are unaffected in synchronous mode.
- The native sha256 backend participates via `NativeHashWrapperFactory`, which draws per-call hash instances from a pool; only hashers wrapping a caller-supplied `hash.Hash` instance must stay gated out.

### Performance (8-core AMD EPYC, benchstat n=10)

Synchronous behavior is unchanged: benchstat against master shows −0.1% geomean across the registry matrix.

1M-validator registry (generated types):

| | sync | async (8 workers) |
|---|---|---|
| binary list | 476 ms | **138 ms** |
| progressive list | 483 ms | **170 ms** |

Full mainnet beacon state (Fulu, 2.33M validators, 334 MB), roots verified identical across all engines and modes:

| | sync | async (8 workers) |
|---|---|---|
| fastssz delegation | 1.23 s | **0.43 s** |
| reflection engine | 1.53 s | **0.71 s** |

For reference, a widely used consensus client hashes the same state in 1.66 s through its generated single-threaded path and 0.86 s through its multithreaded optimized full-recompute pipeline.

### Validation

- Async and synchronous roots compared across ~25k randomized and boundary shape/cadence cases (binary + progressive lists, nested shapes, active-fields containers, packed chunks), plus an independent four-way stress harness (incremental, legacy, tree-proof wrapper, naive spec implementation).
- Real mainnet beacon state hashed identically by delegation, reflection, sync and async paths.
- Race detector clean at `-cpu=2,8`, including concurrent pooled hashers and mid-stream enable/disable.
- hasher package coverage 99.4%, with the async machinery at 100%.
