### PR TITLE
Harden integer conversions in generated SSZ code

### DIFF
--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -95,13 +95,13 @@ func TestGenerateListRegionBound(t *testing.T) {
 	}{
 		// A spec-driven fixed section: 4 offset bytes for the dynamic tail plus
 		// the resolved size of Fixed. Never zero, so no guard.
-		{"spec-sized container element", "itemCount > (len(buf)-startOffset)/(size1+4)", 1},
+		{"spec-sized container element", "uint64(itemCount) > uint64(len(buf)-startOffset)/(size1+4)", 1},
 		// Two entries, each an offset plus the entry's own 4-byte fixed section.
 		// Fully static, so it folds to a literal.
 		{"static vector element", "itemCount > (len(buf)-startOffset)/(16)", 1},
 		// A resolved count can make the divisor zero -- or wrap it past zero --
 		// so the bound itself is checked before dividing by it.
-		{"spec-counted vector element", "int(expr1)*8 > 0 && itemCount > (len(buf)-startOffset)/(int(expr1)*8)", 1},
+		{"spec-counted vector element", "expr1*8 > 0 && uint64(itemCount) > uint64(len(buf)-startOffset)/(expr1*8)", 1},
 		// A wrapper contributes nothing of its own: the bound is the wrapped
 		// vector's, two entries of one offset each.
 		{"wrapper element", "itemCount > (len(buf)-startOffset)/(8)", 1},

--- a/codegen/gen_common.go
+++ b/codegen/gen_common.go
@@ -17,21 +17,15 @@ import (
 
 const varNameVLen = "vlen"
 
-// intCapExpr returns expr usable as an int capacity cap. A capacity above the
-// platform integer range clamps to math.MaxInt — the limit check itself
-// compares in uint64, so nothing is lost — while a plain conversion of a
-// 64-bit limit could wrap negative. Integer literals are resolved at
-// generation time: small ones pass through untouched, larger ones emit the
-// runtime clamp so the generated code compiles on 32-bit platforms too.
-func intCapExpr(expr string, typePrinter *TypePrinter) string {
-	if v, err := strconv.ParseUint(expr, 10, 64); err == nil {
-		if v <= math.MaxInt32 {
-			return expr
-		}
-		return fmt.Sprintf("int(min(uint64(%s), uint64(%s.MaxInt)))", expr, typePrinter.AddImport("math", "math"))
-	}
-	return fmt.Sprintf("int(min(%s, uint64(%s.MaxInt)))", expr, typePrinter.AddImport("math", "math"))
-}
+// convSuppressComment rides emitted lines that convert a resolved ctx.exprs
+// value to int. The value is bounded by the platform-size guard emitted at
+// resolution, but CodeQL and gosec do not carry range facts through array
+// elements, so the exact conversion is flagged. gosec requires #nosec at the
+// comment start; the lgtm marker is CodeQL's end-of-line suppression form
+// (codeql[...] only works as a standalone line), matched anywhere in the
+// comment, and takes effect in scans that include the alert-suppression
+// queries.
+const convSuppressComment = " // #nosec G115 lgtm[go/incorrect-integer-conversion] -- bounded by the platform-size guard at spec resolution"
 
 // Generated error expression constants shared across codegen files.
 const (
@@ -257,7 +251,11 @@ func (g *staticSizeVarGenerator) getStaticSizeVar(desc *ssztypes.TypeDescriptor)
 					exprVar = fmt.Sprintf("(%s+7)/8", exprVar)
 				}
 
-				appendCode(g.codeBuf, 0, "%s := %s * int(%s)\n", sizeVar, itemSizeVar, exprVar)
+				convSuppress := ""
+				if g.exprVarGenerator.isSlice {
+					convSuppress = convSuppressComment
+				}
+				appendCode(g.codeBuf, 0, "%s := %s * int(%s)%s\n", sizeVar, itemSizeVar, exprVar, convSuppress)
 			} else {
 				appendCode(g.codeBuf, 0, "%s := %s * %d\n", sizeVar, itemSizeVar, desc.Len)
 			}
@@ -468,4 +466,30 @@ func localizedVarName(varName string, indent int) string {
 		return "t2"
 	}
 	return "t"
+}
+
+// intCapExpr returns expr usable as an int capacity cap. A capacity above the
+// platform integer range clamps to math.MaxInt — the limit check itself
+// compares in uint64, so nothing is lost — while a plain conversion of a
+// 64-bit limit could wrap negative. Integer literals are resolved at
+// generation time: small ones pass through untouched, larger ones emit the
+// runtime clamp so the generated code compiles on 32-bit platforms too. The
+// qualified helper keeps the generated code clear of the bare min builtin,
+// which a target package may shadow.
+func intCapExpr(expr string) string {
+	if v, err := strconv.ParseUint(expr, 10, 64); err == nil && v <= math.MaxInt32 {
+		return expr
+	}
+	return fmt.Sprintf("sszutils.CapToInt(%s)", expr)
+}
+
+// uintLitArg types an integer literal above the portable int range as uint64
+// for splicing into an `any` argument (error constructors). An untyped
+// constant there defaults to int, which does not compile for values past the
+// target's int width. Variables and smaller literals pass through untouched.
+func uintLitArg(expr string) string {
+	if v, err := strconv.ParseUint(expr, 10, 64); err == nil && v > math.MaxInt32 {
+		return fmt.Sprintf("uint64(%s)", expr)
+	}
+	return expr
 }

--- a/codegen/gen_common.go
+++ b/codegen/gen_common.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -15,6 +16,22 @@ import (
 )
 
 const varNameVLen = "vlen"
+
+// intCapExpr returns expr usable as an int capacity cap. A capacity above the
+// platform integer range clamps to math.MaxInt — the limit check itself
+// compares in uint64, so nothing is lost — while a plain conversion of a
+// 64-bit limit could wrap negative. Integer literals are resolved at
+// generation time: small ones pass through untouched, larger ones emit the
+// runtime clamp so the generated code compiles on 32-bit platforms too.
+func intCapExpr(expr string, typePrinter *TypePrinter) string {
+	if v, err := strconv.ParseUint(expr, 10, 64); err == nil {
+		if v <= math.MaxInt32 {
+			return expr
+		}
+		return fmt.Sprintf("int(min(uint64(%s), uint64(%s.MaxInt)))", expr, typePrinter.AddImport("math", "math"))
+	}
+	return fmt.Sprintf("int(min(%s, uint64(%s.MaxInt)))", expr, typePrinter.AddImport("math", "math"))
+}
 
 // Generated error expression constants shared across codegen files.
 const (
@@ -76,6 +93,34 @@ func (g *exprVarGenerator) getExprVar(expr string, defaultValue uint64) string {
 
 	g.varMap[exprKey] = exprVar
 
+	return exprVar
+}
+
+// getSizeExprVar resolves a size-domain spec expression (a vector or byte
+// size, as opposed to a list limit) via getExprVar and additionally rejects a
+// resolved value above the platform integer range: sizes pass through int at
+// their use sites (allocations, loop bounds, the int-based codec surface), so
+// the guard makes those conversions exact. List limits keep their full uint64
+// range by resolving through getExprVar directly.
+func (g *exprVarGenerator) getSizeExprVar(expr string, defaultValue uint64) string {
+	if expr == "" {
+		return fmt.Sprintf("%v", defaultValue)
+	}
+
+	exprVar := g.getExprVar(expr, defaultValue)
+
+	guardKey := sha256.Sum256([]byte(fmt.Sprintf("sizeguard\n%s\n%v", expr, defaultValue)))
+	if _, ok := g.varMap[guardKey]; ok {
+		return exprVar
+	}
+
+	mathPkgName := g.typePrinter.AddImport("math", "math")
+	appendCode(g.codeBuf, 0, "if %s > %s.MaxInt {\n", exprVar, mathPkgName)
+	appendCode(g.codeBuf, 1, "err = sszutils.ErrPlatformOverflowFn(\"size expression %s\", %s)\n", expr, exprVar)
+	appendCode(g.codeBuf, 1, "return %s\n", g.retVars)
+	appendCode(g.codeBuf, 0, "}\n")
+
+	g.varMap[guardKey] = exprVar
 	return exprVar
 }
 
@@ -206,7 +251,7 @@ func (g *staticSizeVarGenerator) getStaticSizeVar(desc *ssztypes.TypeDescriptor)
 				if desc.SszTypeFlags&ssztypes.SszTypeFlagHasBitSize != 0 && desc.BitSize > 0 {
 					defaultValue = uint64(desc.BitSize)
 				}
-				exprVar := g.exprVarGenerator.getExprVar(*sizeExpression, defaultValue)
+				exprVar := g.exprVarGenerator.getSizeExprVar(*sizeExpression, defaultValue)
 
 				if desc.SszTypeFlags&ssztypes.SszTypeFlagHasBitSize != 0 {
 					exprVar = fmt.Sprintf("(%s+7)/8", exprVar)
@@ -360,7 +405,7 @@ func minSizeExpr(desc *ssztypes.TypeDescriptor, sizeVars *staticSizeVarGenerator
 			return expr, "", exprOk && desc.Len > 0
 		}
 
-		count := fmt.Sprintf("int(%s)", sizeVars.exprVarGenerator.getExprVar(*desc.SizeExpression, uint64(desc.Len)))
+		count := fmt.Sprintf("int(%s)", sizeVars.exprVarGenerator.getSizeExprVar(*desc.SizeExpression, uint64(desc.Len)))
 		expr, exprOk := mulOrAddExpr("*", count, perElem)
 
 		// The product is what the caller divides by, so it is what has to be

--- a/codegen/gen_common.go
+++ b/codegen/gen_common.go
@@ -15,7 +15,10 @@ import (
 	"github.com/pk910/dynamic-ssz/ssztypes"
 )
 
-const varNameVLen = "vlen"
+const (
+	varNameVLen     = "vlen"
+	varNameElemSize = "elemSize"
+)
 
 // convSuppressComment rides emitted lines that convert a resolved ctx.exprs
 // value to int. The value is bounded by the platform-size guard emitted at
@@ -181,7 +184,9 @@ func (g *staticSizeVarGenerator) getStaticSizeVar(desc *ssztypes.TypeDescriptor)
 	// implement DynamicSizer (fullyDelegatesSSZ requires it), so that is the only
 	// case to handle here.
 	if desc.SszType == ssztypes.SszUnspecifiedType && desc.SszCompatFlags&ssztypes.SszCompatFlagDynamicSizer != 0 {
-		appendCode(g.codeBuf, 0, "%s := new(%s).SizeSSZDyn(ds)\n", sizeVar, g.typePrinter.InnerTypeString(desc))
+		// The sizer speaks int; clamping a misbehaving negative to zero keeps
+		// the unsigned sum from wrapping huge.
+		appendCode(g.codeBuf, 0, "%s := uint64(sszutils.Max(new(%s).SizeSSZDyn(ds), 0))\n", sizeVar, g.typePrinter.InnerTypeString(desc))
 		g.varMap[descHash] = sizeVar
 		return sizeVar, nil
 	}
@@ -251,11 +256,11 @@ func (g *staticSizeVarGenerator) getStaticSizeVar(desc *ssztypes.TypeDescriptor)
 					exprVar = fmt.Sprintf("(%s+7)/8", exprVar)
 				}
 
-				convSuppress := ""
-				if g.exprVarGenerator.isSlice {
-					convSuppress = convSuppressComment
-				}
-				appendCode(g.codeBuf, 0, "%s := %s * int(%s)%s\n", sizeVar, itemSizeVar, exprVar, convSuppress)
+				appendCode(g.codeBuf, 0, "%s := %s * %s\n", sizeVar, itemSizeVar, exprVar)
+			} else if _, lerr := strconv.ParseUint(itemSizeVar, 10, 64); lerr == nil {
+				// A fully literal product needs the explicit uint64 type to
+				// join the other unsigned size variables.
+				appendCode(g.codeBuf, 0, "%s := uint64(%s * %d)\n", sizeVar, itemSizeVar, desc.Len)
 			} else {
 				appendCode(g.codeBuf, 0, "%s := %s * %d\n", sizeVar, itemSizeVar, desc.Len)
 			}
@@ -403,12 +408,12 @@ func minSizeExpr(desc *ssztypes.TypeDescriptor, sizeVars *staticSizeVarGenerator
 			return expr, "", exprOk && desc.Len > 0
 		}
 
-		count := fmt.Sprintf("int(%s)", sizeVars.exprVarGenerator.getSizeExprVar(*desc.SizeExpression, uint64(desc.Len)))
+		count := sizeVars.exprVarGenerator.getSizeExprVar(*desc.SizeExpression, uint64(desc.Len))
 		expr, exprOk := mulOrAddExpr("*", count, perElem)
 
 		// The product is what the caller divides by, so it is what has to be
 		// checked: a spec value large enough to overflow the multiplication
-		// lands on zero or a negative, neither of which bounds anything. The
+		// wraps to zero or a small value, neither of which bounds anything. The
 		// reflection engine drops such a product for the same reason.
 		return expr, expr, exprOk
 
@@ -481,6 +486,17 @@ func intCapExpr(expr string) string {
 		return expr
 	}
 	return fmt.Sprintf("sszutils.CapToInt(%s)", expr)
+}
+
+// uintCmpExpr renders a length comparison against a resolved size or limit.
+// Expression values compare in uint64 (lengths are never negative, and the
+// resolved value spans the full range); literals in the portable int range
+// compare as plain int constants, sparing the pointless cast.
+func uintCmpExpr(lenExpr, op, limit string) string {
+	if v, err := strconv.ParseUint(limit, 10, 64); err == nil && v <= math.MaxInt32 {
+		return fmt.Sprintf("%s %s %s", lenExpr, op, limit)
+	}
+	return fmt.Sprintf("uint64(%s) %s %s", lenExpr, op, limit)
 }
 
 // uintLitArg types an integer literal above the portable int range as uint64

--- a/codegen/gen_decoder.go
+++ b/codegen/gen_decoder.go
@@ -524,11 +524,11 @@ func (ctx *decoderContext) unmarshalTypeWrapper(desc *ssztypes.TypeDescriptor, v
 func (ctx *decoderContext) unmarshalContainer(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int) error {
 	staticSize := int64(0)
 	staticSizeVars := []string{}
-	hasDynamicFields := false
+	dynFieldCount := 0
 	for _, field := range desc.ContainerDesc.Fields {
 		if field.Type.SszTypeFlags&ssztypes.SszTypeFlagIsDynamic != 0 {
 			staticSize += 4
-			hasDynamicFields = true
+			dynFieldCount++
 		} else {
 			if field.Type.SszTypeFlags&ssztypes.SszTypeFlagHasSizeExpr != 0 {
 				sizeVar, err := ctx.staticSizeVars.getStaticSizeVar(field.Type)
@@ -545,20 +545,29 @@ func (ctx *decoderContext) unmarshalContainer(desc *ssztypes.TypeDescriptor, var
 
 	totalStaticSizeExpr := strings.Join(staticSizeVars, "+")
 	if len(staticSizeVars) > 1 {
-		ctx.appendCode(indent, "totalSize := %s\n", totalStaticSizeExpr)
+		// The decode arithmetic below runs in the int domain, so the unsigned
+		// size sum binds once as int.
+		ctx.appendCode(indent, "totalSize := int(%s)\n", totalStaticSizeExpr)
 		totalStaticSizeExpr = "totalSize"
 	}
 
 	// Read fixed fields and offsets
-	ctx.appendCode(indent, "maxOffset := dec.GetLength()\n")
 
 	startPosVar := fmt.Sprintf("startPos%d", ctx.startPosVarCounter)
-	if hasDynamicFields {
+	if dynFieldCount > 0 {
 		ctx.appendCode(indent, "%s := dec.GetPosition()\n", startPosVar)
 		ctx.startPosVarCounter++
 	}
-	errCode := fmt.Sprintf("sszutils.ErrFixedFieldsEOFFn(maxOffset, %s)", totalStaticSizeExpr)
-	ctx.appendCode(indent, "if maxOffset < %s {\n\treturn %s\n}\n", totalStaticSizeExpr, typePath.getErrorWith(errCode))
+	errCode := fmt.Sprintf("sszutils.ErrFixedFieldsEOFFn(dec.GetLength(), %s)", totalStaticSizeExpr)
+	ctx.appendCode(indent, "if dec.GetLength() < %s {\n\treturn %s\n}\n", totalStaticSizeExpr, typePath.getErrorWith(errCode))
+	// Only an offset after the first checks against maxOffset (the first
+	// compares against the static size), so the bound is emitted for two or
+	// more dynamic fields. Offsets are 4-byte values, so the bound lives in
+	// uint32: a region past the offset range caps, since no offset can
+	// address it.
+	if dynFieldCount > 1 {
+		ctx.appendCode(indent, "maxOffset := uint32(sszutils.Min(uint64(dec.GetLength()), %s.MaxUint32))\n", ctx.typePrinter.AddImport("math", "math"))
+	}
 	dynamicFields := make([]int, 0)
 
 	for idx, field := range desc.ContainerDesc.Fields {
@@ -570,10 +579,14 @@ func (ctx *decoderContext) unmarshalContainer(desc *ssztypes.TypeDescriptor, var
 			ctx.appendCode(indent, "if err != nil {\n\treturn %s\n}\n", fieldPath.getErrorWith("err"))
 			if len(dynamicFields) > 0 {
 				errCode = fmt.Sprintf("sszutils.ErrOffsetOutOfRangeFn(offset%d, offset%d, maxOffset)", idx, dynamicFields[len(dynamicFields)-1])
-				ctx.appendCode(indent, "if offset%d < offset%d || int(offset%d) > maxOffset {\n\treturn %s\n}\n", idx, dynamicFields[len(dynamicFields)-1], idx, fieldPath.getErrorWith(errCode))
+				ctx.appendCode(indent, "if offset%d < offset%d || offset%d > maxOffset {\n\treturn %s\n}\n", idx, dynamicFields[len(dynamicFields)-1], idx, fieldPath.getErrorWith(errCode))
 			} else {
 				errCode = fmt.Sprintf("sszutils.ErrFirstOffsetMismatchFn(offset%d, %s)", idx, totalStaticSizeExpr)
-				ctx.appendCode(indent, "if int(offset%d) != %s {\n\treturn %s\n}\n", idx, totalStaticSizeExpr, fieldPath.getErrorWith(errCode))
+				firstOffCmp := fmt.Sprintf("int(offset%d) != %s", idx, totalStaticSizeExpr)
+				if _, lerr := strconv.ParseUint(totalStaticSizeExpr, 10, 64); lerr == nil {
+					firstOffCmp = fmt.Sprintf("offset%d != %s", idx, totalStaticSizeExpr)
+				}
+				ctx.appendCode(indent, "if %s {\n\treturn %s\n}\n", firstOffCmp, fieldPath.getErrorWith(errCode))
 			}
 			dynamicFields = append(dynamicFields, idx)
 		} else {
@@ -659,7 +672,10 @@ func (ctx *decoderContext) unmarshalVector(desc *ssztypes.TypeDescriptor, varNam
 	// resolved size; emitted once the array expression exists.
 	arrayBoundPending := false
 
+	// limitVar is the int-domain bound the decode arithmetic uses; limit64 is
+	// the uint64-domain form for length checks and error arguments.
 	limitVar := ""
+	limit64 := ""
 	bitlimitVar := ""
 
 	if sizeExpression != nil {
@@ -670,13 +686,17 @@ func (ctx *decoderContext) unmarshalVector(desc *ssztypes.TypeDescriptor, varNam
 
 		exprVar := ctx.exprVars.getSizeExprVar(*sizeExpression, defaultValue)
 
+		// The decode arithmetic below runs in the int domain, so the resolved
+		// limit binds once as int and every use stays plain.
 		if desc.SszTypeFlags&ssztypes.SszTypeFlagHasBitSize != 0 {
 			ctx.appendCode(indent, "bitlimit := %s\n", exprVar)
-			ctx.appendCode(indent, "limit := (bitlimit+7)/8\n")
-			bitlimitVar = "int(bitlimit)"
+			ctx.appendCode(indent, "limit := (bitlimit + 7) / 8\n")
+			bitlimitVar = "bitlimit"
 			limitVar = "int(limit)"
+			limit64 = "limit"
 		} else {
 			limitVar = fmt.Sprintf("int(%s)", exprVar)
+			limit64 = exprVar
 		}
 
 		if desc.Kind == reflect.Array {
@@ -691,6 +711,7 @@ func (ctx *decoderContext) unmarshalVector(desc *ssztypes.TypeDescriptor, varNam
 			bitlimitVar = fmt.Sprintf("%d", desc.BitSize)
 		}
 		limitVar = fmt.Sprintf("%d", desc.Len)
+		limit64 = limitVar
 	}
 
 	valueVar := varName
@@ -708,8 +729,8 @@ func (ctx *decoderContext) unmarshalVector(desc *ssztypes.TypeDescriptor, varNam
 	}
 
 	if arrayBoundPending {
-		ctx.appendCode(indent, "if %s > len(%s) {\n", limitVar, indexValueVar)
-		errCode := fmt.Sprintf("sszutils.ErrVectorSizeExceedsArrayFn(%s, len(%s))", limitVar, indexValueVar)
+		ctx.appendCode(indent, "if %s {\n", uintCmpExpr(fmt.Sprintf("len(%s)", indexValueVar), "<", limit64))
+		errCode := fmt.Sprintf("sszutils.ErrVectorSizeExceedsArrayFn(%s, len(%s))", limit64, indexValueVar)
 		ctx.appendCode(indent, "\treturn %s\n", typePath.getErrorWith(errCode))
 		ctx.appendCode(indent, "}\n")
 	}
@@ -770,12 +791,20 @@ func (ctx *decoderContext) unmarshalVector(desc *ssztypes.TypeDescriptor, varNam
 			if err != nil {
 				return err
 			}
+			// The decode arithmetic below runs in the int domain, so the
+			// unsigned size variable binds once as int. The bind name carries
+			// the size variable's suffix: nested element scopes would otherwise
+			// shadow an outer bind that is still referenced after the inner
+			// declaration.
+			bindVar := varNameElemSize + strings.TrimPrefix(fieldSizeVar, "size")
+			ctx.appendCode(indent, bindVar+" := int(%s)\n", fieldSizeVar)
+			fieldSizeVar = bindVar
 		} else {
 			fieldSizeVar = fmt.Sprintf("%d", desc.ElemDesc.Size)
 		}
 
 		if !noBufCheck {
-			errCode := fmt.Sprintf("sszutils.ErrVectorElementsEOFFn(dec.GetLength(), int(%s)*%s)", limitVar, fieldSizeVar)
+			errCode := fmt.Sprintf("sszutils.ErrVectorElementsEOFFn(dec.GetLength(), %s*%s)", limitVar, fieldSizeVar)
 			ctx.appendCode(indent, "if %s*%s > dec.GetLength() {\n\treturn %s\n}\n", limitVar, fieldSizeVar, typePath.getErrorWith(errCode))
 		}
 
@@ -1013,6 +1042,14 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 			if err != nil {
 				return err
 			}
+			// The decode arithmetic below runs in the int domain, so the
+			// unsigned size variable binds once as int. The bind name carries
+			// the size variable's suffix: nested element scopes would otherwise
+			// shadow an outer bind that is still referenced after the inner
+			// declaration.
+			bindVar := varNameElemSize + strings.TrimPrefix(fieldSizeVar, "size")
+			ctx.appendCode(indent, bindVar+" := int(%s)\n", fieldSizeVar)
+			fieldSizeVar = bindVar
 		} else {
 			fieldSizeVar = fmt.Sprintf("%d", desc.ElemDesc.Size)
 		}
@@ -1046,7 +1083,7 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 		}
 		if hasMax {
 			errCode := fmt.Sprintf("sszutils.ErrListLengthFn(itemCount, %s)", uintLitArg(maxVar))
-			ctx.appendCode(indent+1, "if uint64(itemCount) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+			ctx.appendCode(indent+1, "if %s {\n\treturn %s\n}\n", uintCmpExpr("itemCount", ">", maxVar), typePath.getErrorWith(errCode))
 		}
 		ctx.appendCode(indent+1, "%s = sszutils.SizeListSlice(dec, %s, itemCount, %s)\n", valueVar, valueVar, fieldSizeVar)
 		ctx.appendCode(indent, "} else {\n")
@@ -1155,7 +1192,11 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 				guard = fmt.Sprintf("%s > 0 && ", positiveGuard)
 			}
 			errCode = fmt.Sprintf("sszutils.ErrListRegionTooSmallFn(itemCount, %s, sszLen-int(startOffset))", minElemSize)
-			ctx.appendCode(indent, "if dec.LengthKnown() && %sitemCount > (sszLen-int(startOffset))/(%s) {\n\treturn %s\n}\n", guard, minElemSize, typePath.getErrorWith(errCode))
+			regionCmp := fmt.Sprintf("uint64(itemCount) > uint64(sszLen-int(startOffset))/(%s)", minElemSize)
+			if _, lerr := strconv.ParseUint(minElemSize, 10, 64); lerr == nil {
+				regionCmp = fmt.Sprintf("itemCount > (sszLen-int(startOffset))/(%s)", minElemSize)
+			}
+			ctx.appendCode(indent, "if dec.LengthKnown() && %s%s {\n\treturn %s\n}\n", guard, regionCmp, typePath.getErrorWith(errCode))
 		}
 
 		// read offsets
@@ -1319,7 +1360,7 @@ func (ctx *decoderContext) unmarshalBitlist(desc *ssztypes.TypeDescriptor, varNa
 		bitsPkgName := ctx.typePrinter.AddImport("math/bits", "bits")
 		ctx.appendCode(indent, "bitCount := 8*(blen-1) + int(%s.Len8(%s[blen-1])) - 1\n", bitsPkgName, valueVar)
 		errCode := fmt.Sprintf("sszutils.ErrBitlistLengthFn(bitCount, %s)", uintLitArg(maxVar))
-		ctx.appendCode(indent, "if uint64(bitCount) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+		ctx.appendCode(indent, "if %s {\n\treturn %s\n}\n", uintCmpExpr("bitCount", ">", maxVar), typePath.getErrorWith(errCode))
 	}
 
 	return nil

--- a/codegen/gen_decoder.go
+++ b/codegen/gen_decoder.go
@@ -6,8 +6,10 @@ package codegen
 
 import (
 	"fmt"
+	"math"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/pk910/dynamic-ssz/ssztypes"
@@ -931,7 +933,7 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 		maxVar = "0"
 	}
 	cappedMaxVar := func() string {
-		return intCapExpr(maxVar, ctx.typePrinter)
+		return intCapExpr(maxVar)
 	}
 	growthLimit := func() string {
 		if hasMax {
@@ -1043,8 +1045,8 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 			ctx.appendCode(indent+1, "itemCount = sszLen / %s\n", fieldSizeVar)
 		}
 		if hasMax {
-			errCode := fmt.Sprintf("sszutils.ErrListLengthFn(itemCount, %s)", maxVar)
-			ctx.appendCode(indent+1, "if uint64(max(itemCount, 0)) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+			errCode := fmt.Sprintf("sszutils.ErrListLengthFn(itemCount, %s)", uintLitArg(maxVar))
+			ctx.appendCode(indent+1, "if uint64(itemCount) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
 		}
 		ctx.appendCode(indent+1, "%s = sszutils.SizeListSlice(dec, %s, itemCount, %s)\n", valueVar, valueVar, fieldSizeVar)
 		ctx.appendCode(indent, "} else {\n")
@@ -1068,7 +1070,7 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 		ctx.appendCode(indent+2, "}\n")
 		// ssz-max bounds the list while its extent is still unknown.
 		if hasMax {
-			errCode := fmt.Sprintf("sszutils.ErrListLengthFn(%s+1, %s)", indexVar, maxVar)
+			errCode := fmt.Sprintf("sszutils.ErrListLengthFn(%s+1, %s)", indexVar, uintLitArg(maxVar))
 			ctx.appendCode(indent+2, "if uint64(%s) >= %s {\n\treturn %s\n}\n", indexVar, maxVar, typePath.getErrorWith(errCode))
 		}
 		ctx.appendCode(indent+2, "%s = sszutils.GrowSlice(%s, %s+1, %s)\n", valueVar, valueVar, indexVar, growthLimit())
@@ -1132,10 +1134,12 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 		// reflection path does.
 		errCode := "sszutils.ErrInvalidListStartOffsetFn(startOffset, sszLen)"
 		// A zero first offset in a non-empty region is rejected (it would
-		// otherwise decode as an empty list), matching the buffer path.
-		ctx.appendCode(indent, "if startOffset%%4 != 0 || sszLen < int(startOffset) || (sszLen != 0 && startOffset == 0) {\n\treturn %s\n}\n", typePath.getErrorWith(errCode))
+		// otherwise decode as an empty list), matching the buffer path. The
+		// length bound compares in the unsigned domain: on a 32-bit platform
+		// int(startOffset) can wrap negative and would slip through.
+		ctx.appendCode(indent, "if startOffset%%4 != 0 || uint64(startOffset) > uint64(sszLen) || (sszLen != 0 && startOffset == 0) {\n\treturn %s\n}\n", typePath.getErrorWith(errCode))
 		if hasMax {
-			errCode = fmt.Sprintf("sszutils.ErrListLengthFn(itemCount, %s)", maxVar)
+			errCode = fmt.Sprintf("sszutils.ErrListLengthFn(itemCount, %s)", uintLitArg(maxVar))
 			ctx.appendCode(indent, "if uint64(startOffset)/4 > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
 		}
 		// The offset table declares the count, but only the region can prove the
@@ -1219,9 +1223,9 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 		ctx.appendCode(indent+1, "if %s >= len(%s) {\n", indexVar, indexValueVar)
 		ctx.appendCode(indent+2, "chunkLen := cap(%s)\n", indexValueVar)
 		ctx.appendCode(indent+2, "if chunkLen == len(%s) {\n", indexValueVar)
-		ctx.appendCode(indent+3, "chunkLen = max(%s+1, 8, len(%s)*2)\n", indexVar, indexValueVar)
+		ctx.appendCode(indent+3, "chunkLen = sszutils.Max(sszutils.Max(%s+1, 8), len(%s)*2)\n", indexVar, indexValueVar)
 		ctx.appendCode(indent+2, "}\n")
-		ctx.appendCode(indent+2, "%s = sszutils.GrowSlice(%s, min(itemCount, chunkLen), itemCount)\n", valueVar, valueVar)
+		ctx.appendCode(indent+2, "%s = sszutils.GrowSlice(%s, sszutils.Min(itemCount, chunkLen), itemCount)\n", valueVar, valueVar)
 		ctx.appendCode(indent+1, "}\n")
 
 		// The trailing element runs to the end of the list, so it takes an open
@@ -1286,7 +1290,18 @@ func (ctx *decoderContext) unmarshalBitlist(desc *ssztypes.TypeDescriptor, varNa
 	// as a read cap and an over-long payload is never allocated.
 	bitlistMaxArg := "-1"
 	if hasMax {
-		ctx.appendCode(indent, "bitlistMaxBytes := (%s / 8) + 1\n", intCapExpr(maxVar, ctx.typePrinter))
+		// The byte cap divides in uint64 before capping to int; capping the bit
+		// limit first would round the cap down a byte for limits past MaxInt.
+		var bitlistCap string
+		switch v, err := strconv.ParseUint(maxVar, 10, 64); {
+		case err == nil && v/8 >= math.MaxInt32:
+			bitlistCap = fmt.Sprintf("sszutils.CapToInt(%d)", v/8+1)
+		case err == nil:
+			bitlistCap = fmt.Sprintf("(%s / 8) + 1", maxVar)
+		default:
+			bitlistCap = fmt.Sprintf("sszutils.CapToInt(%s/8 + 1)", maxVar)
+		}
+		ctx.appendCode(indent, "bitlistMaxBytes := %s\n", bitlistCap)
 		bitlistMaxArg = "bitlistMaxBytes"
 	}
 	ctx.appendCode(indent, "if buf, err := sszutils.DecodeByteListInto(dec, %s, %s); err != nil {\n", valueVar, bitlistMaxArg)
@@ -1303,8 +1318,8 @@ func (ctx *decoderContext) unmarshalBitlist(desc *ssztypes.TypeDescriptor, varNa
 	if hasMax {
 		bitsPkgName := ctx.typePrinter.AddImport("math/bits", "bits")
 		ctx.appendCode(indent, "bitCount := 8*(blen-1) + int(%s.Len8(%s[blen-1])) - 1\n", bitsPkgName, valueVar)
-		errCode := fmt.Sprintf("sszutils.ErrBitlistLengthFn(bitCount, %s)", maxVar)
-		ctx.appendCode(indent, "if uint64(max(bitCount, 0)) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+		errCode := fmt.Sprintf("sszutils.ErrBitlistLengthFn(bitCount, %s)", uintLitArg(maxVar))
+		ctx.appendCode(indent, "if uint64(bitCount) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
 	}
 
 	return nil

--- a/codegen/gen_decoder.go
+++ b/codegen/gen_decoder.go
@@ -520,7 +520,7 @@ func (ctx *decoderContext) unmarshalTypeWrapper(desc *ssztypes.TypeDescriptor, v
 
 // unmarshalContainer generates unmarshal code for SSZ container (struct) types.
 func (ctx *decoderContext) unmarshalContainer(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int) error {
-	staticSize := 0
+	staticSize := uint32(0)
 	staticSizeVars := []string{}
 	hasDynamicFields := false
 	for _, field := range desc.ContainerDesc.Fields {
@@ -535,7 +535,7 @@ func (ctx *decoderContext) unmarshalContainer(desc *ssztypes.TypeDescriptor, var
 				}
 				staticSizeVars = append(staticSizeVars, sizeVar)
 			} else {
-				staticSize += int(field.Type.Size)
+				staticSize += field.Type.Size
 			}
 		}
 	}
@@ -548,15 +548,15 @@ func (ctx *decoderContext) unmarshalContainer(desc *ssztypes.TypeDescriptor, var
 	}
 
 	// Read fixed fields and offsets
-	ctx.appendCode(indent, "maxOffset := uint32(dec.GetLength())\n")
+	ctx.appendCode(indent, "maxOffset := dec.GetLength()\n")
 
 	startPosVar := fmt.Sprintf("startPos%d", ctx.startPosVarCounter)
 	if hasDynamicFields {
 		ctx.appendCode(indent, "%s := dec.GetPosition()\n", startPosVar)
 		ctx.startPosVarCounter++
 	}
-	errCode := fmt.Sprintf("sszutils.ErrFixedFieldsEOFFn(maxOffset, uint32(%s))", totalStaticSizeExpr)
-	ctx.appendCode(indent, "if maxOffset < uint32(%s) {\n\treturn %s\n}\n", totalStaticSizeExpr, typePath.getErrorWith(errCode))
+	errCode := fmt.Sprintf("sszutils.ErrFixedFieldsEOFFn(maxOffset, %s)", totalStaticSizeExpr)
+	ctx.appendCode(indent, "if maxOffset < %s {\n\treturn %s\n}\n", totalStaticSizeExpr, typePath.getErrorWith(errCode))
 	dynamicFields := make([]int, 0)
 
 	for idx, field := range desc.ContainerDesc.Fields {
@@ -568,10 +568,10 @@ func (ctx *decoderContext) unmarshalContainer(desc *ssztypes.TypeDescriptor, var
 			ctx.appendCode(indent, "if err != nil {\n\treturn %s\n}\n", fieldPath.getErrorWith("err"))
 			if len(dynamicFields) > 0 {
 				errCode = fmt.Sprintf("sszutils.ErrOffsetOutOfRangeFn(offset%d, offset%d, maxOffset)", idx, dynamicFields[len(dynamicFields)-1])
-				ctx.appendCode(indent, "if offset%d < offset%d || offset%d > maxOffset {\n\treturn %s\n}\n", idx, dynamicFields[len(dynamicFields)-1], idx, fieldPath.getErrorWith(errCode))
+				ctx.appendCode(indent, "if offset%d < offset%d || int(offset%d) > maxOffset {\n\treturn %s\n}\n", idx, dynamicFields[len(dynamicFields)-1], idx, fieldPath.getErrorWith(errCode))
 			} else {
 				errCode = fmt.Sprintf("sszutils.ErrFirstOffsetMismatchFn(offset%d, %s)", idx, totalStaticSizeExpr)
-				ctx.appendCode(indent, "if offset%d != uint32(%s) {\n\treturn %s\n}\n", idx, totalStaticSizeExpr, fieldPath.getErrorWith(errCode))
+				ctx.appendCode(indent, "if int(offset%d) != %s {\n\treturn %s\n}\n", idx, totalStaticSizeExpr, fieldPath.getErrorWith(errCode))
 			}
 			dynamicFields = append(dynamicFields, idx)
 		} else {
@@ -666,7 +666,7 @@ func (ctx *decoderContext) unmarshalVector(desc *ssztypes.TypeDescriptor, varNam
 			defaultValue = uint64(desc.BitSize)
 		}
 
-		exprVar := ctx.exprVars.getExprVar(*sizeExpression, defaultValue)
+		exprVar := ctx.exprVars.getSizeExprVar(*sizeExpression, defaultValue)
 
 		if desc.SszTypeFlags&ssztypes.SszTypeFlagHasBitSize != 0 {
 			ctx.appendCode(indent, "bitlimit := %s\n", exprVar)
@@ -819,21 +819,18 @@ func (ctx *decoderContext) unmarshalVector(desc *ssztypes.TypeDescriptor, varNam
 	} else {
 		// dynamic elements
 		ctx.appendCode(indent, "sszLen := dec.GetLength()\n")
-		errCode := fmt.Sprintf("sszutils.ErrVectorOffsetsEOFFn(dec.GetLength(), int(%s)*4)", limitVar)
+		errCode := fmt.Sprintf("sszutils.ErrVectorOffsetsEOFFn(dec.GetLength(), %s*4)", limitVar)
 		ctx.appendCode(indent, "if %s*4 > sszLen {\n\treturn %s\n}\n", limitVar, typePath.getErrorWith(errCode))
 		startPosVar := fmt.Sprintf("startPos%d", ctx.startPosVarCounter)
 		ctx.startPosVarCounter++
 		ctx.appendCode(indent, "%s := dec.GetPosition()\n", startPosVar)
 
 		// check first offset
-		ctx.appendCode(indent, "startOffset, err := dec.DecodeOffset()\n")
+		ctx.appendCode(indent, "firstOffset, err := dec.DecodeOffset()\n")
 		ctx.appendCode(indent, "if err != nil {\n\treturn %s\n}\n", typePath.getErrorWith("err"))
-		errCode = fmt.Sprintf("sszutils.ErrFirstOffsetMismatchFn(startOffset, %s*4)", limitVar)
-		// startOffset is a uint32 (from DecodeOffset); limitVar may be a typed
-		// int expression (e.g. int(expr0)) when the vector length is dynamic, so
-		// the comparison RHS must be converted to uint32 to keep the types
-		// compatible. A bare int literal limitVar stays an untyped constant.
-		ctx.appendCode(indent, "if startOffset != uint32(%s*4) {\n\treturn %s\n}\n", limitVar, typePath.getErrorWith(errCode))
+		errCode = fmt.Sprintf("sszutils.ErrFirstOffsetMismatchFn(firstOffset, %s*4)", limitVar)
+		ctx.appendCode(indent, "if int(firstOffset) != %s*4 {\n\treturn %s\n}\n", limitVar, typePath.getErrorWith(errCode))
+		ctx.appendCode(indent, "startOffset := int(firstOffset)\n")
 
 		// read offsets
 		ctx.appendCode(indent, "var offsets []uint32\n")
@@ -864,18 +861,18 @@ func (ctx *decoderContext) unmarshalVector(desc *ssztypes.TypeDescriptor, varNam
 
 		fieldPath := typePath.append("[%d]", indexVar)
 
-		ctx.appendCode(indent+1, "var endOffset uint32\n")
+		ctx.appendCode(indent+1, "var endOffset int\n")
 		ctx.appendCode(indent+1, "if %s < %s-1 {\n", indexVar, limitVar)
 		ctx.appendCode(indent+2, "if canSeek {\n")
-		ctx.appendCode(indent+3, "endOffset = dec.DecodeOffsetAt(%s + int((%s+1)*4))\n", startPosVar, indexVar)
+		ctx.appendCode(indent+3, "endOffset = int(dec.DecodeOffsetAt(%s + int((%s+1)*4)))\n", startPosVar, indexVar)
 		ctx.appendCode(indent+2, "} else {\n")
-		ctx.appendCode(indent+3, "endOffset = offsets[%s]\n", indexVar)
+		ctx.appendCode(indent+3, "endOffset = int(offsets[%s])\n", indexVar)
 		ctx.appendCode(indent+2, "}\n")
 		ctx.appendCode(indent+1, "} else {\n")
-		ctx.appendCode(indent+2, "endOffset = uint32(sszLen)\n")
+		ctx.appendCode(indent+2, "endOffset = sszLen\n")
 		ctx.appendCode(indent+1, "}\n")
 
-		ctx.appendCode(indent+1, "if endOffset < startOffset || endOffset > uint32(sszLen) {\n")
+		ctx.appendCode(indent+1, "if endOffset < startOffset || endOffset > sszLen {\n")
 		errCode = "sszutils.ErrElementOffsetOutOfRangeFn(endOffset, startOffset, sszLen)"
 		ctx.appendCode(indent+2, "return %s\n", fieldPath.getErrorWith(errCode))
 		ctx.appendCode(indent+1, "}\n")
@@ -884,7 +881,7 @@ func (ctx *decoderContext) unmarshalVector(desc *ssztypes.TypeDescriptor, varNam
 		// open region: the whole remainder of the enclosing region, whether or
 		// not that region's extent is known yet.
 		ctx.appendCode(indent+1, "if %s < %s-1 {\n", indexVar, limitVar)
-		ctx.appendCode(indent+2, "dec.PushLimit(int(endOffset - startOffset))\n")
+		ctx.appendCode(indent+2, "dec.PushLimit(endOffset - startOffset)\n")
 		ctx.appendCode(indent+1, "} else {\n")
 		ctx.appendCode(indent+2, "dec.PushOpenLimit()\n")
 		ctx.appendCode(indent+1, "}\n")
@@ -925,19 +922,22 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 
 	switch {
 	case maxExpression != nil:
-		exprVar := ctx.exprVars.getExprVar(*maxExpression, desc.Limit)
-
+		maxVar = ctx.exprVars.getExprVar(*maxExpression, desc.Limit)
 		hasMax = true
-		maxVar = fmt.Sprintf("int(%s)", exprVar)
 	case desc.Limit > 0:
 		maxVar = fmt.Sprintf("%d", desc.Limit)
 		hasMax = true
 	default:
 		maxVar = "0"
 	}
-	growthLimit := "-1"
-	if hasMax {
-		growthLimit = maxVar
+	cappedMaxVar := func() string {
+		return intCapExpr(maxVar, ctx.typePrinter)
+	}
+	growthLimit := func() string {
+		if hasMax {
+			return cappedMaxVar()
+		}
+		return "-1"
 	}
 
 	valueVar := varName
@@ -964,7 +964,7 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 			// either way so an over-long payload is never allocated.
 			maxArg := "-1"
 			if hasMax {
-				maxArg = maxVar
+				maxArg = cappedMaxVar()
 			}
 			if desc.GoTypeFlags&ssztypes.GoTypeFlagIsString != 0 {
 				ctx.appendCode(indent, "if buf, err := sszutils.DecodeByteListInto(dec, nil, %s); err != nil {\n", maxArg)
@@ -993,7 +993,7 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 		if desc.ElemDesc.SszType == ssztypes.SszUint64Type && desc.ElemDesc.GoTypeFlags&(ssztypes.GoTypeFlagIsTime|ssztypes.GoTypeFlagIsPointer) == 0 {
 			maxArg := "-1"
 			if hasMax {
-				maxArg = maxVar
+				maxArg = cappedMaxVar()
 			}
 			ctx.appendCode(indent, "if buf, err := sszutils.DecodeUint64ListInto(dec, %s, %s); err != nil {\n", valueVar, maxArg)
 			ctx.appendCode(indent+1, "return %s\n", typePath.getErrorWith("err"))
@@ -1044,11 +1044,11 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 		}
 		if hasMax {
 			errCode := fmt.Sprintf("sszutils.ErrListLengthFn(itemCount, %s)", maxVar)
-			ctx.appendCode(indent+1, "if itemCount > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+			ctx.appendCode(indent+1, "if uint64(max(itemCount, 0)) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
 		}
 		ctx.appendCode(indent+1, "%s = sszutils.SizeListSlice(dec, %s, itemCount, %s)\n", valueVar, valueVar, fieldSizeVar)
 		ctx.appendCode(indent, "} else {\n")
-		ctx.appendCode(indent+1, "%s = sszutils.GrowSlice(%s, 0, %s)\n", valueVar, valueVar, growthLimit)
+		ctx.appendCode(indent+1, "%s = sszutils.GrowSlice(%s, 0, %s)\n", valueVar, valueVar, growthLimit())
 		ctx.appendCode(indent, "}\n")
 
 		startPosVar := fmt.Sprintf("startPos%d", ctx.startPosVarCounter)
@@ -1069,15 +1069,15 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 		// ssz-max bounds the list while its extent is still unknown.
 		if hasMax {
 			errCode := fmt.Sprintf("sszutils.ErrListLengthFn(%s+1, %s)", indexVar, maxVar)
-			ctx.appendCode(indent+2, "if %s >= %s {\n\treturn %s\n}\n", indexVar, maxVar, typePath.getErrorWith(errCode))
+			ctx.appendCode(indent+2, "if uint64(%s) >= %s {\n\treturn %s\n}\n", indexVar, maxVar, typePath.getErrorWith(errCode))
 		}
-		ctx.appendCode(indent+2, "%s = sszutils.GrowSlice(%s, %s+1, %s)\n", valueVar, valueVar, indexVar, growthLimit)
+		ctx.appendCode(indent+2, "%s = sszutils.GrowSlice(%s, %s+1, %s)\n", valueVar, valueVar, indexVar, growthLimit())
 		ctx.appendCode(indent+1, "}\n")
 		// The count was declared rather than witnessed, so the slice was seeded
 		// from delivered bytes; extend it as the rest arrives. When the extent
 		// was known this is already full length and never taken.
 		ctx.appendCode(indent+1, "if %s >= len(%s) {\n", indexVar, indexValueVar)
-		ctx.appendCode(indent+2, "%s = sszutils.GrowSlice(%s, %s+1, %s)\n", valueVar, valueVar, indexVar, growthLimit)
+		ctx.appendCode(indent+2, "%s = sszutils.GrowSlice(%s, %s+1, %s)\n", valueVar, valueVar, indexVar, growthLimit())
 		ctx.appendCode(indent+1, "}\n")
 
 		valVar := fmt.Sprintf("%s[%s]", indexValueVar, indexVar)
@@ -1119,7 +1119,7 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 		// makes the length exact, so sszLen is read afterwards.
 		ctx.appendCode(indent, "listEmpty, err := sszutils.RegionEmpty(dec)\n")
 		ctx.appendCode(indent, "if err != nil {\n\treturn %s\n}\n", typePath.getErrorWith("err"))
-		ctx.appendCode(indent, "sszLen := uint32(dec.GetLength())\n")
+		ctx.appendCode(indent, "sszLen := dec.GetLength()\n")
 		ctx.appendCode(indent, "if !listEmpty {\n")
 		ctx.appendCode(indent+1, "startOffset, err = dec.DecodeOffset()\n")
 		ctx.appendCode(indent+1, "if err != nil {\n\treturn %s\n}\n", typePath.getErrorWith("err"))
@@ -1133,10 +1133,10 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 		errCode := "sszutils.ErrInvalidListStartOffsetFn(startOffset, sszLen)"
 		// A zero first offset in a non-empty region is rejected (it would
 		// otherwise decode as an empty list), matching the buffer path.
-		ctx.appendCode(indent, "if startOffset%%4 != 0 || uint32(sszLen) < startOffset || (sszLen != 0 && startOffset == 0) {\n\treturn %s\n}\n", typePath.getErrorWith(errCode))
+		ctx.appendCode(indent, "if startOffset%%4 != 0 || sszLen < int(startOffset) || (sszLen != 0 && startOffset == 0) {\n\treturn %s\n}\n", typePath.getErrorWith(errCode))
 		if hasMax {
 			errCode = fmt.Sprintf("sszutils.ErrListLengthFn(itemCount, %s)", maxVar)
-			ctx.appendCode(indent, "if itemCount > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+			ctx.appendCode(indent, "if uint64(startOffset)/4 > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
 		}
 		// The offset table declares the count, but only the region can prove the
 		// bodies exist -- see the buffer path. LengthKnown is re-read here because
@@ -1150,8 +1150,8 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 			if positiveGuard != "" {
 				guard = fmt.Sprintf("%s > 0 && ", positiveGuard)
 			}
-			errCode = fmt.Sprintf("sszutils.ErrListRegionTooSmallFn(itemCount, %s, int(sszLen-startOffset))", minElemSize)
-			ctx.appendCode(indent, "if dec.LengthKnown() && %sitemCount > int(sszLen-startOffset)/(%s) {\n\treturn %s\n}\n", guard, minElemSize, typePath.getErrorWith(errCode))
+			errCode = fmt.Sprintf("sszutils.ErrListRegionTooSmallFn(itemCount, %s, sszLen-int(startOffset))", minElemSize)
+			ctx.appendCode(indent, "if dec.LengthKnown() && %sitemCount > (sszLen-int(startOffset))/(%s) {\n\treturn %s\n}\n", guard, minElemSize, typePath.getErrorWith(errCode))
 		}
 
 		// read offsets
@@ -1199,20 +1199,21 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 		lastIdxVar := fmt.Sprintf("lastIdx%d", ctx.startPosVarCounter)
 		ctx.startPosVarCounter++
 		ctx.appendCode(indent, "%s := itemCount - 1\n", lastIdxVar)
+		ctx.appendCode(indent, "curOffset := int(startOffset)\n")
 		ctx.appendCode(indent, "for %s := range itemCount {\n", indexVar)
 
-		ctx.appendCode(indent+1, "var endOffset uint32\n")
+		ctx.appendCode(indent+1, "var endOffset int\n")
 		ctx.appendCode(indent+1, "if %s < %s {\n", indexVar, lastIdxVar)
 		ctx.appendCode(indent+2, "if canSeek {\n")
-		ctx.appendCode(indent+3, "endOffset = dec.DecodeOffsetAt(%s + int((%s+1)*4))\n", startPosVar, indexVar)
+		ctx.appendCode(indent+3, "endOffset = int(dec.DecodeOffsetAt(%s + int((%s+1)*4)))\n", startPosVar, indexVar)
 		ctx.appendCode(indent+2, "} else {\n")
-		ctx.appendCode(indent+3, "endOffset = offsets[%s]\n", indexVar)
+		ctx.appendCode(indent+3, "endOffset = int(offsets[%s])\n", indexVar)
 		ctx.appendCode(indent+2, "}\n")
 		ctx.appendCode(indent+1, "} else {\n")
-		ctx.appendCode(indent+2, "endOffset = uint32(sszLen)\n")
+		ctx.appendCode(indent+2, "endOffset = sszLen\n")
 		ctx.appendCode(indent+1, "}\n")
-		ctx.appendCode(indent+1, "if endOffset < startOffset || endOffset > uint32(sszLen) {\n")
-		errCode = "sszutils.ErrElementOffsetOutOfRangeFn(endOffset, startOffset, sszLen)"
+		ctx.appendCode(indent+1, "if endOffset < curOffset || endOffset > sszLen {\n")
+		errCode = "sszutils.ErrElementOffsetOutOfRangeFn(endOffset, curOffset, sszLen)"
 		ctx.appendCode(indent+2, "return %s\n", fieldPath.getErrorWith(errCode))
 		ctx.appendCode(indent+1, "}\n")
 		ctx.appendCode(indent+1, "if %s >= len(%s) {\n", indexVar, indexValueVar)
@@ -1227,11 +1228,11 @@ func (ctx *decoderContext) unmarshalList(desc *ssztypes.TypeDescriptor, varName 
 		// region: the whole remainder of the enclosing region, whether or not
 		// that region's extent is known yet.
 		ctx.appendCode(indent+1, "if %s < %s {\n", indexVar, lastIdxVar)
-		ctx.appendCode(indent+2, "dec.PushLimit(int(endOffset - startOffset))\n")
+		ctx.appendCode(indent+2, "dec.PushLimit(endOffset - curOffset)\n")
 		ctx.appendCode(indent+1, "} else {\n")
 		ctx.appendCode(indent+2, "dec.PushOpenLimit()\n")
 		ctx.appendCode(indent+1, "}\n")
-		ctx.appendCode(indent+1, "startOffset = endOffset\n")
+		ctx.appendCode(indent+1, "curOffset = endOffset\n")
 
 		valVar := ctx.getValVar()
 		ctx.appendCode(indent+1, "%s := %s[%s]\n", valVar, indexValueVar, indexVar)
@@ -1265,10 +1266,8 @@ func (ctx *decoderContext) unmarshalBitlist(desc *ssztypes.TypeDescriptor, varNa
 
 	switch {
 	case maxExpression != nil:
-		exprVar := ctx.exprVars.getExprVar(*maxExpression, desc.Limit)
-
+		maxVar = ctx.exprVars.getExprVar(*maxExpression, desc.Limit)
 		hasMax = true
-		maxVar = fmt.Sprintf("int(%s)", exprVar)
 	case desc.Limit > 0:
 		maxVar = fmt.Sprintf("%d", desc.Limit)
 		hasMax = true
@@ -1287,7 +1286,7 @@ func (ctx *decoderContext) unmarshalBitlist(desc *ssztypes.TypeDescriptor, varNa
 	// as a read cap and an over-long payload is never allocated.
 	bitlistMaxArg := "-1"
 	if hasMax {
-		ctx.appendCode(indent, "bitlistMaxBytes := (%s / 8) + 1\n", maxVar)
+		ctx.appendCode(indent, "bitlistMaxBytes := (%s / 8) + 1\n", intCapExpr(maxVar, ctx.typePrinter))
 		bitlistMaxArg = "bitlistMaxBytes"
 	}
 	ctx.appendCode(indent, "if buf, err := sszutils.DecodeByteListInto(dec, %s, %s); err != nil {\n", valueVar, bitlistMaxArg)
@@ -1305,7 +1304,7 @@ func (ctx *decoderContext) unmarshalBitlist(desc *ssztypes.TypeDescriptor, varNa
 		bitsPkgName := ctx.typePrinter.AddImport("math/bits", "bits")
 		ctx.appendCode(indent, "bitCount := 8*(blen-1) + int(%s.Len8(%s[blen-1])) - 1\n", bitsPkgName, valueVar)
 		errCode := fmt.Sprintf("sszutils.ErrBitlistLengthFn(bitCount, %s)", maxVar)
-		ctx.appendCode(indent, "if bitCount > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+		ctx.appendCode(indent, "if uint64(max(bitCount, 0)) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
 	}
 
 	return nil

--- a/codegen/gen_decoder.go
+++ b/codegen/gen_decoder.go
@@ -520,7 +520,7 @@ func (ctx *decoderContext) unmarshalTypeWrapper(desc *ssztypes.TypeDescriptor, v
 
 // unmarshalContainer generates unmarshal code for SSZ container (struct) types.
 func (ctx *decoderContext) unmarshalContainer(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int) error {
-	staticSize := uint32(0)
+	staticSize := int64(0)
 	staticSizeVars := []string{}
 	hasDynamicFields := false
 	for _, field := range desc.ContainerDesc.Fields {

--- a/codegen/gen_decoder.go
+++ b/codegen/gen_decoder.go
@@ -544,11 +544,14 @@ func (ctx *decoderContext) unmarshalContainer(desc *ssztypes.TypeDescriptor, var
 	staticSizeVars = append(staticSizeVars, fmt.Sprintf("%d", staticSize))
 
 	totalStaticSizeExpr := strings.Join(staticSizeVars, "+")
+	lenExpr := "dec.GetLength()"
 	if len(staticSizeVars) > 1 {
-		// The decode arithmetic below runs in the int domain, so the unsigned
-		// size sum binds once as int.
-		ctx.appendCode(indent, "totalSize := int(%s)\n", totalStaticSizeExpr)
+		// The size sum stays uint64 and the comparisons promote the length
+		// side instead: an adversarial spec could wrap an int-converted sum
+		// negative, turning the EOF check into a pass on a short region.
+		ctx.appendCode(indent, "totalSize := %s\n", totalStaticSizeExpr)
 		totalStaticSizeExpr = "totalSize"
+		lenExpr = "uint64(dec.GetLength())"
 	}
 
 	// Read fixed fields and offsets
@@ -559,7 +562,7 @@ func (ctx *decoderContext) unmarshalContainer(desc *ssztypes.TypeDescriptor, var
 		ctx.startPosVarCounter++
 	}
 	errCode := fmt.Sprintf("sszutils.ErrFixedFieldsEOFFn(dec.GetLength(), %s)", totalStaticSizeExpr)
-	ctx.appendCode(indent, "if dec.GetLength() < %s {\n\treturn %s\n}\n", totalStaticSizeExpr, typePath.getErrorWith(errCode))
+	ctx.appendCode(indent, "if %s < %s {\n\treturn %s\n}\n", lenExpr, totalStaticSizeExpr, typePath.getErrorWith(errCode))
 	// Only an offset after the first checks against maxOffset (the first
 	// compares against the static size), so the bound is emitted for two or
 	// more dynamic fields. Offsets are 4-byte values, so the bound lives in
@@ -582,7 +585,7 @@ func (ctx *decoderContext) unmarshalContainer(desc *ssztypes.TypeDescriptor, var
 				ctx.appendCode(indent, "if offset%d < offset%d || offset%d > maxOffset {\n\treturn %s\n}\n", idx, dynamicFields[len(dynamicFields)-1], idx, fieldPath.getErrorWith(errCode))
 			} else {
 				errCode = fmt.Sprintf("sszutils.ErrFirstOffsetMismatchFn(offset%d, %s)", idx, totalStaticSizeExpr)
-				firstOffCmp := fmt.Sprintf("int(offset%d) != %s", idx, totalStaticSizeExpr)
+				firstOffCmp := fmt.Sprintf("uint64(offset%d) != %s", idx, totalStaticSizeExpr)
 				if _, lerr := strconv.ParseUint(totalStaticSizeExpr, 10, 64); lerr == nil {
 					firstOffCmp = fmt.Sprintf("offset%d != %s", idx, totalStaticSizeExpr)
 				}

--- a/codegen/gen_encoder.go
+++ b/codegen/gen_encoder.go
@@ -552,7 +552,7 @@ func (ctx *encoderContext) marshalContainer(desc *ssztypes.TypeDescriptor, varNa
 		if _, err := strconv.ParseUint(staticSizeExpr, 10, 64); err == nil {
 			ctx.appendCode(indent, "dynoff := uint64(%s)\n", staticSizeExpr)
 		} else {
-			ctx.appendCode(indent, "staticSize := max(%s, 0)\n", staticSizeExpr)
+			ctx.appendCode(indent, "staticSize := sszutils.Max(%s, 0)\n", staticSizeExpr)
 			ctx.appendCode(indent, "dynoff := uint64(staticSize)\n")
 		}
 	}
@@ -571,7 +571,7 @@ func (ctx *encoderContext) marshalContainer(desc *ssztypes.TypeDescriptor, varNa
 			ctx.appendCode(indent+1, "}\n")
 			ctx.appendCode(indent+1, "enc.EncodeOffset(uint32(dynoff))\n")
 			sizeFnCall := ctx.getSizeFnCall(field.Type, fmt.Sprintf("%s.%s", varName, field.Name))
-			ctx.appendCode(indent+1, "fieldSize%d := max(%s, 0)\n", idx, sizeFnCall)
+			ctx.appendCode(indent+1, "fieldSize%d := sszutils.Max(%s, 0)\n", idx, sizeFnCall)
 			ctx.appendCode(indent+1, "dynoff += uint64(fieldSize%d)\n", idx)
 			ctx.appendCode(indent, "}\n")
 		} else {
@@ -599,7 +599,7 @@ func (ctx *encoderContext) marshalContainer(desc *ssztypes.TypeDescriptor, varNa
 		ctx.appendCode(indent, "{ // Dynamic Field #%d '%s'\n", idx, field.Name)
 
 		ctx.appendCode(indent, "\tif canSeek {\n")
-		ctx.appendCode(indent, "\t\tif off := uint64(max(enc.GetPosition()-dstlen, 0)); off > %s.MaxUint32 {\n", ctx.typePrinter.AddImport("math", "math"))
+		ctx.appendCode(indent, "\t\tif off := uint64(sszutils.Max(enc.GetPosition()-dstlen, 0)); off > %s.MaxUint32 {\n", ctx.typePrinter.AddImport("math", "math"))
 		ctx.appendCode(indent, "\t\t\treturn sszutils.ErrOffsetOverflowFn(off)\n")
 		ctx.appendCode(indent, "\t\t} else {\n")
 		ctx.appendCode(indent, "\t\t\tenc.EncodeOffsetAt(offset%d, uint32(off))\n", idx)
@@ -628,6 +628,9 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 	limitVar := ""
 	bitlimitVar := ""
 	hasLimitVar := false
+	// Rides every emitted line that uses limitVar when it carries the int
+	// conversion of a resolved ctx.exprs value; empty for literal limits.
+	convSuppress := ""
 	if sizeExpression != nil {
 		defaultValue := uint64(desc.Len)
 		if desc.SszTypeFlags&ssztypes.SszTypeFlagHasBitSize != 0 {
@@ -648,6 +651,7 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 		}
 
 		hasLimitVar = true
+		convSuppress = convSuppressComment
 	} else {
 		if desc.SszTypeFlags&ssztypes.SszTypeFlagHasBitSize != 0 && desc.BitSize > 0 && desc.BitSize%8 != 0 {
 			bitlimitVar = fmt.Sprintf("%d", desc.BitSize)
@@ -676,23 +680,34 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 		return fmt.Sprintf("%s%s", ptrPrefix, valueVar)
 	}
 
+	// A trailing suppression on a block-opening line attaches to the block's
+	// first statement in gosec, so if/for lines carry it as a standalone
+	// comment line above instead.
+	suppressLine := func(prefix string) {
+		if convSuppress != "" {
+			ctx.appendCode(indent, prefix+"%s\n", strings.TrimSpace(convSuppress))
+		}
+	}
+
 	lenVar := ""
 	switch {
 	case desc.Kind != reflect.Array:
 		ctx.appendCode(indent, "%s := len(%s)\n", varNameVLen, getValueVar(true, ""))
+		suppressLine("")
 		ctx.appendCode(indent, "if %s > %s {\n", varNameVLen, limitVar)
 		errCode := fmt.Sprintf("sszutils.ErrVectorLengthFn(%s, %s)", varNameVLen, limitVar)
-		ctx.appendCode(indent+1, "return %s\n", typePath.getErrorWith(errCode))
+		ctx.appendCode(indent+1, "return %s%s\n", typePath.getErrorWith(errCode), convSuppress)
 		ctx.appendCode(indent, "}\n")
 		lenVar = varNameVLen
 	case hasLimitVar:
 		// The resolved size is the vector's length; the static ssz-size is only
 		// the fallback. See marshalVector.
+		suppressLine("")
 		ctx.appendCode(indent, "if %s > len(%s) {\n", limitVar, getValueVar(false, ""))
 		errCode := fmt.Sprintf("sszutils.ErrVectorSizeExceedsArrayFn(%s, len(%s))", limitVar, getValueVar(false, ""))
-		ctx.appendCode(indent+1, "return %s\n", typePath.getErrorWith(errCode))
+		ctx.appendCode(indent+1, "return %s%s\n", typePath.getErrorWith(errCode), convSuppress)
 		ctx.appendCode(indent, "}\n")
-		ctx.appendCode(indent, varNameVLen+" := %s\n", limitVar)
+		ctx.appendCode(indent, varNameVLen+" := %s%s\n", limitVar, convSuppress)
 		lenVar = varNameVLen
 	default:
 		lenVar = fmt.Sprintf("%d", desc.Len)
@@ -722,6 +737,9 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 				}
 				checkIndent := indent
 				if len(conds) > 0 {
+					if lenVar == varNameVLen {
+						suppressLine("")
+					}
 					ctx.appendCode(indent, "if %s {\n", strings.Join(conds, " && "))
 					checkIndent++
 				}
@@ -767,8 +785,9 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 				}
 				elemSizeStr = sizeVar
 			}
+			suppressLine("")
 			ctx.appendCode(indent, "if %s < %s {\n", lenVar, limitVar)
-			ctx.appendCode(indent, "\tenc.EncodeZeroPadding((%s - %s) * %s)\n", limitVar, lenVar, elemSizeStr)
+			ctx.appendCode(indent, "\tenc.EncodeZeroPadding((%s - %s) * %s)%s\n", limitVar, lenVar, elemSizeStr, convSuppress)
 			ctx.appendCode(indent, "}\n")
 		}
 	} else {
@@ -778,7 +797,7 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 
 		ctx.usedSeekable = true
 		ctx.appendCode(indent, "if canSeek {\n")
-		ctx.appendCode(indent, "\tenc.EncodeZeroPadding(%s * 4)\n", limitVar)
+		ctx.appendCode(indent, "\tenc.EncodeZeroPadding(%s * 4)%s\n", limitVar, convSuppress)
 		ctx.appendCode(indent, "} else {\n")
 
 		// The offset header has one 4-byte entry per vector slot (limit entries),
@@ -790,14 +809,14 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 		if _, err := strconv.ParseUint(limitVar, 10, 64); err == nil {
 			ctx.appendCode(indent, "\toffset := uint64(%s) * 4\n", limitVar)
 		} else {
-			ctx.appendCode(indent, "\toffset := uint64(max(%s, 0)) * 4\n", limitVar)
+			ctx.appendCode(indent, "\toffset := uint64(%s) * 4%s\n", limitVar, convSuppress)
 		}
 		ctx.appendCode(indent, "\tfor i := range %s {\n", lenVar)
 		ctx.appendCode(indent, "\t\tif offset > %s.MaxUint32 {\n", mathPkgName)
 		ctx.appendCode(indent, "\t\t\treturn sszutils.ErrOffsetOverflowFn(offset)\n")
 		ctx.appendCode(indent, "\t\t}\n")
 		ctx.appendCode(indent, "\t\tenc.EncodeOffset(uint32(offset))\n")
-		ctx.appendCode(indent, "\t\telemSize := max(%s, 0)\n", sizeFnCall)
+		ctx.appendCode(indent, "\t\telemSize := sszutils.Max(%s, 0)\n", sizeFnCall)
 		ctx.appendCode(indent, "\t\toffset += uint64(elemSize)\n")
 		ctx.appendCode(indent, "\t}\n")
 
@@ -805,11 +824,13 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 			// append zero padding if we have less items than the limit. The
 			// padding item is a zero value of the element's own Go type (a nil
 			// pointer for pointer elements, which the element encoder handles).
+			suppressLine("\t")
 			ctx.appendCode(indent, "\tif %s < %s {\n", lenVar, limitVar)
 			ctx.appendCode(indent, "\t\tvar zeroItem %s\n", ctx.typePrinter.TypeString(desc.ElemDesc))
 
 			zeroItemSizeFnCall := ctx.getSizeFnCall(desc.ElemDesc, "zeroItem")
-			ctx.appendCode(indent, "\t\tzeroSize := max(%s, 0)\n", zeroItemSizeFnCall)
+			ctx.appendCode(indent, "\t\tzeroSize := sszutils.Max(%s, 0)\n", zeroItemSizeFnCall)
+			suppressLine("\t\t")
 			ctx.appendCode(indent, "\t\tfor i := %s; i < %s; i++ {\n", lenVar, limitVar)
 			ctx.appendCode(indent, "\t\t\tif offset > %s.MaxUint32 {\n", mathPkgName)
 			ctx.appendCode(indent, "\t\t\t\treturn sszutils.ErrOffsetOverflowFn(offset)\n")
@@ -827,7 +848,7 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 		ctx.appendCode(indent, "for %s := range %s {\n", indexVar, lenVar)
 
 		ctx.appendCode(indent, "\tif canSeek {\n")
-		ctx.appendCode(indent, "\t\tif off := uint64(max(enc.GetPosition()-dstlen, 0)); off > %s.MaxUint32 {\n", ctx.typePrinter.AddImport("math", "math"))
+		ctx.appendCode(indent, "\t\tif off := uint64(sszutils.Max(enc.GetPosition()-dstlen, 0)); off > %s.MaxUint32 {\n", ctx.typePrinter.AddImport("math", "math"))
 		ctx.appendCode(indent, "\t\t\treturn sszutils.ErrOffsetOverflowFn(off)\n")
 		ctx.appendCode(indent, "\t\t} else {\n")
 		ctx.appendCode(indent, "\t\t\tenc.EncodeOffsetAt(dstlen+(%s*4), uint32(off))\n", indexVar)
@@ -850,11 +871,13 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 			// padding item is a zero value of the element's own Go type (a nil
 			// pointer for pointer elements, which the element encoder handles); the
 			// vector's own pointer-ness is irrelevant to the element type here.
+			suppressLine("")
 			ctx.appendCode(indent, "if %s < %s {\n", lenVar, limitVar)
 			ctx.appendCode(indent, "\tvar zeroItem %s\n", ctx.typePrinter.TypeString(desc.ElemDesc))
+			suppressLine("\t")
 			ctx.appendCode(indent, "\tfor %s := %s; %s < %s; %s++ {\n", indexVar, lenVar, indexVar, limitVar, indexVar)
 			ctx.appendCode(indent, "\t\tif canSeek {\n")
-			ctx.appendCode(indent, "\t\t\tif off := uint64(max(enc.GetPosition()-dstlen, 0)); off > %s.MaxUint32 {\n", ctx.typePrinter.AddImport("math", "math"))
+			ctx.appendCode(indent, "\t\t\tif off := uint64(sszutils.Max(enc.GetPosition()-dstlen, 0)); off > %s.MaxUint32 {\n", ctx.typePrinter.AddImport("math", "math"))
 			ctx.appendCode(indent, "\t\t\t\treturn sszutils.ErrOffsetOverflowFn(off)\n")
 			ctx.appendCode(indent, "\t\t\t} else {\n")
 			ctx.appendCode(indent, "\t\t\t\tenc.EncodeOffsetAt(dstlen+(%s*4), uint32(off))\n", indexVar)
@@ -925,7 +948,7 @@ func (ctx *encoderContext) marshalList(desc *ssztypes.TypeDescriptor, varName st
 	if hasMax {
 		addVlen()
 		ctx.appendCode(indent, "if uint64(vlen) > %s {\n", maxVar)
-		errCode := fmt.Sprintf("sszutils.ErrListLengthFn(vlen, %s)", maxVar)
+		errCode := fmt.Sprintf("sszutils.ErrListLengthFn(vlen, %s)", uintLitArg(maxVar))
 		ctx.appendCode(indent, "\treturn %s\n", typePath.getErrorWith(errCode))
 		ctx.appendCode(indent, "}\n")
 	}
@@ -978,7 +1001,7 @@ func (ctx *encoderContext) marshalList(desc *ssztypes.TypeDescriptor, varName st
 		ctx.appendCode(indent, "\t}\n")
 		ctx.appendCode(indent, "\tenc.EncodeOffset(uint32(offset))\n")
 		ctx.appendCode(indent, "\tfor i := range vlen-1 {\n")
-		ctx.appendCode(indent, "\t\telemSize := max(%s, 0)\n", sizeFnCall)
+		ctx.appendCode(indent, "\t\telemSize := sszutils.Max(%s, 0)\n", sizeFnCall)
 		ctx.appendCode(indent, "\t\toffset += uint64(elemSize)\n")
 		ctx.appendCode(indent, "\t\tif offset > %s.MaxUint32 {\n", mathPkgName)
 		ctx.appendCode(indent, "\t\t\treturn sszutils.ErrOffsetOverflowFn(offset)\n")
@@ -992,7 +1015,7 @@ func (ctx *encoderContext) marshalList(desc *ssztypes.TypeDescriptor, varName st
 
 		ctx.appendCode(indent, "for %s := range vlen {\n", indexVar)
 		ctx.appendCode(indent, "\tif canSeek {\n")
-		ctx.appendCode(indent, "\t\tif off := uint64(max(enc.GetPosition()-dstlen, 0)); off > %s.MaxUint32 {\n", ctx.typePrinter.AddImport("math", "math"))
+		ctx.appendCode(indent, "\t\tif off := uint64(sszutils.Max(enc.GetPosition()-dstlen, 0)); off > %s.MaxUint32 {\n", ctx.typePrinter.AddImport("math", "math"))
 		ctx.appendCode(indent, "\t\t\treturn sszutils.ErrOffsetOverflowFn(off)\n")
 		ctx.appendCode(indent, "\t\t} else {\n")
 		ctx.appendCode(indent, "\t\t\tenc.EncodeOffsetAt(dstlen+(%s*4), uint32(off))\n", indexVar)
@@ -1052,8 +1075,8 @@ func (ctx *encoderContext) marshalBitlist(desc *ssztypes.TypeDescriptor, varName
 		bitsPkgName := ctx.typePrinter.AddImport("math/bits", "bits")
 		ctx.appendCode(indent, "if vlen > 0 {\n")
 		ctx.appendCode(indent+1, "bitCount := 8*(vlen-1) + %s.Len8(bval[vlen-1]) - 1\n", bitsPkgName)
-		errCode := fmt.Sprintf("sszutils.ErrBitlistLengthFn(bitCount, %s)", maxVar)
-		ctx.appendCode(indent+1, "if uint64(max(bitCount, 0)) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+		errCode := fmt.Sprintf("sszutils.ErrBitlistLengthFn(bitCount, %s)", uintLitArg(maxVar))
+		ctx.appendCode(indent+1, "if uint64(bitCount) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
 		ctx.appendCode(indent, "}\n")
 	}
 

--- a/codegen/gen_encoder.go
+++ b/codegen/gen_encoder.go
@@ -293,7 +293,9 @@ func (ctx *encoderContext) generateEncodeContext(indent int) string {
 
 	appendCode(&codeBuf, indent, "type encoderCtx struct {\n")
 	appendCode(&codeBuf, indent, "\t%s sszutils.DynamicSpecs\n", padField("ds"))
-	appendCode(&codeBuf, indent, "\t%s [%d]uint64\n", padField("exprs"), ctx.exprVars.varCounter)
+	if ctx.exprVars.varCounter > 0 {
+		appendCode(&codeBuf, indent, "\t%s [%d]uint64\n", padField("exprs"), ctx.exprVars.varCounter)
+	}
 
 	for _, fnName := range fnNameList {
 		appendCode(&codeBuf, indent, "\t%s %s\n", padField(fnName), ctx.sizeFnSignature[fnName])
@@ -552,8 +554,9 @@ func (ctx *encoderContext) marshalContainer(desc *ssztypes.TypeDescriptor, varNa
 		if _, err := strconv.ParseUint(staticSizeExpr, 10, 64); err == nil {
 			ctx.appendCode(indent, "dynoff := uint64(%s)\n", staticSizeExpr)
 		} else {
-			ctx.appendCode(indent, "staticSize := sszutils.Max(%s, 0)\n", staticSizeExpr)
-			ctx.appendCode(indent, "dynoff := uint64(staticSize)\n")
+			// The size variables are uint64, so the offset accumulator sums
+			// them directly.
+			ctx.appendCode(indent, "dynoff := %s\n", staticSizeExpr)
 		}
 	}
 
@@ -625,11 +628,14 @@ func (ctx *encoderContext) marshalContainer(desc *ssztypes.TypeDescriptor, varNa
 func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int) error {
 	sizeExpression := desc.SizeExpression
 
+	// limitVar is the uint64-domain resolved size (raw expression or literal);
+	// intLimit is its int form for the codec sinks that require one.
 	limitVar := ""
+	intLimit := ""
 	bitlimitVar := ""
 	hasLimitVar := false
-	// Rides every emitted line that uses limitVar when it carries the int
-	// conversion of a resolved ctx.exprs value; empty for literal limits.
+	// Rides every emitted line converting the resolved ctx.exprs value to int;
+	// empty for literal limits.
 	convSuppress := ""
 	if sizeExpression != nil {
 		defaultValue := uint64(desc.Len)
@@ -645,10 +651,11 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 
 		if desc.SszTypeFlags&ssztypes.SszTypeFlagHasBitSize != 0 {
 			bitlimitVar = exprVar
-			limitVar = fmt.Sprintf("int((%s+7)/8)", exprVar)
+			limitVar = fmt.Sprintf("(%s+7)/8", exprVar)
 		} else {
-			limitVar = fmt.Sprintf("int(%s)", exprVar)
+			limitVar = exprVar
 		}
+		intLimit = fmt.Sprintf("int(%s)", limitVar)
 
 		hasLimitVar = true
 		convSuppress = convSuppressComment
@@ -657,6 +664,7 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 			bitlimitVar = fmt.Sprintf("%d", desc.BitSize)
 		}
 		limitVar = fmt.Sprintf("%d", desc.Len)
+		intLimit = limitVar
 	}
 
 	valueVar := varName
@@ -680,34 +688,23 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 		return fmt.Sprintf("%s%s", ptrPrefix, valueVar)
 	}
 
-	// A trailing suppression on a block-opening line attaches to the block's
-	// first statement in gosec, so if/for lines carry it as a standalone
-	// comment line above instead.
-	suppressLine := func(prefix string) {
-		if convSuppress != "" {
-			ctx.appendCode(indent, prefix+"%s\n", strings.TrimSpace(convSuppress))
-		}
-	}
-
 	lenVar := ""
 	switch {
 	case desc.Kind != reflect.Array:
 		ctx.appendCode(indent, "%s := len(%s)\n", varNameVLen, getValueVar(true, ""))
-		suppressLine("")
-		ctx.appendCode(indent, "if %s > %s {\n", varNameVLen, limitVar)
-		errCode := fmt.Sprintf("sszutils.ErrVectorLengthFn(%s, %s)", varNameVLen, limitVar)
-		ctx.appendCode(indent+1, "return %s%s\n", typePath.getErrorWith(errCode), convSuppress)
+		ctx.appendCode(indent, "if %s {\n", uintCmpExpr(varNameVLen, ">", limitVar))
+		errCode := fmt.Sprintf("sszutils.ErrVectorLengthFn(%s, %s)", varNameVLen, uintLitArg(limitVar))
+		ctx.appendCode(indent+1, "return %s\n", typePath.getErrorWith(errCode))
 		ctx.appendCode(indent, "}\n")
 		lenVar = varNameVLen
 	case hasLimitVar:
 		// The resolved size is the vector's length; the static ssz-size is only
 		// the fallback. See marshalVector.
-		suppressLine("")
-		ctx.appendCode(indent, "if %s > len(%s) {\n", limitVar, getValueVar(false, ""))
+		ctx.appendCode(indent, "if %s {\n", uintCmpExpr(fmt.Sprintf("len(%s)", getValueVar(false, "")), "<", limitVar))
 		errCode := fmt.Sprintf("sszutils.ErrVectorSizeExceedsArrayFn(%s, len(%s))", limitVar, getValueVar(false, ""))
-		ctx.appendCode(indent+1, "return %s%s\n", typePath.getErrorWith(errCode), convSuppress)
+		ctx.appendCode(indent+1, "return %s\n", typePath.getErrorWith(errCode))
 		ctx.appendCode(indent, "}\n")
-		ctx.appendCode(indent, varNameVLen+" := %s%s\n", limitVar, convSuppress)
+		ctx.appendCode(indent, varNameVLen+" := %s%s\n", intLimit, convSuppress)
 		lenVar = varNameVLen
 	default:
 		lenVar = fmt.Sprintf("%d", desc.Len)
@@ -730,16 +727,13 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 				// their last byte is a data byte, not the boundary byte.
 				conds := []string{}
 				if lenVar == varNameVLen {
-					conds = append(conds, fmt.Sprintf("%s == %s", lenVar, limitVar))
+					conds = append(conds, uintCmpExpr(lenVar, "==", limitVar))
 				}
 				if sizeExpression != nil {
 					conds = append(conds, fmt.Sprintf("%s %% 8 != 0", bitlimitVar))
 				}
 				checkIndent := indent
 				if len(conds) > 0 {
-					if lenVar == varNameVLen {
-						suppressLine("")
-					}
 					ctx.appendCode(indent, "if %s {\n", strings.Join(conds, " && "))
 					checkIndent++
 				}
@@ -778,16 +772,23 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 			// element itself is dynssz-sized (e.g. a multi-dimensional fixed
 			// vector), not the static fallback baked at generation time.
 			elemSizeStr := fmt.Sprintf("%d", desc.ElemDesc.Size)
+			elemIsLiteral := true
 			if desc.ElemDesc.SszTypeFlags&ssztypes.SszTypeFlagHasSizeExpr != 0 && !ctx.options.WithoutDynamicExpressions {
 				sizeVar, err := ctx.staticSizeVars.getStaticSizeVar(desc.ElemDesc)
 				if err != nil {
 					return err
 				}
 				elemSizeStr = sizeVar
+				elemIsLiteral = false
 			}
-			suppressLine("")
-			ctx.appendCode(indent, "if %s < %s {\n", lenVar, limitVar)
-			ctx.appendCode(indent, "\tenc.EncodeZeroPadding((%s - %s) * %s)%s\n", limitVar, lenVar, elemSizeStr, convSuppress)
+			ctx.appendCode(indent, "if %s {\n", uintCmpExpr(lenVar, "<", limitVar))
+			if _, limErr := strconv.ParseUint(limitVar, 10, 64); limErr == nil && elemIsLiteral {
+				ctx.appendCode(indent, "\tenc.EncodeZeroPadding((%s - %s) * %s)\n", limitVar, lenVar, elemSizeStr)
+			} else {
+				// The subtraction and product run in uint64 (the size variables
+				// are unsigned); the codec surface takes the byte count as int.
+				ctx.appendCode(indent, "\tenc.EncodeZeroPadding(int((%s - uint64(%s)) * %s))%s\n", limitVar, lenVar, elemSizeStr, convSuppressComment)
+			}
 			ctx.appendCode(indent, "}\n")
 		}
 	} else {
@@ -797,7 +798,7 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 
 		ctx.usedSeekable = true
 		ctx.appendCode(indent, "if canSeek {\n")
-		ctx.appendCode(indent, "\tenc.EncodeZeroPadding(%s * 4)%s\n", limitVar, convSuppress)
+		ctx.appendCode(indent, "\tenc.EncodeZeroPadding(%s * 4)%s\n", intLimit, convSuppress)
 		ctx.appendCode(indent, "} else {\n")
 
 		// The offset header has one 4-byte entry per vector slot (limit entries),
@@ -809,7 +810,7 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 		if _, err := strconv.ParseUint(limitVar, 10, 64); err == nil {
 			ctx.appendCode(indent, "\toffset := uint64(%s) * 4\n", limitVar)
 		} else {
-			ctx.appendCode(indent, "\toffset := uint64(%s) * 4%s\n", limitVar, convSuppress)
+			ctx.appendCode(indent, "\toffset := %s * 4\n", limitVar)
 		}
 		ctx.appendCode(indent, "\tfor i := range %s {\n", lenVar)
 		ctx.appendCode(indent, "\t\tif offset > %s.MaxUint32 {\n", mathPkgName)
@@ -824,14 +825,12 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 			// append zero padding if we have less items than the limit. The
 			// padding item is a zero value of the element's own Go type (a nil
 			// pointer for pointer elements, which the element encoder handles).
-			suppressLine("\t")
-			ctx.appendCode(indent, "\tif %s < %s {\n", lenVar, limitVar)
+			ctx.appendCode(indent, "\tif %s {\n", uintCmpExpr(lenVar, "<", limitVar))
 			ctx.appendCode(indent, "\t\tvar zeroItem %s\n", ctx.typePrinter.TypeString(desc.ElemDesc))
 
 			zeroItemSizeFnCall := ctx.getSizeFnCall(desc.ElemDesc, "zeroItem")
 			ctx.appendCode(indent, "\t\tzeroSize := sszutils.Max(%s, 0)\n", zeroItemSizeFnCall)
-			suppressLine("\t\t")
-			ctx.appendCode(indent, "\t\tfor i := %s; i < %s; i++ {\n", lenVar, limitVar)
+			ctx.appendCode(indent, "\t\tfor i := %s; %s; i++ {\n", lenVar, uintCmpExpr("i", "<", limitVar))
 			ctx.appendCode(indent, "\t\t\tif offset > %s.MaxUint32 {\n", mathPkgName)
 			ctx.appendCode(indent, "\t\t\t\treturn sszutils.ErrOffsetOverflowFn(offset)\n")
 			ctx.appendCode(indent, "\t\t\t}\n")
@@ -871,11 +870,9 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 			// padding item is a zero value of the element's own Go type (a nil
 			// pointer for pointer elements, which the element encoder handles); the
 			// vector's own pointer-ness is irrelevant to the element type here.
-			suppressLine("")
-			ctx.appendCode(indent, "if %s < %s {\n", lenVar, limitVar)
+			ctx.appendCode(indent, "if %s {\n", uintCmpExpr(lenVar, "<", limitVar))
 			ctx.appendCode(indent, "\tvar zeroItem %s\n", ctx.typePrinter.TypeString(desc.ElemDesc))
-			suppressLine("\t")
-			ctx.appendCode(indent, "\tfor %s := %s; %s < %s; %s++ {\n", indexVar, lenVar, indexVar, limitVar, indexVar)
+			ctx.appendCode(indent, "\tfor %s := %s; %s; %s++ {\n", indexVar, lenVar, uintCmpExpr(indexVar, "<", limitVar), indexVar)
 			ctx.appendCode(indent, "\t\tif canSeek {\n")
 			ctx.appendCode(indent, "\t\t\tif off := uint64(sszutils.Max(enc.GetPosition()-dstlen, 0)); off > %s.MaxUint32 {\n", ctx.typePrinter.AddImport("math", "math"))
 			ctx.appendCode(indent, "\t\t\t\treturn sszutils.ErrOffsetOverflowFn(off)\n")
@@ -947,7 +944,7 @@ func (ctx *encoderContext) marshalList(desc *ssztypes.TypeDescriptor, varName st
 
 	if hasMax {
 		addVlen()
-		ctx.appendCode(indent, "if uint64(vlen) > %s {\n", maxVar)
+		ctx.appendCode(indent, "if %s {\n", uintCmpExpr("vlen", ">", maxVar))
 		errCode := fmt.Sprintf("sszutils.ErrListLengthFn(vlen, %s)", uintLitArg(maxVar))
 		ctx.appendCode(indent, "\treturn %s\n", typePath.getErrorWith(errCode))
 		ctx.appendCode(indent, "}\n")
@@ -1076,7 +1073,7 @@ func (ctx *encoderContext) marshalBitlist(desc *ssztypes.TypeDescriptor, varName
 		ctx.appendCode(indent, "if vlen > 0 {\n")
 		ctx.appendCode(indent+1, "bitCount := 8*(vlen-1) + %s.Len8(bval[vlen-1]) - 1\n", bitsPkgName)
 		errCode := fmt.Sprintf("sszutils.ErrBitlistLengthFn(bitCount, %s)", uintLitArg(maxVar))
-		ctx.appendCode(indent+1, "if uint64(bitCount) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+		ctx.appendCode(indent+1, "if %s {\n\treturn %s\n}\n", uintCmpExpr("bitCount", ">", maxVar), typePath.getErrorWith(errCode))
 		ctx.appendCode(indent, "}\n")
 	}
 

--- a/codegen/gen_encoder.go
+++ b/codegen/gen_encoder.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/pk910/dynamic-ssz/ssztypes"
@@ -547,7 +548,13 @@ func (ctx *encoderContext) marshalContainer(desc *ssztypes.TypeDescriptor, varNa
 	if hasDynamic {
 		ctx.usedSeekable = true
 		ctx.appendCode(indent, "dstlen := enc.GetPosition()\n")
-		ctx.appendCode(indent, "dynoff := uint32(%v)\n", strings.Join(staticSizeVars, " + "))
+		staticSizeExpr := strings.Join(staticSizeVars, " + ")
+		if _, err := strconv.ParseUint(staticSizeExpr, 10, 64); err == nil {
+			ctx.appendCode(indent, "dynoff := uint64(%s)\n", staticSizeExpr)
+		} else {
+			ctx.appendCode(indent, "staticSize := max(%s, 0)\n", staticSizeExpr)
+			ctx.appendCode(indent, "dynoff := uint64(staticSize)\n")
+		}
 	}
 
 	// Write offsets for dynamic fields
@@ -558,9 +565,14 @@ func (ctx *encoderContext) marshalContainer(desc *ssztypes.TypeDescriptor, varNa
 			ctx.appendCode(indent, "if canSeek {\n")
 			ctx.appendCode(indent+1, "enc.EncodeOffset(0)\n")
 			ctx.appendCode(indent, "} else {\n")
-			ctx.appendCode(indent+1, "enc.EncodeOffset(dynoff)\n")
+			mathPkgName := ctx.typePrinter.AddImport("math", "math")
+			ctx.appendCode(indent+1, "if dynoff > %s.MaxUint32 {\n", mathPkgName)
+			ctx.appendCode(indent+2, "return sszutils.ErrOffsetOverflowFn(dynoff)\n")
+			ctx.appendCode(indent+1, "}\n")
+			ctx.appendCode(indent+1, "enc.EncodeOffset(uint32(dynoff))\n")
 			sizeFnCall := ctx.getSizeFnCall(field.Type, fmt.Sprintf("%s.%s", varName, field.Name))
-			ctx.appendCode(indent+1, "dynoff += uint32(%s)\n", sizeFnCall)
+			ctx.appendCode(indent+1, "fieldSize%d := max(%s, 0)\n", idx, sizeFnCall)
+			ctx.appendCode(indent+1, "dynoff += uint64(fieldSize%d)\n", idx)
 			ctx.appendCode(indent, "}\n")
 		} else {
 			// Marshal fixed fields
@@ -587,7 +599,11 @@ func (ctx *encoderContext) marshalContainer(desc *ssztypes.TypeDescriptor, varNa
 		ctx.appendCode(indent, "{ // Dynamic Field #%d '%s'\n", idx, field.Name)
 
 		ctx.appendCode(indent, "\tif canSeek {\n")
-		ctx.appendCode(indent, "\t\tenc.EncodeOffsetAt(offset%d, uint32(enc.GetPosition()-dstlen))\n", idx)
+		ctx.appendCode(indent, "\t\tif off := uint64(max(enc.GetPosition()-dstlen, 0)); off > %s.MaxUint32 {\n", ctx.typePrinter.AddImport("math", "math"))
+		ctx.appendCode(indent, "\t\t\treturn sszutils.ErrOffsetOverflowFn(off)\n")
+		ctx.appendCode(indent, "\t\t} else {\n")
+		ctx.appendCode(indent, "\t\t\tenc.EncodeOffsetAt(offset%d, uint32(off))\n", idx)
+		ctx.appendCode(indent, "\t\t}\n")
 		ctx.appendCode(indent, "\t}\n")
 
 		valVar := "t"
@@ -622,7 +638,7 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 			}
 		}
 
-		exprVar := ctx.exprVars.getExprVar(*sizeExpression, defaultValue)
+		exprVar := ctx.exprVars.getSizeExprVar(*sizeExpression, defaultValue)
 
 		if desc.SszTypeFlags&ssztypes.SszTypeFlagHasBitSize != 0 {
 			bitlimitVar = exprVar
@@ -770,10 +786,19 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 		// real element, then for each zero-padding slot when the vector is
 		// under-filled. (Byte-identical to a full vector; correct when shorter.)
 		sizeFnCall := ctx.getSizeFnCall(desc.ElemDesc, fmt.Sprintf("%s[i]", getValueVar(false, "")))
-		ctx.appendCode(indent, "\toffset := %s * 4\n", limitVar)
+		mathPkgName := ctx.typePrinter.AddImport("math", "math")
+		if _, err := strconv.ParseUint(limitVar, 10, 64); err == nil {
+			ctx.appendCode(indent, "\toffset := uint64(%s) * 4\n", limitVar)
+		} else {
+			ctx.appendCode(indent, "\toffset := uint64(max(%s, 0)) * 4\n", limitVar)
+		}
 		ctx.appendCode(indent, "\tfor i := range %s {\n", lenVar)
+		ctx.appendCode(indent, "\t\tif offset > %s.MaxUint32 {\n", mathPkgName)
+		ctx.appendCode(indent, "\t\t\treturn sszutils.ErrOffsetOverflowFn(offset)\n")
+		ctx.appendCode(indent, "\t\t}\n")
 		ctx.appendCode(indent, "\t\tenc.EncodeOffset(uint32(offset))\n")
-		ctx.appendCode(indent, "\t\toffset += %s\n", sizeFnCall)
+		ctx.appendCode(indent, "\t\telemSize := max(%s, 0)\n", sizeFnCall)
+		ctx.appendCode(indent, "\t\toffset += uint64(elemSize)\n")
 		ctx.appendCode(indent, "\t}\n")
 
 		if desc.Kind != reflect.Array {
@@ -784,10 +809,13 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 			ctx.appendCode(indent, "\t\tvar zeroItem %s\n", ctx.typePrinter.TypeString(desc.ElemDesc))
 
 			zeroItemSizeFnCall := ctx.getSizeFnCall(desc.ElemDesc, "zeroItem")
-			ctx.appendCode(indent, "\t\tzeroSize := %s\n", zeroItemSizeFnCall)
+			ctx.appendCode(indent, "\t\tzeroSize := max(%s, 0)\n", zeroItemSizeFnCall)
 			ctx.appendCode(indent, "\t\tfor i := %s; i < %s; i++ {\n", lenVar, limitVar)
+			ctx.appendCode(indent, "\t\t\tif offset > %s.MaxUint32 {\n", mathPkgName)
+			ctx.appendCode(indent, "\t\t\t\treturn sszutils.ErrOffsetOverflowFn(offset)\n")
+			ctx.appendCode(indent, "\t\t\t}\n")
 			ctx.appendCode(indent, "\t\t\tenc.EncodeOffset(uint32(offset))\n")
-			ctx.appendCode(indent, "\t\t\toffset += zeroSize\n")
+			ctx.appendCode(indent, "\t\t\toffset += uint64(zeroSize)\n")
 			ctx.appendCode(indent, "\t\t}\n")
 			ctx.appendCode(indent, "\t}\n")
 		}
@@ -799,7 +827,11 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 		ctx.appendCode(indent, "for %s := range %s {\n", indexVar, lenVar)
 
 		ctx.appendCode(indent, "\tif canSeek {\n")
-		ctx.appendCode(indent, "\t\tenc.EncodeOffsetAt(dstlen+(%s*4), uint32(enc.GetPosition() - dstlen))\n", indexVar)
+		ctx.appendCode(indent, "\t\tif off := uint64(max(enc.GetPosition()-dstlen, 0)); off > %s.MaxUint32 {\n", ctx.typePrinter.AddImport("math", "math"))
+		ctx.appendCode(indent, "\t\t\treturn sszutils.ErrOffsetOverflowFn(off)\n")
+		ctx.appendCode(indent, "\t\t} else {\n")
+		ctx.appendCode(indent, "\t\t\tenc.EncodeOffsetAt(dstlen+(%s*4), uint32(off))\n", indexVar)
+		ctx.appendCode(indent, "\t\t}\n")
 		ctx.appendCode(indent, "\t}\n")
 
 		valVar := "t"
@@ -822,7 +854,11 @@ func (ctx *encoderContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 			ctx.appendCode(indent, "\tvar zeroItem %s\n", ctx.typePrinter.TypeString(desc.ElemDesc))
 			ctx.appendCode(indent, "\tfor %s := %s; %s < %s; %s++ {\n", indexVar, lenVar, indexVar, limitVar, indexVar)
 			ctx.appendCode(indent, "\t\tif canSeek {\n")
-			ctx.appendCode(indent, "\t\t\tenc.EncodeOffsetAt(dstlen+(%s*4), uint32(enc.GetPosition()-dstlen))\n", indexVar)
+			ctx.appendCode(indent, "\t\t\tif off := uint64(max(enc.GetPosition()-dstlen, 0)); off > %s.MaxUint32 {\n", ctx.typePrinter.AddImport("math", "math"))
+			ctx.appendCode(indent, "\t\t\t\treturn sszutils.ErrOffsetOverflowFn(off)\n")
+			ctx.appendCode(indent, "\t\t\t} else {\n")
+			ctx.appendCode(indent, "\t\t\t\tenc.EncodeOffsetAt(dstlen+(%s*4), uint32(off))\n", indexVar)
+			ctx.appendCode(indent, "\t\t\t}\n")
 			ctx.appendCode(indent, "\t\t}\n")
 			if err := ctx.marshalType(desc.ElemDesc, "zeroItem", typePath.append("[+%d]", indexVar), indent+2, false); err != nil {
 				return err
@@ -840,14 +876,15 @@ func (ctx *encoderContext) marshalList(desc *ssztypes.TypeDescriptor, varName st
 	maxExpression := desc.MaxExpression
 
 	hasMax := false
+	// The raw spec expression variable or the untyped limit literal. Length
+	// checks compare in uint64 so a limit above the int range never truncates.
 	maxVar := ""
-
 	switch {
 	case maxExpression != nil:
 		exprVar := ctx.exprVars.getExprVar(*maxExpression, desc.Limit)
 
 		hasMax = true
-		maxVar = fmt.Sprintf("int(%s)", exprVar)
+		maxVar = exprVar
 	case desc.Limit > 0:
 		maxVar = fmt.Sprintf("%d", desc.Limit)
 		hasMax = true
@@ -887,7 +924,7 @@ func (ctx *encoderContext) marshalList(desc *ssztypes.TypeDescriptor, varName st
 
 	if hasMax {
 		addVlen()
-		ctx.appendCode(indent, "if vlen > %s {\n", maxVar)
+		ctx.appendCode(indent, "if uint64(vlen) > %s {\n", maxVar)
 		errCode := fmt.Sprintf("sszutils.ErrListLengthFn(vlen, %s)", maxVar)
 		ctx.appendCode(indent, "\treturn %s\n", typePath.getErrorWith(errCode))
 		ctx.appendCode(indent, "}\n")
@@ -934,10 +971,18 @@ func (ctx *encoderContext) marshalList(desc *ssztypes.TypeDescriptor, varName st
 		ctx.appendCode(indent, "\tenc.EncodeZeroPadding(vlen * 4)\n")
 		ctx.appendCode(indent, "} else if vlen > 0 {\n")
 		sizeFnCall := ctx.getSizeFnCall(desc.ElemDesc, fmt.Sprintf("%s[i]", getValueVar(false, "")))
-		ctx.appendCode(indent, "\toffset := vlen * 4\n")
+		mathPkgName := ctx.typePrinter.AddImport("math", "math")
+		ctx.appendCode(indent, "\toffset := uint64(vlen) * 4\n")
+		ctx.appendCode(indent, "\tif offset > %s.MaxUint32 {\n", mathPkgName)
+		ctx.appendCode(indent, "\t\treturn sszutils.ErrOffsetOverflowFn(offset)\n")
+		ctx.appendCode(indent, "\t}\n")
 		ctx.appendCode(indent, "\tenc.EncodeOffset(uint32(offset))\n")
 		ctx.appendCode(indent, "\tfor i := range vlen-1 {\n")
-		ctx.appendCode(indent, "\t\toffset += %s\n", sizeFnCall)
+		ctx.appendCode(indent, "\t\telemSize := max(%s, 0)\n", sizeFnCall)
+		ctx.appendCode(indent, "\t\toffset += uint64(elemSize)\n")
+		ctx.appendCode(indent, "\t\tif offset > %s.MaxUint32 {\n", mathPkgName)
+		ctx.appendCode(indent, "\t\t\treturn sszutils.ErrOffsetOverflowFn(offset)\n")
+		ctx.appendCode(indent, "\t\t}\n")
 		ctx.appendCode(indent, "\t\tenc.EncodeOffset(uint32(offset))\n")
 		ctx.appendCode(indent, "\t}\n")
 		ctx.appendCode(indent, "}\n")
@@ -947,7 +992,11 @@ func (ctx *encoderContext) marshalList(desc *ssztypes.TypeDescriptor, varName st
 
 		ctx.appendCode(indent, "for %s := range vlen {\n", indexVar)
 		ctx.appendCode(indent, "\tif canSeek {\n")
-		ctx.appendCode(indent, "\t\tenc.EncodeOffsetAt(dstlen+(%s*4), uint32(enc.GetPosition()-dstlen))\n", indexVar)
+		ctx.appendCode(indent, "\t\tif off := uint64(max(enc.GetPosition()-dstlen, 0)); off > %s.MaxUint32 {\n", ctx.typePrinter.AddImport("math", "math"))
+		ctx.appendCode(indent, "\t\t\treturn sszutils.ErrOffsetOverflowFn(off)\n")
+		ctx.appendCode(indent, "\t\t} else {\n")
+		ctx.appendCode(indent, "\t\t\tenc.EncodeOffsetAt(dstlen+(%s*4), uint32(off))\n", indexVar)
+		ctx.appendCode(indent, "\t\t}\n")
 		ctx.appendCode(indent, "\t}\n")
 		valVar := "t"
 		if ctx.isInlineable(desc.ElemDesc) {
@@ -968,14 +1017,15 @@ func (ctx *encoderContext) marshalBitlist(desc *ssztypes.TypeDescriptor, varName
 	maxExpression := desc.MaxExpression
 
 	hasMax := false
+	// The raw spec expression variable or the untyped limit literal. Length
+	// checks compare in uint64 so a limit above the int range never truncates.
 	maxVar := ""
-
 	switch {
 	case maxExpression != nil:
 		exprVar := ctx.exprVars.getExprVar(*maxExpression, desc.Limit)
 
 		hasMax = true
-		maxVar = fmt.Sprintf("int(%s)", exprVar)
+		maxVar = exprVar
 	case desc.Limit > 0:
 		maxVar = fmt.Sprintf("%d", desc.Limit)
 		hasMax = true
@@ -1003,7 +1053,7 @@ func (ctx *encoderContext) marshalBitlist(desc *ssztypes.TypeDescriptor, varName
 		ctx.appendCode(indent, "if vlen > 0 {\n")
 		ctx.appendCode(indent+1, "bitCount := 8*(vlen-1) + %s.Len8(bval[vlen-1]) - 1\n", bitsPkgName)
 		errCode := fmt.Sprintf("sszutils.ErrBitlistLengthFn(bitCount, %s)", maxVar)
-		ctx.appendCode(indent+1, "if bitCount > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+		ctx.appendCode(indent+1, "if uint64(max(bitCount, 0)) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
 		ctx.appendCode(indent, "}\n")
 	}
 

--- a/codegen/gen_hashtreeroot.go
+++ b/codegen/gen_hashtreeroot.go
@@ -647,7 +647,7 @@ func (ctx *hashTreeRootContext) hashVector(desc *ssztypes.TypeDescriptor, varNam
 			}
 		}
 
-		exprVar := ctx.exprVars.getExprVar(*sizeExpression, defaultValue)
+		exprVar := ctx.exprVars.getSizeExprVar(*sizeExpression, defaultValue)
 
 		if desc.SszTypeFlags&ssztypes.SszTypeFlagHasBitSize != 0 {
 			bitlimitVar = fmt.Sprintf("int(%s)", exprVar)
@@ -913,7 +913,7 @@ func (ctx *hashTreeRootContext) hashList(desc *ssztypes.TypeDescriptor, varName 
 			indexVar, indexDefer := ctx.getIndexVar()
 			defer indexDefer()
 
-			ctx.appendCode(indent, "for %s := range int(vlen) {\n", indexVar)
+			ctx.appendCode(indent, "for %s := range len(%s) {\n", indexVar, getValueVar(true, ""))
 			valVar := "t"
 			if ctx.isInlineable(desc.ElemDesc) {
 				valVar = fmt.Sprintf("%s[%s]", getValueVar(false, ""), indexVar)

--- a/codegen/gen_hashtreeroot.go
+++ b/codegen/gen_hashtreeroot.go
@@ -864,7 +864,7 @@ func (ctx *hashTreeRootContext) hashList(desc *ssztypes.TypeDescriptor, varName 
 	if hasMax {
 		addVlen()
 		ctx.appendCode(indent, "if vlen > %s {\n", maxVar)
-		errCode := fmt.Sprintf("sszutils.ErrListLengthFn(vlen, %s)", maxVar)
+		errCode := fmt.Sprintf("sszutils.ErrListLengthFn(vlen, %s)", uintLitArg(maxVar))
 		ctx.appendCode(indent, "\treturn %s\n", typePath.getErrorWith(errCode))
 		ctx.appendCode(indent, "}\n")
 	}
@@ -1002,7 +1002,7 @@ func (ctx *hashTreeRootContext) hashBitlist(desc *ssztypes.TypeDescriptor, varNa
 
 	if maxVar != "" {
 		ctx.appendCode(indent, "if size > %s {\n", maxVar)
-		errCode := fmt.Sprintf("sszutils.ErrBitlistLengthFn(size, %s)", maxVar)
+		errCode := fmt.Sprintf("sszutils.ErrBitlistLengthFn(size, %s)", uintLitArg(maxVar))
 		ctx.appendCode(indent, "\treturn %s\n", typePath.getErrorWith(errCode))
 		ctx.appendCode(indent, "}\n")
 	}

--- a/codegen/gen_hashtreeroot.go
+++ b/codegen/gen_hashtreeroot.go
@@ -635,7 +635,10 @@ func (ctx *hashTreeRootContext) hashVector(desc *ssztypes.TypeDescriptor, varNam
 		sizeExpression = nil
 	}
 
+	// limitVar is the uint64-domain resolved size (raw expression or literal);
+	// intLimit is its int form for the slicing and indexing sinks.
 	limitVar := ""
+	intLimit := ""
 	bitlimitVar := ""
 	if sizeExpression != nil {
 		defaultValue := uint64(desc.Len)
@@ -650,16 +653,18 @@ func (ctx *hashTreeRootContext) hashVector(desc *ssztypes.TypeDescriptor, varNam
 		exprVar := ctx.exprVars.getSizeExprVar(*sizeExpression, defaultValue)
 
 		if desc.SszTypeFlags&ssztypes.SszTypeFlagHasBitSize != 0 {
-			bitlimitVar = fmt.Sprintf("int(%s)", exprVar)
-			limitVar = fmt.Sprintf("int((%s+7)/8)", exprVar)
+			bitlimitVar = exprVar
+			limitVar = fmt.Sprintf("(%s+7)/8", exprVar)
 		} else {
-			limitVar = fmt.Sprintf("int(%s)", exprVar)
+			limitVar = exprVar
 		}
+		intLimit = fmt.Sprintf("int(%s)", limitVar)
 	} else {
 		if desc.SszTypeFlags&ssztypes.SszTypeFlagHasBitSize != 0 && desc.BitSize > 0 && desc.BitSize%8 != 0 {
 			bitlimitVar = fmt.Sprintf("%d", desc.BitSize)
 		}
 		limitVar = fmt.Sprintf("%d", desc.Len)
+		intLimit = limitVar
 	}
 
 	valueVar := varName
@@ -687,19 +692,19 @@ func (ctx *hashTreeRootContext) hashVector(desc *ssztypes.TypeDescriptor, varNam
 	switch {
 	case desc.Kind != reflect.Array:
 		ctx.appendCode(indent, "vlen := len(%s)\n", getValueVar(true, ""))
-		ctx.appendCode(indent, "if vlen > %s {\n", limitVar)
-		errCode := fmt.Sprintf("sszutils.ErrVectorLengthFn(%s, %s)", varNameVLen, limitVar)
+		ctx.appendCode(indent, "if %s {\n", uintCmpExpr("vlen", ">", limitVar))
+		errCode := fmt.Sprintf("sszutils.ErrVectorLengthFn(%s, %s)", varNameVLen, uintLitArg(limitVar))
 		ctx.appendCode(indent, "\treturn %s\n", typePath.getErrorWith(errCode))
 		ctx.appendCode(indent, "}\n")
 		lenVar = varNameVLen
 	case sizeExpression != nil:
 		// The resolved size is the vector's length; the static ssz-size is only
 		// the fallback. See marshalVector.
-		ctx.appendCode(indent, "if %s > len(%s) {\n", limitVar, getValueVar(false, ""))
+		ctx.appendCode(indent, "if %s {\n", uintCmpExpr(fmt.Sprintf("len(%s)", getValueVar(false, "")), "<", limitVar))
 		errCode := fmt.Sprintf("sszutils.ErrVectorSizeExceedsArrayFn(%s, len(%s))", limitVar, getValueVar(false, ""))
 		ctx.appendCode(indent, "\treturn %s\n", typePath.getErrorWith(errCode))
 		ctx.appendCode(indent, "}\n")
-		lenVar = limitVar
+		lenVar = intLimit
 	default:
 		lenVar = fmt.Sprintf("%d", desc.Len)
 	}
@@ -721,8 +726,8 @@ func (ctx *hashTreeRootContext) hashVector(desc *ssztypes.TypeDescriptor, varNam
 			valVar = "val"
 
 			// append zero padding if we have less items than the limit
-			ctx.appendCode(indent, "if %s < %s {\n", lenVar, limitVar)
-			ctx.appendCode(indent, "\tval = sszutils.AppendZeroPadding(val, (%s-%s)*%d)\n", limitVar, lenVar, desc.ElemDesc.Size)
+			ctx.appendCode(indent, "if %s {\n", uintCmpExpr(lenVar, "<", limitVar))
+			ctx.appendCode(indent, "\tval = sszutils.AppendZeroPadding(val, (%s-%s)*%d)\n", intLimit, lenVar, desc.ElemDesc.Size)
 			ctx.appendCode(indent, "}\n")
 		} else {
 			valVar = getValueVar(false, "")
@@ -738,7 +743,7 @@ func (ctx *hashTreeRootContext) hashVector(desc *ssztypes.TypeDescriptor, varNam
 				checkIndent++
 			}
 			ctx.appendCode(checkIndent, "paddingMask := uint8((uint16(0xff) << (%s %% 8)) & 0xff)\n", bitlimitVar)
-			ctx.appendCode(checkIndent, "if %s[%s-1] & paddingMask != 0 {\n", valVar, limitVar)
+			ctx.appendCode(checkIndent, "if %s[%s-1] & paddingMask != 0 {\n", valVar, intLimit)
 			errCode := errCodeBitvectorPadding
 			ctx.appendCode(checkIndent, "\treturn %s\n", typePath.getErrorWith(errCode))
 			ctx.appendCode(checkIndent, "}\n")
@@ -748,9 +753,9 @@ func (ctx *hashTreeRootContext) hashVector(desc *ssztypes.TypeDescriptor, varNam
 		}
 
 		if pack {
-			ctx.appendCode(indent, "hh.Append(%s[:%s])\n", valVar, limitVar)
+			ctx.appendCode(indent, "hh.Append(%s[:%s])\n", valVar, intLimit)
 		} else {
-			ctx.appendCode(indent, "hh.PutBytes(%s[:%s])\n", valVar, limitVar)
+			ctx.appendCode(indent, "hh.PutBytes(%s[:%s])\n", valVar, intLimit)
 		}
 		_ = itemSize // itemSize only used in element hashing branch
 	} else {
@@ -778,7 +783,7 @@ func (ctx *hashTreeRootContext) hashVector(desc *ssztypes.TypeDescriptor, varNam
 		defer indexDefer()
 
 		ctx.appendCode(indent, "var %s%s %s%s\n", valVar, emptyVarAddin, valVarPtrPrefix, ctx.typePrinter.TypeString(desc.ElemDesc))
-		ctx.appendCode(indent, "for %s := range %s {\n", indexVar, limitVar)
+		ctx.appendCode(indent, "for %s := range %s {\n", indexVar, intLimit)
 		ctx.appendCode(indent, "\tif %s < %s {\n", indexVar, lenVar)
 		ctx.appendCode(indent, "\t\t%s = %s[%s]\n", valVar, getValueVar(false, ctx.getPtrPrefix(desc.ElemDesc, "&")), indexVar)
 		ctx.appendCode(indent, "\t} else if %s == %s {\n", indexVar, lenVar)

--- a/codegen/gen_marshal.go
+++ b/codegen/gen_marshal.go
@@ -849,7 +849,7 @@ func (ctx *marshalContext) marshalList(desc *ssztypes.TypeDescriptor, varName st
 	if hasMax {
 		addVlen()
 		ctx.appendCode(indent, "if uint64(vlen) > %s {\n", maxVar)
-		errCode := fmt.Sprintf("sszutils.ErrListLengthFn(vlen, %s)", maxVar)
+		errCode := fmt.Sprintf("sszutils.ErrListLengthFn(vlen, %s)", uintLitArg(maxVar))
 		ctx.appendCode(indent, "\treturn nil, %s\n", typePath.getErrorWith(errCode))
 		ctx.appendCode(indent, "}\n")
 	}
@@ -970,8 +970,8 @@ func (ctx *marshalContext) marshalBitlist(desc *ssztypes.TypeDescriptor, varName
 		bitsPkgName := ctx.typePrinter.AddImport("math/bits", "bits")
 		ctx.appendCode(indent, "if vlen > 0 {\n")
 		ctx.appendCode(indent+1, "bitCount := 8*(vlen-1) + %s.Len8(bval[vlen-1]) - 1\n", bitsPkgName)
-		errCode := fmt.Sprintf("sszutils.ErrBitlistLengthFn(bitCount, %s)", maxVar)
-		ctx.appendCode(indent+1, "if uint64(max(bitCount, 0)) > %s {\n\treturn nil, %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+		errCode := fmt.Sprintf("sszutils.ErrBitlistLengthFn(bitCount, %s)", uintLitArg(maxVar))
+		ctx.appendCode(indent+1, "if uint64(bitCount) > %s {\n\treturn nil, %s\n}\n", maxVar, typePath.getErrorWith(errCode))
 		ctx.appendCode(indent, "}\n")
 	}
 

--- a/codegen/gen_marshal.go
+++ b/codegen/gen_marshal.go
@@ -566,7 +566,12 @@ func (ctx *marshalContext) marshalContainer(desc *ssztypes.TypeDescriptor, varNa
 
 		ctx.appendCode(indent, "{ // Dynamic Field #%d '%s'\n", idx, field.Name)
 		binaryPkgName := ctx.typePrinter.AddImport("encoding/binary", "binary")
-		ctx.appendCode(indent, "\t%s.LittleEndian.PutUint32(dst[%s:], uint32(len(dst)-dstlen))\n", binaryPkgName, offsetExprs[idx])
+		mathPkgName := ctx.typePrinter.AddImport("math", "math")
+		ctx.appendCode(indent, "\tif off := uint64(len(dst)) - uint64(dstlen); off > %s.MaxUint32 {\n", mathPkgName)
+		ctx.appendCode(indent, "\t\treturn nil, sszutils.ErrOffsetOverflowFn(off)\n")
+		ctx.appendCode(indent, "\t} else {\n")
+		ctx.appendCode(indent, "\t\t%s.LittleEndian.PutUint32(dst[%s:], uint32(off))\n", binaryPkgName, offsetExprs[idx])
+		ctx.appendCode(indent, "\t}\n")
 		valVar := "t"
 		if ctx.isInlineable(field.Type) {
 			valVar = fmt.Sprintf("%s.%s", varName, field.Name)
@@ -602,7 +607,7 @@ func (ctx *marshalContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 			}
 		}
 
-		exprVar := ctx.exprVars.getExprVar(*sizeExpression, defaultValue)
+		exprVar := ctx.exprVars.getSizeExprVar(*sizeExpression, defaultValue)
 
 		if desc.SszTypeFlags&ssztypes.SszTypeFlagHasBitSize != 0 {
 			bitlimitVar = exprVar
@@ -745,7 +750,12 @@ func (ctx *marshalContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 		ctx.appendCode(indent, "dst = sszutils.AppendZeroPadding(dst, %s*4)\n", limitVar)
 		ctx.appendCode(indent, "for %s := range %s {\n", indexVar, lenVar)
 		binaryPkgName := ctx.typePrinter.AddImport("encoding/binary", "binary")
-		ctx.appendCode(indent, "\t%s.LittleEndian.PutUint32(dst[dstlen+(%s*4):], uint32(len(dst)-dstlen))\n", binaryPkgName, indexVar)
+		mathPkgName := ctx.typePrinter.AddImport("math", "math")
+		ctx.appendCode(indent, "\tif off := uint64(len(dst)) - uint64(dstlen); off > %s.MaxUint32 {\n", mathPkgName)
+		ctx.appendCode(indent, "\t\treturn nil, sszutils.ErrOffsetOverflowFn(off)\n")
+		ctx.appendCode(indent, "\t} else {\n")
+		ctx.appendCode(indent, "\t\t%s.LittleEndian.PutUint32(dst[dstlen+(%s*4):], uint32(off))\n", binaryPkgName, indexVar)
+		ctx.appendCode(indent, "\t}\n")
 		valVar := "t"
 		if ctx.isInlineable(desc.ElemDesc) {
 			valVar = fmt.Sprintf("%s[%s]", getValueVar(false, ""), indexVar)
@@ -764,7 +774,12 @@ func (ctx *marshalContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 			ctx.appendCode(indent, "if %s < %s {\n", lenVar, limitVar)
 			ctx.appendCode(indent, "\tvar zeroItem %s\n", ctx.typePrinter.TypeString(desc.ElemDesc))
 			ctx.appendCode(indent, "\tfor %s := %s; %s < %s; %s++ {\n", indexVar, lenVar, indexVar, limitVar, indexVar)
-			ctx.appendCode(indent, "\t\t%s.LittleEndian.PutUint32(dst[dstlen+(%s*4):], uint32(len(dst)-dstlen))\n", binaryPkgName, indexVar)
+			mathPkgName := ctx.typePrinter.AddImport("math", "math")
+			ctx.appendCode(indent, "\t\tif off := uint64(len(dst)) - uint64(dstlen); off > %s.MaxUint32 {\n", mathPkgName)
+			ctx.appendCode(indent, "\t\t\treturn nil, sszutils.ErrOffsetOverflowFn(off)\n")
+			ctx.appendCode(indent, "\t\t} else {\n")
+			ctx.appendCode(indent, "\t\t\t%s.LittleEndian.PutUint32(dst[dstlen+(%s*4):], uint32(off))\n", binaryPkgName, indexVar)
+			ctx.appendCode(indent, "\t\t}\n")
 			if err := ctx.marshalType(desc.ElemDesc, "zeroItem", typePath.append("[+%d]", indexVar), indent+1, false); err != nil {
 				return err
 			}
@@ -784,6 +799,8 @@ func (ctx *marshalContext) marshalList(desc *ssztypes.TypeDescriptor, varName st
 	}
 
 	hasMax := false
+	// The raw spec expression variable or the untyped limit literal. Length
+	// checks compare in uint64 so a limit above the int range never truncates.
 	maxVar := ""
 
 	switch {
@@ -791,7 +808,7 @@ func (ctx *marshalContext) marshalList(desc *ssztypes.TypeDescriptor, varName st
 		exprVar := ctx.exprVars.getExprVar(*maxExpression, desc.Limit)
 
 		hasMax = true
-		maxVar = fmt.Sprintf("int(%s)", exprVar)
+		maxVar = exprVar
 	case desc.Limit > 0:
 		maxVar = fmt.Sprintf("%d", desc.Limit)
 		hasMax = true
@@ -831,7 +848,7 @@ func (ctx *marshalContext) marshalList(desc *ssztypes.TypeDescriptor, varName st
 
 	if hasMax {
 		addVlen()
-		ctx.appendCode(indent, "if vlen > %s {\n", maxVar)
+		ctx.appendCode(indent, "if uint64(vlen) > %s {\n", maxVar)
 		errCode := fmt.Sprintf("sszutils.ErrListLengthFn(vlen, %s)", maxVar)
 		ctx.appendCode(indent, "\treturn nil, %s\n", typePath.getErrorWith(errCode))
 		ctx.appendCode(indent, "}\n")
@@ -877,7 +894,12 @@ func (ctx *marshalContext) marshalList(desc *ssztypes.TypeDescriptor, varName st
 		ctx.appendCode(indent, "dst = sszutils.AppendZeroPadding(dst, vlen*4)\n")
 		ctx.appendCode(indent, "for %s := range vlen {\n", indexVar)
 		binaryPkgName := ctx.typePrinter.AddImport("encoding/binary", "binary")
-		ctx.appendCode(indent, "\t%s.LittleEndian.PutUint32(dst[dstlen+(%s*4):], uint32(len(dst)-dstlen))\n", binaryPkgName, indexVar)
+		mathPkgName := ctx.typePrinter.AddImport("math", "math")
+		ctx.appendCode(indent, "\tif off := uint64(len(dst)) - uint64(dstlen); off > %s.MaxUint32 {\n", mathPkgName)
+		ctx.appendCode(indent, "\t\treturn nil, sszutils.ErrOffsetOverflowFn(off)\n")
+		ctx.appendCode(indent, "\t} else {\n")
+		ctx.appendCode(indent, "\t\t%s.LittleEndian.PutUint32(dst[dstlen+(%s*4):], uint32(off))\n", binaryPkgName, indexVar)
+		ctx.appendCode(indent, "\t}\n")
 		valVar := "t"
 		if ctx.isInlineable(desc.ElemDesc) {
 			valVar = fmt.Sprintf("%s[%s]", getValueVar(false, ""), indexVar)
@@ -900,6 +922,8 @@ func (ctx *marshalContext) marshalBitlist(desc *ssztypes.TypeDescriptor, varName
 	}
 
 	hasMax := false
+	// The raw spec expression variable or the untyped limit literal. Length
+	// checks compare in uint64 so a limit above the int range never truncates.
 	maxVar := ""
 
 	switch {
@@ -907,7 +931,7 @@ func (ctx *marshalContext) marshalBitlist(desc *ssztypes.TypeDescriptor, varName
 		exprVar := ctx.exprVars.getExprVar(*maxExpression, desc.Limit)
 
 		hasMax = true
-		maxVar = fmt.Sprintf("int(%s)", exprVar)
+		maxVar = exprVar
 	case desc.Limit > 0:
 		maxVar = fmt.Sprintf("%d", desc.Limit)
 		hasMax = true
@@ -947,7 +971,7 @@ func (ctx *marshalContext) marshalBitlist(desc *ssztypes.TypeDescriptor, varName
 		ctx.appendCode(indent, "if vlen > 0 {\n")
 		ctx.appendCode(indent+1, "bitCount := 8*(vlen-1) + %s.Len8(bval[vlen-1]) - 1\n", bitsPkgName)
 		errCode := fmt.Sprintf("sszutils.ErrBitlistLengthFn(bitCount, %s)", maxVar)
-		ctx.appendCode(indent+1, "if bitCount > %s {\n\treturn nil, %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+		ctx.appendCode(indent+1, "if uint64(max(bitCount, 0)) > %s {\n\treturn nil, %s\n}\n", maxVar, typePath.getErrorWith(errCode))
 		ctx.appendCode(indent, "}\n")
 	}
 

--- a/codegen/gen_marshal.go
+++ b/codegen/gen_marshal.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/pk910/dynamic-ssz/ssztypes"
@@ -594,7 +595,10 @@ func (ctx *marshalContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 		sizeExpression = nil
 	}
 
+	// limitVar is the uint64-domain resolved size (raw expression or literal);
+	// intLimit is its int form for the codec sinks that require one.
 	limitVar := ""
+	intLimit := ""
 	bitlimitVar := ""
 	hasLimitVar := false
 	if sizeExpression != nil {
@@ -611,10 +615,11 @@ func (ctx *marshalContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 
 		if desc.SszTypeFlags&ssztypes.SszTypeFlagHasBitSize != 0 {
 			bitlimitVar = exprVar
-			limitVar = fmt.Sprintf("int((%s+7)/8)", exprVar)
+			limitVar = fmt.Sprintf("(%s+7)/8", exprVar)
 		} else {
-			limitVar = fmt.Sprintf("int(%s)", exprVar)
+			limitVar = exprVar
 		}
+		intLimit = fmt.Sprintf("int(%s)", limitVar)
 
 		hasLimitVar = true
 	} else {
@@ -622,6 +627,7 @@ func (ctx *marshalContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 			bitlimitVar = fmt.Sprintf("%d", desc.BitSize)
 		}
 		limitVar = fmt.Sprintf("%d", desc.Len)
+		intLimit = limitVar
 	}
 
 	valueVar := varName
@@ -650,8 +656,8 @@ func (ctx *marshalContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 	switch {
 	case desc.Kind != reflect.Array:
 		ctx.appendCode(indent, "vlen := len(%s)\n", getValueVar(true, ""))
-		ctx.appendCode(indent, "if vlen > %s {\n", limitVar)
-		errCode := fmt.Sprintf("sszutils.ErrVectorLengthFn(%s, %s)", varNameVLen, limitVar)
+		ctx.appendCode(indent, "if %s {\n", uintCmpExpr("vlen", ">", limitVar))
+		errCode := fmt.Sprintf("sszutils.ErrVectorLengthFn(%s, %s)", varNameVLen, uintLitArg(limitVar))
 		ctx.appendCode(indent, "\treturn nil, %s\n", typePath.getErrorWith(errCode))
 		ctx.appendCode(indent, "}\n")
 		lenVar = varNameVLen
@@ -660,11 +666,11 @@ func (ctx *marshalContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 		// the fallback for when the expression does not resolve, so bounding by
 		// it would truncate a vector whose spec value exceeds it. The backing
 		// array is what has to hold the result, and it may be larger.
-		ctx.appendCode(indent, "if %s > len(%s) {\n", limitVar, getValueVar(false, ""))
+		ctx.appendCode(indent, "if %s {\n", uintCmpExpr(fmt.Sprintf("len(%s)", getValueVar(false, "")), "<", limitVar))
 		errCode := fmt.Sprintf("sszutils.ErrVectorSizeExceedsArrayFn(%s, len(%s))", limitVar, getValueVar(false, ""))
 		ctx.appendCode(indent, "\treturn nil, %s\n", typePath.getErrorWith(errCode))
 		ctx.appendCode(indent, "}\n")
-		ctx.appendCode(indent, "vlen := %s\n", limitVar)
+		ctx.appendCode(indent, "vlen := %s\n", intLimit)
 		lenVar = varNameVLen
 	default:
 		lenVar = fmt.Sprintf("%d", desc.Len)
@@ -681,7 +687,7 @@ func (ctx *marshalContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 				// their last byte is a data byte, not the boundary byte.
 				conds := []string{}
 				if lenVar == varNameVLen {
-					conds = append(conds, fmt.Sprintf("%s == %s", lenVar, limitVar))
+					conds = append(conds, uintCmpExpr(lenVar, "==", limitVar))
 				}
 				if sizeExpression != nil {
 					conds = append(conds, fmt.Sprintf("%s %% 8 != 0", bitlimitVar))
@@ -729,15 +735,23 @@ func (ctx *marshalContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 			// element itself is dynssz-sized (e.g. a multi-dimensional fixed
 			// vector), not the static fallback baked at generation time.
 			elemSizeStr := fmt.Sprintf("%d", desc.ElemDesc.Size)
+			elemIsLiteral := true
 			if desc.ElemDesc.SszTypeFlags&ssztypes.SszTypeFlagHasSizeExpr != 0 && !ctx.options.WithoutDynamicExpressions {
 				sizeVar, err := ctx.staticSizeVars.getStaticSizeVar(desc.ElemDesc)
 				if err != nil {
 					return err
 				}
 				elemSizeStr = sizeVar
+				elemIsLiteral = false
 			}
-			ctx.appendCode(indent, "if %s < %s {\n", lenVar, limitVar)
-			ctx.appendCode(indent, "\tdst = sszutils.AppendZeroPadding(dst, (%s-%s)*%s)\n", limitVar, lenVar, elemSizeStr)
+			ctx.appendCode(indent, "if %s {\n", uintCmpExpr(lenVar, "<", limitVar))
+			if _, limErr := strconv.ParseUint(limitVar, 10, 64); limErr == nil && elemIsLiteral {
+				ctx.appendCode(indent, "\tdst = sszutils.AppendZeroPadding(dst, (%s-%s)*%s)\n", limitVar, lenVar, elemSizeStr)
+			} else {
+				// The subtraction and product run in uint64 (the size variables
+				// are unsigned); the codec surface takes the byte count as int.
+				ctx.appendCode(indent, "\tdst = sszutils.AppendZeroPadding(dst, int((%s-uint64(%s))*%s))\n", limitVar, lenVar, elemSizeStr)
+			}
 			ctx.appendCode(indent, "}\n")
 		}
 	} else {
@@ -747,7 +761,7 @@ func (ctx *marshalContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 		defer indexDefer()
 
 		ctx.appendCode(indent, "dstlen := len(dst)\n")
-		ctx.appendCode(indent, "dst = sszutils.AppendZeroPadding(dst, %s*4)\n", limitVar)
+		ctx.appendCode(indent, "dst = sszutils.AppendZeroPadding(dst, %s*4)\n", intLimit)
 		ctx.appendCode(indent, "for %s := range %s {\n", indexVar, lenVar)
 		binaryPkgName := ctx.typePrinter.AddImport("encoding/binary", "binary")
 		mathPkgName := ctx.typePrinter.AddImport("math", "math")
@@ -771,9 +785,9 @@ func (ctx *marshalContext) marshalVector(desc *ssztypes.TypeDescriptor, varName 
 			// append zero padding if we have less items than the limit. The
 			// padding item is a zero value of the element's own Go type (a nil
 			// pointer for pointer elements, which the element marshaler handles).
-			ctx.appendCode(indent, "if %s < %s {\n", lenVar, limitVar)
+			ctx.appendCode(indent, "if %s {\n", uintCmpExpr(lenVar, "<", limitVar))
 			ctx.appendCode(indent, "\tvar zeroItem %s\n", ctx.typePrinter.TypeString(desc.ElemDesc))
-			ctx.appendCode(indent, "\tfor %s := %s; %s < %s; %s++ {\n", indexVar, lenVar, indexVar, limitVar, indexVar)
+			ctx.appendCode(indent, "\tfor %s := %s; %s; %s++ {\n", indexVar, lenVar, uintCmpExpr(indexVar, "<", limitVar), indexVar)
 			mathPkgName := ctx.typePrinter.AddImport("math", "math")
 			ctx.appendCode(indent, "\t\tif off := uint64(len(dst)) - uint64(dstlen); off > %s.MaxUint32 {\n", mathPkgName)
 			ctx.appendCode(indent, "\t\t\treturn nil, sszutils.ErrOffsetOverflowFn(off)\n")
@@ -848,7 +862,7 @@ func (ctx *marshalContext) marshalList(desc *ssztypes.TypeDescriptor, varName st
 
 	if hasMax {
 		addVlen()
-		ctx.appendCode(indent, "if uint64(vlen) > %s {\n", maxVar)
+		ctx.appendCode(indent, "if %s {\n", uintCmpExpr("vlen", ">", maxVar))
 		errCode := fmt.Sprintf("sszutils.ErrListLengthFn(vlen, %s)", uintLitArg(maxVar))
 		ctx.appendCode(indent, "\treturn nil, %s\n", typePath.getErrorWith(errCode))
 		ctx.appendCode(indent, "}\n")
@@ -971,7 +985,7 @@ func (ctx *marshalContext) marshalBitlist(desc *ssztypes.TypeDescriptor, varName
 		ctx.appendCode(indent, "if vlen > 0 {\n")
 		ctx.appendCode(indent+1, "bitCount := 8*(vlen-1) + %s.Len8(bval[vlen-1]) - 1\n", bitsPkgName)
 		errCode := fmt.Sprintf("sszutils.ErrBitlistLengthFn(bitCount, %s)", uintLitArg(maxVar))
-		ctx.appendCode(indent+1, "if uint64(bitCount) > %s {\n\treturn nil, %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+		ctx.appendCode(indent+1, "if %s {\n\treturn nil, %s\n}\n", uintCmpExpr("bitCount", ">", maxVar), typePath.getErrorWith(errCode))
 		ctx.appendCode(indent, "}\n")
 	}
 

--- a/codegen/gen_size.go
+++ b/codegen/gen_size.go
@@ -501,11 +501,17 @@ func (ctx *sizeContext) sizeVector(desc *ssztypes.TypeDescriptor, varName, sizeV
 
 		exprVar := ctx.exprVars.getSizeExprVar(*sizeExpression, defaultValue)
 
+		rawLimit := exprVar
 		if desc.SszTypeFlags&ssztypes.SszTypeFlagHasBitSize != 0 {
-			limitVar = fmt.Sprintf("int((%s+7)/8)", exprVar)
-		} else {
-			limitVar = fmt.Sprintf("int(%s)", exprVar)
+			rawLimit = fmt.Sprintf("(%s+7)/8", exprVar)
 		}
+		// The size accumulator is int (the size interface), so the resolved
+		// limit binds once in the int domain and every use below stays plain.
+		convSuppress := ""
+		if ctx.exprVars.isSlice {
+			convSuppress = convSuppressComment
+		}
+		ctx.appendCode(indent, "%s := int(%s)%s\n", limitVar, rawLimit, convSuppress)
 	} else {
 		ctx.appendCode(indent, "%s := %d\n", limitVar, desc.Len)
 	}
@@ -521,7 +527,11 @@ func (ctx *sizeContext) sizeVector(desc *ssztypes.TypeDescriptor, varName, sizeV
 			if err != nil {
 				return err
 			}
-			ctx.appendCode(indent, "%s += int(%s) * %s\n", sizeVar, innerSizeVar, limitVar)
+			elemConvSuppress := ""
+			if ctx.exprVars.isSlice {
+				elemConvSuppress = convSuppressComment
+			}
+			ctx.appendCode(indent, "%s += int(%s) * %s%s\n", sizeVar, innerSizeVar, limitVar, elemConvSuppress)
 		case desc.GoTypeFlags&ssztypes.GoTypeFlagIsByteArray != 0 || desc.ElemDesc.Size == 1:
 			// For byte arrays, size is just the vector length
 			ctx.appendCode(indent, "%s += %s\n", sizeVar, limitVar)

--- a/codegen/gen_size.go
+++ b/codegen/gen_size.go
@@ -499,7 +499,7 @@ func (ctx *sizeContext) sizeVector(desc *ssztypes.TypeDescriptor, varName, sizeV
 			}
 		}
 
-		exprVar := ctx.exprVars.getExprVar(*sizeExpression, defaultValue)
+		exprVar := ctx.exprVars.getSizeExprVar(*sizeExpression, defaultValue)
 
 		if desc.SszTypeFlags&ssztypes.SszTypeFlagHasBitSize != 0 {
 			limitVar = fmt.Sprintf("int((%s+7)/8)", exprVar)

--- a/codegen/gen_size_test.go
+++ b/codegen/gen_size_test.go
@@ -232,7 +232,7 @@ func TestSizeExtendedTypes(t *testing.T) {
 	extendedTypes := []struct {
 		name    string
 		sszType ssztypes.SszType
-		size    uint32
+		size    int64
 	}{
 		{"Int8", ssztypes.SszInt8Type, 1},
 		{"Int16", ssztypes.SszInt16Type, 2},

--- a/codegen/gen_unmarshal.go
+++ b/codegen/gen_unmarshal.go
@@ -858,7 +858,7 @@ func (ctx *unmarshalContext) unmarshalVector(desc *ssztypes.TypeDescriptor, varN
 			defaultValue = uint64(desc.BitSize)
 		}
 
-		exprVar := ctx.exprVars.getExprVar(*sizeExpression, defaultValue)
+		exprVar := ctx.exprVars.getSizeExprVar(*sizeExpression, defaultValue)
 
 		if desc.SszTypeFlags&ssztypes.SszTypeFlagHasBitSize != 0 {
 			ctx.appendCode(indent, "bitlimit := %s\n", exprVar)
@@ -1072,10 +1072,8 @@ func (ctx *unmarshalContext) unmarshalList(desc *ssztypes.TypeDescriptor, varNam
 
 	switch {
 	case maxExpression != nil:
-		exprVar := ctx.exprVars.getExprVar(*maxExpression, desc.Limit)
-
+		maxVar = ctx.exprVars.getExprVar(*maxExpression, desc.Limit)
 		hasMax = true
-		maxVar = fmt.Sprintf("int(%s)", exprVar)
 	case desc.Limit > 0:
 		maxVar = fmt.Sprintf("%d", desc.Limit)
 		hasMax = true
@@ -1103,7 +1101,7 @@ func (ctx *unmarshalContext) unmarshalList(desc *ssztypes.TypeDescriptor, varNam
 		if desc.GoTypeFlags&ssztypes.GoTypeFlagIsByteArray != 0 {
 			if hasMax {
 				errCode := fmt.Sprintf("sszutils.ErrListLengthFn(len(buf), %s)", maxVar)
-				ctx.appendCode(indent, "if len(buf) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+				ctx.appendCode(indent, "if uint64(len(buf)) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
 			}
 			if desc.GoTypeFlags&ssztypes.GoTypeFlagIsString != 0 {
 				typename := ctx.typePrinter.InnerTypeString(desc)
@@ -1130,7 +1128,7 @@ func (ctx *unmarshalContext) unmarshalList(desc *ssztypes.TypeDescriptor, varNam
 			ctx.appendCode(indent, "if len(buf)%%8 != 0 {\n\treturn %s\n}\n", typePath.getErrorWith(errCode))
 			if hasMax {
 				errCode = fmt.Sprintf("sszutils.ErrListLengthFn(itemCount, %s)", maxVar)
-				ctx.appendCode(indent, "if itemCount > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+				ctx.appendCode(indent, "if uint64(max(itemCount, 0)) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
 			}
 			if desc.Kind != reflect.Array {
 				ctx.appendCode(indent, "%s = sszutils.ExpandSlice(%s, itemCount)\n", valueVar, valueVar)
@@ -1160,7 +1158,7 @@ func (ctx *unmarshalContext) unmarshalList(desc *ssztypes.TypeDescriptor, varNam
 		}
 		if hasMax {
 			errCode := fmt.Sprintf("sszutils.ErrListLengthFn(itemCount, %s)", maxVar)
-			ctx.appendCode(indent, "if itemCount > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+			ctx.appendCode(indent, "if uint64(max(itemCount, 0)) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
 		}
 		if desc.Kind != reflect.Array {
 			ctx.appendCode(indent, "%s = sszutils.ExpandSlice(%s, itemCount)\n", valueVar, valueVar)
@@ -1216,7 +1214,7 @@ func (ctx *unmarshalContext) unmarshalList(desc *ssztypes.TypeDescriptor, varNam
 		ctx.appendCode(indent, "if startOffset%%4 != 0 || len(buf) < startOffset || (len(buf) != 0 && startOffset == 0) {\n\treturn %s\n}\n", typePath.getErrorWith(errCode))
 		if hasMax {
 			errCode = fmt.Sprintf("sszutils.ErrListLengthFn(itemCount, %s)", maxVar)
-			ctx.appendCode(indent, "if itemCount > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+			ctx.appendCode(indent, "if uint64(max(itemCount, 0)) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
 		}
 		// The offset table declares the count, but only the region can prove the
 		// bodies exist. Each costs at least the element's fixed section, so a
@@ -1282,10 +1280,8 @@ func (ctx *unmarshalContext) unmarshalBitlist(desc *ssztypes.TypeDescriptor, var
 
 	switch {
 	case maxExpression != nil:
-		exprVar := ctx.exprVars.getExprVar(*maxExpression, desc.Limit)
-
+		maxVar = ctx.exprVars.getExprVar(*maxExpression, desc.Limit)
 		hasMax = true
-		maxVar = fmt.Sprintf("int(%s)", exprVar)
 	case desc.Limit > 0:
 		maxVar = fmt.Sprintf("%d", desc.Limit)
 		hasMax = true
@@ -1303,7 +1299,7 @@ func (ctx *unmarshalContext) unmarshalBitlist(desc *ssztypes.TypeDescriptor, var
 		bitsPkgName := ctx.typePrinter.AddImport("math/bits", "bits")
 		ctx.appendCode(indent, "bitCount := 8*(blen-1) + int(%s.Len8(buf[blen-1])) - 1\n", bitsPkgName)
 		errCode := fmt.Sprintf("sszutils.ErrBitlistLengthFn(bitCount, %s)", maxVar)
-		ctx.appendCode(indent, "if bitCount > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+		ctx.appendCode(indent, "if uint64(max(bitCount, 0)) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
 	}
 
 	valueVar := varName

--- a/codegen/gen_unmarshal.go
+++ b/codegen/gen_unmarshal.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/pk910/dynamic-ssz/ssztypes"
@@ -657,7 +658,7 @@ func (ctx *unmarshalContext) unmarshalBigInt(desc *ssztypes.TypeDescriptor, varN
 	// the marshal side.
 	if desc.MaxExpression == nil && desc.Limit > 0 {
 		limitErr := fmt.Sprintf("sszutils.NewSszErrorf(sszutils.ErrListTooBig, \"big.Int payload length %%d exceeds maximum %%d\", len(buf), %d)", desc.Limit)
-		ctx.appendCode(indent, "if uint64(len(buf)) > %d {\n\t\treturn %s\n\t}\n", desc.Limit, typePath.getErrorWith(limitErr))
+		ctx.appendCode(indent, "if %s {\n\t\treturn %s\n\t}\n", uintCmpExpr("len(buf)", ">", fmt.Sprintf("%d", desc.Limit)), typePath.getErrorWith(limitErr))
 	}
 	ctx.appendCode(indent, "if buf[0] > 1 {\n\t\treturn %s\n\t}\n", typePath.getErrorWith(signErr))
 	ctx.appendCode(indent, "if len(buf) > 1 && buf[1] == 0 {\n\t\treturn %s\n\t}\n", typePath.getErrorWith(leadZeroErr))
@@ -716,7 +717,9 @@ func (ctx *unmarshalContext) unmarshalContainer(desc *ssztypes.TypeDescriptor, v
 	totalStaticSizeExpr := strings.Join(staticSizeVars, "+")
 	if len(staticSizeVars) > 1 {
 		ctx.appendCode(indent, "exproffset := 0\n")
-		ctx.appendCode(indent, "totalSize := %s\n", totalStaticSizeExpr)
+		// The buffer arithmetic below runs in the int domain, so the unsigned
+		// size sum binds once as int.
+		ctx.appendCode(indent, "totalSize := int(%s)\n", totalStaticSizeExpr)
 		totalStaticSizeExpr = "totalSize"
 	}
 
@@ -767,7 +770,7 @@ func (ctx *unmarshalContext) unmarshalContainer(desc *ssztypes.TypeDescriptor, v
 				if err != nil {
 					return err
 				}
-				ctx.appendCode(indent, "\tbuf := buf[%s%d : %s%s+%d]\n", offsetPrefix, offset, offsetPrefix, fieldSizeVar, offset)
+				ctx.appendCode(indent, "\tbuf := buf[%s%d : %sint(%s)+%d]\n", offsetPrefix, offset, offsetPrefix, fieldSizeVar, offset)
 				ctx.appendCode(indent, "\texproffset += int(%s)\n", fieldSizeVar)
 				offsetPrefix = "exproffset+"
 			} else {
@@ -848,7 +851,10 @@ func (ctx *unmarshalContext) unmarshalVector(desc *ssztypes.TypeDescriptor, varN
 	// resolved size; emitted once the array expression exists.
 	arrayBoundPending := false
 
+	// limitVar is the int-domain bound the buffer arithmetic uses; limit64 is
+	// the uint64-domain form for length checks and error arguments.
 	limitVar := ""
+	limit64 := ""
 	bitlimitVar := ""
 	needExpression := desc.GoTypeFlags&ssztypes.GoTypeFlagIsString == 0 || !noBufCheck
 
@@ -860,13 +866,18 @@ func (ctx *unmarshalContext) unmarshalVector(desc *ssztypes.TypeDescriptor, varN
 
 		exprVar := ctx.exprVars.getSizeExprVar(*sizeExpression, defaultValue)
 
+		// The buffer arithmetic below runs in the int domain (len(buf) and
+		// slice bounds), so the resolved limit binds once as int and every use
+		// stays plain.
 		if desc.SszTypeFlags&ssztypes.SszTypeFlagHasBitSize != 0 {
 			ctx.appendCode(indent, "bitlimit := %s\n", exprVar)
-			ctx.appendCode(indent, "limit := (bitlimit+7)/8\n")
-			bitlimitVar = "int(bitlimit)"
+			ctx.appendCode(indent, "limit := (bitlimit + 7) / 8\n")
+			bitlimitVar = "bitlimit"
 			limitVar = "int(limit)"
+			limit64 = "limit"
 		} else {
 			limitVar = fmt.Sprintf("int(%s)", exprVar)
+			limit64 = exprVar
 		}
 
 		if desc.Kind == reflect.Array {
@@ -881,6 +892,7 @@ func (ctx *unmarshalContext) unmarshalVector(desc *ssztypes.TypeDescriptor, varN
 			bitlimitVar = fmt.Sprintf("%d", desc.BitSize)
 		}
 		limitVar = fmt.Sprintf("%d", desc.Len)
+		limit64 = limitVar
 	}
 
 	valueVar := varName
@@ -899,8 +911,8 @@ func (ctx *unmarshalContext) unmarshalVector(desc *ssztypes.TypeDescriptor, varN
 	}
 
 	if arrayBoundPending {
-		ctx.appendCode(indent, "if %s > len(%s) {\n", limitVar, indexValueVar)
-		errCode := fmt.Sprintf("sszutils.ErrVectorSizeExceedsArrayFn(%s, len(%s))", limitVar, indexValueVar)
+		ctx.appendCode(indent, "if %s {\n", uintCmpExpr(fmt.Sprintf("len(%s)", indexValueVar), "<", limit64))
+		errCode := fmt.Sprintf("sszutils.ErrVectorSizeExceedsArrayFn(%s, len(%s))", limit64, indexValueVar)
 		ctx.appendCode(indent, "\treturn %s\n", typePath.getErrorWith(errCode))
 		ctx.appendCode(indent, "}\n")
 	}
@@ -963,6 +975,14 @@ func (ctx *unmarshalContext) unmarshalVector(desc *ssztypes.TypeDescriptor, varN
 			if err != nil {
 				return err
 			}
+			// The decode arithmetic below runs in the int domain, so the
+			// unsigned size variable binds once as int. The bind name carries
+			// the size variable's suffix: nested element scopes would otherwise
+			// shadow an outer bind that is still referenced after the inner
+			// declaration.
+			bindVar := varNameElemSize + strings.TrimPrefix(fieldSizeVar, "size")
+			ctx.appendCode(indent, bindVar+" := int(%s)\n", fieldSizeVar)
+			fieldSizeVar = bindVar
 		} else {
 			fieldSizeVar = fmt.Sprintf("%d", desc.ElemDesc.Size)
 		}
@@ -1101,7 +1121,7 @@ func (ctx *unmarshalContext) unmarshalList(desc *ssztypes.TypeDescriptor, varNam
 		if desc.GoTypeFlags&ssztypes.GoTypeFlagIsByteArray != 0 {
 			if hasMax {
 				errCode := fmt.Sprintf("sszutils.ErrListLengthFn(len(buf), %s)", uintLitArg(maxVar))
-				ctx.appendCode(indent, "if uint64(len(buf)) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+				ctx.appendCode(indent, "if %s {\n\treturn %s\n}\n", uintCmpExpr("len(buf)", ">", maxVar), typePath.getErrorWith(errCode))
 			}
 			if desc.GoTypeFlags&ssztypes.GoTypeFlagIsString != 0 {
 				typename := ctx.typePrinter.InnerTypeString(desc)
@@ -1128,7 +1148,7 @@ func (ctx *unmarshalContext) unmarshalList(desc *ssztypes.TypeDescriptor, varNam
 			ctx.appendCode(indent, "if len(buf)%%8 != 0 {\n\treturn %s\n}\n", typePath.getErrorWith(errCode))
 			if hasMax {
 				errCode = fmt.Sprintf("sszutils.ErrListLengthFn(itemCount, %s)", uintLitArg(maxVar))
-				ctx.appendCode(indent, "if uint64(itemCount) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+				ctx.appendCode(indent, "if %s {\n\treturn %s\n}\n", uintCmpExpr("itemCount", ">", maxVar), typePath.getErrorWith(errCode))
 			}
 			if desc.Kind != reflect.Array {
 				ctx.appendCode(indent, "%s = sszutils.ExpandSlice(%s, itemCount)\n", valueVar, valueVar)
@@ -1145,6 +1165,14 @@ func (ctx *unmarshalContext) unmarshalList(desc *ssztypes.TypeDescriptor, varNam
 			if err != nil {
 				return err
 			}
+			// The decode arithmetic below runs in the int domain, so the
+			// unsigned size variable binds once as int. The bind name carries
+			// the size variable's suffix: nested element scopes would otherwise
+			// shadow an outer bind that is still referenced after the inner
+			// declaration.
+			bindVar := varNameElemSize + strings.TrimPrefix(fieldSizeVar, "size")
+			ctx.appendCode(indent, bindVar+" := int(%s)\n", fieldSizeVar)
+			fieldSizeVar = bindVar
 		} else {
 			fieldSizeVar = fmt.Sprintf("%d", desc.ElemDesc.Size)
 		}
@@ -1158,7 +1186,7 @@ func (ctx *unmarshalContext) unmarshalList(desc *ssztypes.TypeDescriptor, varNam
 		}
 		if hasMax {
 			errCode := fmt.Sprintf("sszutils.ErrListLengthFn(itemCount, %s)", uintLitArg(maxVar))
-			ctx.appendCode(indent, "if uint64(itemCount) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+			ctx.appendCode(indent, "if %s {\n\treturn %s\n}\n", uintCmpExpr("itemCount", ">", maxVar), typePath.getErrorWith(errCode))
 		}
 		if desc.Kind != reflect.Array {
 			ctx.appendCode(indent, "%s = sszutils.ExpandSlice(%s, itemCount)\n", valueVar, valueVar)
@@ -1218,7 +1246,7 @@ func (ctx *unmarshalContext) unmarshalList(desc *ssztypes.TypeDescriptor, varNam
 		ctx.appendCode(indent, "itemCount := startOffset / 4\n")
 		if hasMax {
 			errCode = fmt.Sprintf("sszutils.ErrListLengthFn(itemCount, %s)", uintLitArg(maxVar))
-			ctx.appendCode(indent, "if uint64(itemCount) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+			ctx.appendCode(indent, "if %s {\n\treturn %s\n}\n", uintCmpExpr("itemCount", ">", maxVar), typePath.getErrorWith(errCode))
 		}
 		// The offset table declares the count, but only the region can prove the
 		// bodies exist. Each costs at least the element's fixed section, so a
@@ -1234,7 +1262,11 @@ func (ctx *unmarshalContext) unmarshalList(desc *ssztypes.TypeDescriptor, varNam
 				guard = fmt.Sprintf("%s > 0 && ", positiveGuard)
 			}
 			errCode = fmt.Sprintf("sszutils.ErrListRegionTooSmallFn(itemCount, %s, len(buf)-startOffset)", minElemSize)
-			ctx.appendCode(indent, "if %sitemCount > (len(buf)-startOffset)/(%s) {\n\treturn %s\n}\n", guard, minElemSize, typePath.getErrorWith(errCode))
+			regionCmp := fmt.Sprintf("uint64(itemCount) > uint64(len(buf)-startOffset)/(%s)", minElemSize)
+			if _, lerr := strconv.ParseUint(minElemSize, 10, 64); lerr == nil {
+				regionCmp = fmt.Sprintf("itemCount > (len(buf)-startOffset)/(%s)", minElemSize)
+			}
+			ctx.appendCode(indent, "if %s%s {\n\treturn %s\n}\n", guard, regionCmp, typePath.getErrorWith(errCode))
 		}
 		if desc.Kind != reflect.Array {
 			ctx.appendCode(indent, "%s = sszutils.ExpandSlice(%s, itemCount)\n", valueVar, valueVar)
@@ -1303,7 +1335,7 @@ func (ctx *unmarshalContext) unmarshalBitlist(desc *ssztypes.TypeDescriptor, var
 		bitsPkgName := ctx.typePrinter.AddImport("math/bits", "bits")
 		ctx.appendCode(indent, "bitCount := 8*(blen-1) + int(%s.Len8(buf[blen-1])) - 1\n", bitsPkgName)
 		errCode := fmt.Sprintf("sszutils.ErrBitlistLengthFn(bitCount, %s)", uintLitArg(maxVar))
-		ctx.appendCode(indent, "if uint64(bitCount) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+		ctx.appendCode(indent, "if %s {\n\treturn %s\n}\n", uintCmpExpr("bitCount", ">", maxVar), typePath.getErrorWith(errCode))
 	}
 
 	valueVar := varName
@@ -1365,7 +1397,7 @@ func (ctx *unmarshalContext) unmarshalUnion(desc *ssztypes.TypeDescriptor, varNa
 				if serr != nil {
 					return serr
 				}
-				sizeExpr = fmt.Sprintf("1 + %s", sizeVar)
+				sizeExpr = fmt.Sprintf("1 + int(%s)", sizeVar)
 			} else {
 				sizeExpr = fmt.Sprintf("%d", 1+elemSize)
 			}

--- a/codegen/gen_unmarshal.go
+++ b/codegen/gen_unmarshal.go
@@ -1100,7 +1100,7 @@ func (ctx *unmarshalContext) unmarshalList(desc *ssztypes.TypeDescriptor, varNam
 		// static byte arrays
 		if desc.GoTypeFlags&ssztypes.GoTypeFlagIsByteArray != 0 {
 			if hasMax {
-				errCode := fmt.Sprintf("sszutils.ErrListLengthFn(len(buf), %s)", maxVar)
+				errCode := fmt.Sprintf("sszutils.ErrListLengthFn(len(buf), %s)", uintLitArg(maxVar))
 				ctx.appendCode(indent, "if uint64(len(buf)) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
 			}
 			if desc.GoTypeFlags&ssztypes.GoTypeFlagIsString != 0 {
@@ -1127,8 +1127,8 @@ func (ctx *unmarshalContext) unmarshalList(desc *ssztypes.TypeDescriptor, varNam
 			errCode := "sszutils.ErrListNotAlignedFn(len(buf), 8)"
 			ctx.appendCode(indent, "if len(buf)%%8 != 0 {\n\treturn %s\n}\n", typePath.getErrorWith(errCode))
 			if hasMax {
-				errCode = fmt.Sprintf("sszutils.ErrListLengthFn(itemCount, %s)", maxVar)
-				ctx.appendCode(indent, "if uint64(max(itemCount, 0)) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+				errCode = fmt.Sprintf("sszutils.ErrListLengthFn(itemCount, %s)", uintLitArg(maxVar))
+				ctx.appendCode(indent, "if uint64(itemCount) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
 			}
 			if desc.Kind != reflect.Array {
 				ctx.appendCode(indent, "%s = sszutils.ExpandSlice(%s, itemCount)\n", valueVar, valueVar)
@@ -1157,8 +1157,8 @@ func (ctx *unmarshalContext) unmarshalList(desc *ssztypes.TypeDescriptor, varNam
 			ctx.appendCode(indent, "if len(buf)%%%s != 0 {\n\treturn %s\n}\n", fieldSizeVar, typePath.getErrorWith(errCode))
 		}
 		if hasMax {
-			errCode := fmt.Sprintf("sszutils.ErrListLengthFn(itemCount, %s)", maxVar)
-			ctx.appendCode(indent, "if uint64(max(itemCount, 0)) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+			errCode := fmt.Sprintf("sszutils.ErrListLengthFn(itemCount, %s)", uintLitArg(maxVar))
+			ctx.appendCode(indent, "if uint64(itemCount) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
 		}
 		if desc.Kind != reflect.Array {
 			ctx.appendCode(indent, "%s = sszutils.ExpandSlice(%s, itemCount)\n", valueVar, valueVar)
@@ -1203,18 +1203,22 @@ func (ctx *unmarshalContext) unmarshalList(desc *ssztypes.TypeDescriptor, varNam
 		ctx.appendCode(indent, "if len(buf) != 0 {\n")
 		errCode := "sszutils.ErrListOffsetsEOFFn(len(buf), 4)"
 		ctx.appendCode(indent, "\tif len(buf) < 4 {\n\t\treturn %s\n\t}\n", typePath.getErrorWith(errCode))
-		ctx.appendCode(indent, "\tstartOffset = int(%s.LittleEndian.Uint32(buf[0:4]))\n", binaryPkgName)
+		ctx.appendCode(indent, "\tfirstOffset := %s.LittleEndian.Uint32(buf[0:4])\n", binaryPkgName)
+		// The offset validates in the unsigned domain, before the int conversion:
+		// on a 32-bit platform a raw value past MaxInt32 would wrap negative and
+		// slip through int-domain checks as an empty list. A non-empty region
+		// must begin with an offset table, so the first offset is at least 4; a
+		// first offset of 0 means zero items and is only valid for a zero-length
+		// region, anything else leaves unconsumed trailing data that the
+		// reflection path rejects.
+		errCode = "sszutils.ErrInvalidListStartOffsetFn(firstOffset, len(buf))"
+		ctx.appendCode(indent, "\tif firstOffset%%4 != 0 || uint64(firstOffset) > uint64(len(buf)) || firstOffset == 0 {\n\t\treturn %s\n\t}\n", typePath.getErrorWith(errCode))
+		ctx.appendCode(indent, "\tstartOffset = int(firstOffset)\n")
 		ctx.appendCode(indent, "}\n")
 		ctx.appendCode(indent, "itemCount := startOffset / 4\n")
-		errCode = "sszutils.ErrInvalidListStartOffsetFn(startOffset, len(buf))"
-		// A non-empty region must begin with an offset table, so the first offset
-		// is at least 4. A first offset of 0 means zero items and is only valid
-		// for a zero-length region; otherwise the remaining bytes are unconsumed
-		// trailing data that the reflection path rejects.
-		ctx.appendCode(indent, "if startOffset%%4 != 0 || len(buf) < startOffset || (len(buf) != 0 && startOffset == 0) {\n\treturn %s\n}\n", typePath.getErrorWith(errCode))
 		if hasMax {
-			errCode = fmt.Sprintf("sszutils.ErrListLengthFn(itemCount, %s)", maxVar)
-			ctx.appendCode(indent, "if uint64(max(itemCount, 0)) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+			errCode = fmt.Sprintf("sszutils.ErrListLengthFn(itemCount, %s)", uintLitArg(maxVar))
+			ctx.appendCode(indent, "if uint64(itemCount) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
 		}
 		// The offset table declares the count, but only the region can prove the
 		// bodies exist. Each costs at least the element's fixed section, so a
@@ -1298,8 +1302,8 @@ func (ctx *unmarshalContext) unmarshalBitlist(desc *ssztypes.TypeDescriptor, var
 	if hasMax {
 		bitsPkgName := ctx.typePrinter.AddImport("math/bits", "bits")
 		ctx.appendCode(indent, "bitCount := 8*(blen-1) + int(%s.Len8(buf[blen-1])) - 1\n", bitsPkgName)
-		errCode := fmt.Sprintf("sszutils.ErrBitlistLengthFn(bitCount, %s)", maxVar)
-		ctx.appendCode(indent, "if uint64(max(bitCount, 0)) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
+		errCode := fmt.Sprintf("sszutils.ErrBitlistLengthFn(bitCount, %s)", uintLitArg(maxVar))
+		ctx.appendCode(indent, "if uint64(bitCount) > %s {\n\treturn %s\n}\n", maxVar, typePath.getErrorWith(errCode))
 	}
 
 	valueVar := varName

--- a/codegen/gen_unmarshal.go
+++ b/codegen/gen_unmarshal.go
@@ -624,8 +624,8 @@ func (ctx *unmarshalContext) unmarshalOptionalList(desc *ssztypes.TypeDescriptor
 			sizeVar = fmt.Sprintf("%d", desc.ElemDesc.Size)
 		}
 		eofErr := typePath.getErrorWith("sszutils.ErrOptionalValueEOFFn()")
-		trailErr := typePath.getErrorWith(fmt.Sprintf("sszutils.ErrTrailingDataFn(len(buf) - int(%s))", sizeVar))
-		ctx.appendExactLenCheck(indent+1, fmt.Sprintf("int(%s)", sizeVar), "len(buf)", eofErr, trailErr)
+		trailErr := typePath.getErrorWith(fmt.Sprintf("sszutils.ErrTrailingDataFn(uint64(len(buf)) - %s)", sizeVar))
+		ctx.appendExactLenCheck(indent+1, sizeVar, "uint64(len(buf))", eofErr, trailErr)
 	}
 	valVar := ctx.getValVar()
 	ctx.appendCode(indent+1, "var %s %s\n", valVar, ctx.typePrinter.TypeString(desc.ElemDesc))
@@ -695,11 +695,11 @@ func (ctx *unmarshalContext) appendExactLenCheck(indent int, sizeExpr, lenExpr, 
 func (ctx *unmarshalContext) unmarshalContainer(desc *ssztypes.TypeDescriptor, varName string, typePath typePathList, indent int) error {
 	staticSize := 0
 	staticSizeVars := []string{}
-	hasDynamicFields := false
+	dynFieldCount := 0
 	for _, field := range desc.ContainerDesc.Fields {
 		if field.Type.SszTypeFlags&ssztypes.SszTypeFlagIsDynamic != 0 {
 			staticSize += 4
-			hasDynamicFields = true
+			dynFieldCount++
 		} else {
 			if field.Type.SszTypeFlags&ssztypes.SszTypeFlagHasSizeExpr != 0 && !ctx.options.WithoutDynamicExpressions {
 				sizeVar, err := ctx.staticSizeVars.getStaticSizeVar(field.Type)
@@ -716,22 +716,30 @@ func (ctx *unmarshalContext) unmarshalContainer(desc *ssztypes.TypeDescriptor, v
 
 	totalStaticSizeExpr := strings.Join(staticSizeVars, "+")
 	if len(staticSizeVars) > 1 {
-		ctx.appendCode(indent, "exproffset := 0\n")
-		// The buffer arithmetic below runs in the int domain, so the unsigned
-		// size sum binds once as int.
-		ctx.appendCode(indent, "totalSize := int(%s)\n", totalStaticSizeExpr)
+		ctx.appendCode(indent, "exproffset := uint64(0)\n")
+		// The size sum stays uint64 (an adversarial spec could wrap an
+		// int-converted sum negative, turning the EOF check into a pass on a
+		// short buffer); buflen lives in the same domain.
+		ctx.appendCode(indent, "totalSize := %s\n", totalStaticSizeExpr)
 		totalStaticSizeExpr = "totalSize"
 	}
 
 	// Read fixed fields and offsets
 	offset := 0
 	offsetPrefix := ""
-	ctx.appendCode(indent, "buflen := len(buf)\n")
+	ctx.appendCode(indent, "buflen := uint64(len(buf))\n")
 	errCode := fmt.Sprintf("sszutils.ErrFixedFieldsEOFFn(buflen, %s)", totalStaticSizeExpr)
-	if hasDynamicFields {
+	if dynFieldCount > 0 {
 		// Variable-length container: only a shortfall in the fixed prefix is an
 		// error; trailing bytes belong to the dynamic fields.
 		ctx.appendCode(indent, "if buflen < %s {\n\treturn %s\n}\n", totalStaticSizeExpr, typePath.getErrorWith(errCode))
+		if dynFieldCount > 1 {
+			// Only an offset after the first checks against maxOffset (the
+			// first compares against the static size). Offsets are 4-byte
+			// values, so the bound lives in uint32: a region past the offset
+			// range caps, since no offset can address it.
+			ctx.appendCode(indent, "maxOffset := uint32(sszutils.Min(buflen, %s.MaxUint32))\n", ctx.typePrinter.AddImport("math", "math"))
+		}
 	} else {
 		// A fully fixed container occupies exactly its size, so any extra bytes
 		// are trailing data and must be rejected (matching the reflection and
@@ -751,14 +759,18 @@ func (ctx *unmarshalContext) unmarshalContainer(desc *ssztypes.TypeDescriptor, v
 				fmtSpace = " "
 			}
 			binaryPkgName := ctx.typePrinter.AddImport("encoding/binary", "binary")
-			ctx.appendCode(indent, "offset%d := int(%s.LittleEndian.Uint32(buf[%s%d%s:%s%s%d]))\n", idx, binaryPkgName, offsetPrefix, offset, fmtSpace, fmtSpace, offsetPrefix, offset+4)
+			ctx.appendCode(indent, "offset%d := %s.LittleEndian.Uint32(buf[%s%d%s:%s%s%d])\n", idx, binaryPkgName, offsetPrefix, offset, fmtSpace, fmtSpace, offsetPrefix, offset+4)
 			fieldOffsetPath := typePath.append(fmt.Sprintf("%s:o", field.Name))
 			if len(dynamicFields) > 0 {
 				errCode = fmt.Sprintf("sszutils.ErrOffsetOutOfRangeFn(offset%d, offset%d, buflen)", idx, dynamicFields[len(dynamicFields)-1])
-				ctx.appendCode(indent, "if offset%d < offset%d || offset%d > buflen {\n\treturn %s\n}\n", idx, dynamicFields[len(dynamicFields)-1], idx, fieldOffsetPath.getErrorWith(errCode))
+				ctx.appendCode(indent, "if offset%d < offset%d || offset%d > maxOffset {\n\treturn %s\n}\n", idx, dynamicFields[len(dynamicFields)-1], idx, fieldOffsetPath.getErrorWith(errCode))
 			} else {
 				errCode = fmt.Sprintf("sszutils.ErrFirstOffsetMismatchFn(offset%d, %s)", idx, totalStaticSizeExpr)
-				ctx.appendCode(indent, "if offset%d != %s {\n\treturn %s\n}\n", idx, totalStaticSizeExpr, fieldOffsetPath.getErrorWith(errCode))
+				firstOffCmp := fmt.Sprintf("uint64(offset%d) != %s", idx, totalStaticSizeExpr)
+				if _, lerr := strconv.ParseUint(totalStaticSizeExpr, 10, 64); lerr == nil {
+					firstOffCmp = fmt.Sprintf("offset%d != %s", idx, totalStaticSizeExpr)
+				}
+				ctx.appendCode(indent, "if %s {\n\treturn %s\n}\n", firstOffCmp, fieldOffsetPath.getErrorWith(errCode))
 			}
 			offset += 4
 			dynamicFields = append(dynamicFields, idx)
@@ -770,8 +782,8 @@ func (ctx *unmarshalContext) unmarshalContainer(desc *ssztypes.TypeDescriptor, v
 				if err != nil {
 					return err
 				}
-				ctx.appendCode(indent, "\tbuf := buf[%s%d : %sint(%s)+%d]\n", offsetPrefix, offset, offsetPrefix, fieldSizeVar, offset)
-				ctx.appendCode(indent, "\texproffset += int(%s)\n", fieldSizeVar)
+				ctx.appendCode(indent, "\tbuf := buf[%s%d : %s%s+%d]\n", offsetPrefix, offset, offsetPrefix, fieldSizeVar, offset)
+				ctx.appendCode(indent, "\texproffset += %s\n", fieldSizeVar)
 				offsetPrefix = "exproffset+"
 			} else {
 				fmtSpace := ""

--- a/codegen/parser.go
+++ b/codegen/parser.go
@@ -1261,7 +1261,7 @@ func (p *Parser) buildUint256Descriptor(desc *ssztypes.TypeDescriptor, typ types
 func (p *Parser) buildContainerDescriptor(desc *ssztypes.TypeDescriptor, dataStruct, schemaStruct *types.Struct) error {
 	fields := []ssztypes.FieldDescriptor{}
 	dynFields := []ssztypes.DynFieldDescriptor{}
-	size := uint32(0)
+	size := int64(0)
 	isDynamic := false
 
 	// Progressive-container detection: tracks whether any field carries an
@@ -1437,7 +1437,7 @@ func (p *Parser) buildContainerDescriptor(desc *ssztypes.TypeDescriptor, dataStr
 func (p *Parser) buildVectorDescriptor(desc *ssztypes.TypeDescriptor, dataType, schemaType types.Type, sizeHints []ssztypes.SszSizeHint, maxSizeHints []ssztypes.SszMaxSizeHint, typeHints []ssztypes.SszTypeHint) error {
 	var schemaElemType types.Type
 	var dataElemType types.Type
-	var length uint32
+	var length int64
 
 	arrayLen := uint64(0)
 	if arrType, isArr := schemaType.(*types.Array); isArr {
@@ -1451,7 +1451,7 @@ func (p *Parser) buildVectorDescriptor(desc *ssztypes.TypeDescriptor, dataType, 
 	switch t := schemaType.(type) {
 	case *types.Array:
 		schemaElemType = t.Elem()
-		length = uint32(t.Len())
+		length = int64(t.Len())
 		if len(sizeHints) > 0 && sizeHints[0].Size > 0 {
 			byteSize := sizeHints[0].Size
 			if sizeHints[0].Bits {

--- a/codegen/parser.go
+++ b/codegen/parser.go
@@ -1451,7 +1451,7 @@ func (p *Parser) buildVectorDescriptor(desc *ssztypes.TypeDescriptor, dataType, 
 	switch t := schemaType.(type) {
 	case *types.Array:
 		schemaElemType = t.Elem()
-		length = int64(t.Len())
+		length = t.Len()
 		if len(sizeHints) > 0 && sizeHints[0].Size > 0 {
 			byteSize := sizeHints[0].Size
 			if sizeHints[0].Bits {

--- a/codegen/parser_test.go
+++ b/codegen/parser_test.go
@@ -314,7 +314,7 @@ func TestBuildTypeDescriptorBasicTypes(t *testing.T) {
 		name     string
 		typeKind types.BasicKind
 		expected ssztypes.SszType
-		size     uint32
+		size     int64
 	}{
 		{"bool", types.Bool, ssztypes.SszBoolType, 1},
 		{"uint8", types.Uint8, ssztypes.SszUint8Type, 1},

--- a/codegen/tests/codegen_test.go
+++ b/codegen/tests/codegen_test.go
@@ -156,6 +156,37 @@ var testMatrix = []TestPayload{
 		Hash:    "1bee9de04dd4f275d8c785741e5ae754bc95d6cf3d6abf1f98c3a41d066f557f",
 	},
 	{
+		Name:    "GenCovBranches",
+		Payload: GenCovBranches_Payload,
+		Specs:   GenCovBranches_Specs,
+		Hash:    "5467d3272bb3d7fdc5a98771df8936d8ed00c8e2bc1c8524b231f0029b3a394d",
+	},
+	{
+		Name:    "GenCovCustomHolder2",
+		Payload: GenCovCustomHolder2_Payload,
+		Specs:   map[string]any{},
+		Hash:    "0a3b5fb13b2a99c649c2e75acf707a67c5cb680117a3e0dcc2934b891f7f1156",
+	},
+	{
+		Name:    "GenCovWideOffsets",
+		Payload: GenCovWideOffsets_Payload,
+		Specs:   map[string]any{},
+		Hash:    "f1bab90ff9c8f01b31fa444c6d9b2ace4749d0dcf3d6ca1ae35f4b9e00b284cb",
+	},
+	{
+		Name:    "ViewMixHolder",
+		Payload: ViewMixHolder_Payload,
+		Specs:   map[string]any{},
+		Hash:    "853c0bb51de56d2bd79fefe13caabbc18965129ca87438d4187fbcc48c557c82",
+	},
+	{
+		Name:    "ViewMixHolder_View",
+		Payload: ViewMixHolder_Payload,
+		View:    (*ViewMixHolder_View)(nil),
+		Specs:   map[string]any{},
+		Hash:    "853c0bb51de56d2bd79fefe13caabbc18965129ca87438d4187fbcc48c557c82",
+	},
+	{
 		Name:    "AnnotatedContainer",
 		Payload: AnnotatedContainer_Payload,
 		Specs:   map[string]any{},
@@ -467,6 +498,7 @@ func TestCodegenAtkNest(t *testing.T) {
 	testCodegenPayloadByReflection(t, AtkNestOpt_Payload, nil, ext)
 	testCodegenPayloadByReflection(t, AtkNestOptList_Payload, nil, ext)
 	testCodegenPayloadByReflection(t, AtkWellHolder_Payload, nil, ext)
+	testCodegenPayloadByReflection(t, GenCovCustomHolder_Payload, nil, ext)
 
 	// The inlined static encoding of the external delegated child must be
 	// byte-identical to what its own Dynamic* method produces. AtkWellHolder is

--- a/codegen/tests/gen_atknest.yaml
+++ b/codegen/tests/gen_atknest.yaml
@@ -23,3 +23,4 @@ types:
   - AtkNestOpt
   - AtkNestOptList
   - AtkWellHolder
+  - name: GenCovCustomHolder

--- a/codegen/tests/gen_ssz.yaml
+++ b/codegen/tests/gen_ssz.yaml
@@ -219,3 +219,9 @@ types:
     output: gen_edgecases.go
   - name: WideDynamicList
     output: gen_edgecases.go
+  - name: GenCovBranches
+    output: gen_edgecases.go
+  - name: GenCovWideOffsets
+    output: gen_edgecases.go
+  - name: GenCovCustomHolder2
+    output: gen_edgecases.go

--- a/codegen/tests/gen_viewtypes4.yaml
+++ b/codegen/tests/gen_viewtypes4.yaml
@@ -8,3 +8,25 @@ types:
     output: gen_viewtypes4.go
     views:
       - ViewTypes4_View1
+  - name: ViewMixChildA
+    output: gen_viewtypes4.go
+    views:
+      - ViewMixChildA_View
+    skip-encoder: true
+    skip-decoder: true
+  - name: ViewMixChildB
+    output: gen_viewtypes4.go
+    views:
+      - ViewMixChildB_View
+    skip-marshal: true
+    skip-unmarshal: true
+  - name: ViewMixChildC
+    output: gen_viewtypes4.go
+    views:
+      - ViewMixChildC_View
+    skip-encoder: true
+    skip-decoder: true
+  - name: ViewMixHolder
+    output: gen_viewtypes4.go
+    views:
+      - ViewMixHolder_View

--- a/codegen/tests/types.go
+++ b/codegen/tests/types.go
@@ -2453,3 +2453,530 @@ type HashParityWrap struct {
 		Data []uint8 `ssz-max:"8"`
 	}, []uint8] `ssz-type:"wrapper"`
 }
+
+// GenCovBranches exercises generator branches no other fixture reaches: bulk
+// fixed-byte collections, limits past the int32 range, spec-sized strings and
+// bit sizes, duplicate hinted shapes, wrapper-borne static sizes, and a
+// fastssz-only child in the streaming decoder.
+type GenCovBranches struct {
+	RootsVec  [][32]byte `ssz-size:"4"`
+	RootsList [][32]byte `ssz-max:"64"`
+	HugeLimit []uint64   `ssz-max:"1099511627776"`
+	SpecStr   string     `dynssz-size:"TEST_SPEC"`
+	Bits2     []byte     `ssz-type:"bitvector" ssz-bitsize:"30"`
+	BitsArr   [4]byte    `ssz-type:"bitvector" ssz-bitsize:"30"`
+	HintA     []byte     `ssz-size:"32" dynssz-size:"SPEC_A"`
+	HintB     []byte     `ssz-size:"32" dynssz-size:"SPEC_B"`
+	Fast      CustomType1
+	WrapSpec  dynssz.TypeWrapper[struct {
+		Data []byte `ssz-size:"32" dynssz-size:"TEST_SPEC"`
+	}, []byte] `ssz-type:"wrapper"`
+	UnionList []dynssz.CompatibleUnion[struct {
+		V1 uint64
+		V2 []byte `ssz-max:"8"`
+	}] `ssz-max:"8"`
+	SpecVecList [][2]genCovSpecInner `ssz-max:"8"`
+	VecOfList   [][2][]uint8         `ssz-max:"8,?,4"`
+	Dyn         []byte               `ssz-max:"32"`
+}
+
+// genCovSpecInner is a dynamic container with a spec-sized static part, so
+// the list region bound over vectors of it groups a compound minimum.
+type genCovSpecInner struct {
+	A []byte `ssz-size:"4" dynssz-size:"TEST_SPEC"`
+	B []byte `ssz-max:"4"`
+}
+
+// GenCovCustomHolder pairs a fastssz-only custom field with a dynamic
+// sibling; generated without fastssz, every generator emits its custom-type
+// return.
+type GenCovCustomHolder struct {
+	C CustomType1 `ssz-type:"custom"`
+	D []byte      `ssz-max:"8"`
+}
+
+// GenCovWideOffsets carries enough consecutive dynamic fields that the
+// grouped offset reservation exceeds the bulk-padding threshold.
+type GenCovWideOffsets struct {
+	F000 []byte `ssz-max:"4"`
+	F001 []byte `ssz-max:"4"`
+	F002 []byte `ssz-max:"4"`
+	F003 []byte `ssz-max:"4"`
+	F004 []byte `ssz-max:"4"`
+	F005 []byte `ssz-max:"4"`
+	F006 []byte `ssz-max:"4"`
+	F007 []byte `ssz-max:"4"`
+	F008 []byte `ssz-max:"4"`
+	F009 []byte `ssz-max:"4"`
+	F010 []byte `ssz-max:"4"`
+	F011 []byte `ssz-max:"4"`
+	F012 []byte `ssz-max:"4"`
+	F013 []byte `ssz-max:"4"`
+	F014 []byte `ssz-max:"4"`
+	F015 []byte `ssz-max:"4"`
+	F016 []byte `ssz-max:"4"`
+	F017 []byte `ssz-max:"4"`
+	F018 []byte `ssz-max:"4"`
+	F019 []byte `ssz-max:"4"`
+	F020 []byte `ssz-max:"4"`
+	F021 []byte `ssz-max:"4"`
+	F022 []byte `ssz-max:"4"`
+	F023 []byte `ssz-max:"4"`
+	F024 []byte `ssz-max:"4"`
+	F025 []byte `ssz-max:"4"`
+	F026 []byte `ssz-max:"4"`
+	F027 []byte `ssz-max:"4"`
+	F028 []byte `ssz-max:"4"`
+	F029 []byte `ssz-max:"4"`
+	F030 []byte `ssz-max:"4"`
+	F031 []byte `ssz-max:"4"`
+	F032 []byte `ssz-max:"4"`
+	F033 []byte `ssz-max:"4"`
+	F034 []byte `ssz-max:"4"`
+	F035 []byte `ssz-max:"4"`
+	F036 []byte `ssz-max:"4"`
+	F037 []byte `ssz-max:"4"`
+	F038 []byte `ssz-max:"4"`
+	F039 []byte `ssz-max:"4"`
+	F040 []byte `ssz-max:"4"`
+	F041 []byte `ssz-max:"4"`
+	F042 []byte `ssz-max:"4"`
+	F043 []byte `ssz-max:"4"`
+	F044 []byte `ssz-max:"4"`
+	F045 []byte `ssz-max:"4"`
+	F046 []byte `ssz-max:"4"`
+	F047 []byte `ssz-max:"4"`
+	F048 []byte `ssz-max:"4"`
+	F049 []byte `ssz-max:"4"`
+	F050 []byte `ssz-max:"4"`
+	F051 []byte `ssz-max:"4"`
+	F052 []byte `ssz-max:"4"`
+	F053 []byte `ssz-max:"4"`
+	F054 []byte `ssz-max:"4"`
+	F055 []byte `ssz-max:"4"`
+	F056 []byte `ssz-max:"4"`
+	F057 []byte `ssz-max:"4"`
+	F058 []byte `ssz-max:"4"`
+	F059 []byte `ssz-max:"4"`
+	F060 []byte `ssz-max:"4"`
+	F061 []byte `ssz-max:"4"`
+	F062 []byte `ssz-max:"4"`
+	F063 []byte `ssz-max:"4"`
+	F064 []byte `ssz-max:"4"`
+	F065 []byte `ssz-max:"4"`
+	F066 []byte `ssz-max:"4"`
+	F067 []byte `ssz-max:"4"`
+	F068 []byte `ssz-max:"4"`
+	F069 []byte `ssz-max:"4"`
+	F070 []byte `ssz-max:"4"`
+	F071 []byte `ssz-max:"4"`
+	F072 []byte `ssz-max:"4"`
+	F073 []byte `ssz-max:"4"`
+	F074 []byte `ssz-max:"4"`
+	F075 []byte `ssz-max:"4"`
+	F076 []byte `ssz-max:"4"`
+	F077 []byte `ssz-max:"4"`
+	F078 []byte `ssz-max:"4"`
+	F079 []byte `ssz-max:"4"`
+	F080 []byte `ssz-max:"4"`
+	F081 []byte `ssz-max:"4"`
+	F082 []byte `ssz-max:"4"`
+	F083 []byte `ssz-max:"4"`
+	F084 []byte `ssz-max:"4"`
+	F085 []byte `ssz-max:"4"`
+	F086 []byte `ssz-max:"4"`
+	F087 []byte `ssz-max:"4"`
+	F088 []byte `ssz-max:"4"`
+	F089 []byte `ssz-max:"4"`
+	F090 []byte `ssz-max:"4"`
+	F091 []byte `ssz-max:"4"`
+	F092 []byte `ssz-max:"4"`
+	F093 []byte `ssz-max:"4"`
+	F094 []byte `ssz-max:"4"`
+	F095 []byte `ssz-max:"4"`
+	F096 []byte `ssz-max:"4"`
+	F097 []byte `ssz-max:"4"`
+	F098 []byte `ssz-max:"4"`
+	F099 []byte `ssz-max:"4"`
+	F100 []byte `ssz-max:"4"`
+	F101 []byte `ssz-max:"4"`
+	F102 []byte `ssz-max:"4"`
+	F103 []byte `ssz-max:"4"`
+	F104 []byte `ssz-max:"4"`
+	F105 []byte `ssz-max:"4"`
+	F106 []byte `ssz-max:"4"`
+	F107 []byte `ssz-max:"4"`
+	F108 []byte `ssz-max:"4"`
+	F109 []byte `ssz-max:"4"`
+	F110 []byte `ssz-max:"4"`
+	F111 []byte `ssz-max:"4"`
+	F112 []byte `ssz-max:"4"`
+	F113 []byte `ssz-max:"4"`
+	F114 []byte `ssz-max:"4"`
+	F115 []byte `ssz-max:"4"`
+	F116 []byte `ssz-max:"4"`
+	F117 []byte `ssz-max:"4"`
+	F118 []byte `ssz-max:"4"`
+	F119 []byte `ssz-max:"4"`
+	F120 []byte `ssz-max:"4"`
+	F121 []byte `ssz-max:"4"`
+	F122 []byte `ssz-max:"4"`
+	F123 []byte `ssz-max:"4"`
+	F124 []byte `ssz-max:"4"`
+	F125 []byte `ssz-max:"4"`
+	F126 []byte `ssz-max:"4"`
+	F127 []byte `ssz-max:"4"`
+	F128 []byte `ssz-max:"4"`
+	F129 []byte `ssz-max:"4"`
+	F130 []byte `ssz-max:"4"`
+	F131 []byte `ssz-max:"4"`
+	F132 []byte `ssz-max:"4"`
+	F133 []byte `ssz-max:"4"`
+	F134 []byte `ssz-max:"4"`
+	F135 []byte `ssz-max:"4"`
+	F136 []byte `ssz-max:"4"`
+	F137 []byte `ssz-max:"4"`
+	F138 []byte `ssz-max:"4"`
+	F139 []byte `ssz-max:"4"`
+	F140 []byte `ssz-max:"4"`
+	F141 []byte `ssz-max:"4"`
+	F142 []byte `ssz-max:"4"`
+	F143 []byte `ssz-max:"4"`
+	F144 []byte `ssz-max:"4"`
+	F145 []byte `ssz-max:"4"`
+	F146 []byte `ssz-max:"4"`
+	F147 []byte `ssz-max:"4"`
+	F148 []byte `ssz-max:"4"`
+	F149 []byte `ssz-max:"4"`
+	F150 []byte `ssz-max:"4"`
+	F151 []byte `ssz-max:"4"`
+	F152 []byte `ssz-max:"4"`
+	F153 []byte `ssz-max:"4"`
+	F154 []byte `ssz-max:"4"`
+	F155 []byte `ssz-max:"4"`
+	F156 []byte `ssz-max:"4"`
+	F157 []byte `ssz-max:"4"`
+	F158 []byte `ssz-max:"4"`
+	F159 []byte `ssz-max:"4"`
+	F160 []byte `ssz-max:"4"`
+	F161 []byte `ssz-max:"4"`
+	F162 []byte `ssz-max:"4"`
+	F163 []byte `ssz-max:"4"`
+	F164 []byte `ssz-max:"4"`
+	F165 []byte `ssz-max:"4"`
+	F166 []byte `ssz-max:"4"`
+	F167 []byte `ssz-max:"4"`
+	F168 []byte `ssz-max:"4"`
+	F169 []byte `ssz-max:"4"`
+	F170 []byte `ssz-max:"4"`
+	F171 []byte `ssz-max:"4"`
+	F172 []byte `ssz-max:"4"`
+	F173 []byte `ssz-max:"4"`
+	F174 []byte `ssz-max:"4"`
+	F175 []byte `ssz-max:"4"`
+	F176 []byte `ssz-max:"4"`
+	F177 []byte `ssz-max:"4"`
+	F178 []byte `ssz-max:"4"`
+	F179 []byte `ssz-max:"4"`
+	F180 []byte `ssz-max:"4"`
+	F181 []byte `ssz-max:"4"`
+	F182 []byte `ssz-max:"4"`
+	F183 []byte `ssz-max:"4"`
+	F184 []byte `ssz-max:"4"`
+	F185 []byte `ssz-max:"4"`
+	F186 []byte `ssz-max:"4"`
+	F187 []byte `ssz-max:"4"`
+	F188 []byte `ssz-max:"4"`
+	F189 []byte `ssz-max:"4"`
+	F190 []byte `ssz-max:"4"`
+	F191 []byte `ssz-max:"4"`
+	F192 []byte `ssz-max:"4"`
+	F193 []byte `ssz-max:"4"`
+	F194 []byte `ssz-max:"4"`
+	F195 []byte `ssz-max:"4"`
+	F196 []byte `ssz-max:"4"`
+	F197 []byte `ssz-max:"4"`
+	F198 []byte `ssz-max:"4"`
+	F199 []byte `ssz-max:"4"`
+	F200 []byte `ssz-max:"4"`
+	F201 []byte `ssz-max:"4"`
+	F202 []byte `ssz-max:"4"`
+	F203 []byte `ssz-max:"4"`
+	F204 []byte `ssz-max:"4"`
+	F205 []byte `ssz-max:"4"`
+	F206 []byte `ssz-max:"4"`
+	F207 []byte `ssz-max:"4"`
+	F208 []byte `ssz-max:"4"`
+	F209 []byte `ssz-max:"4"`
+	F210 []byte `ssz-max:"4"`
+	F211 []byte `ssz-max:"4"`
+	F212 []byte `ssz-max:"4"`
+	F213 []byte `ssz-max:"4"`
+	F214 []byte `ssz-max:"4"`
+	F215 []byte `ssz-max:"4"`
+	F216 []byte `ssz-max:"4"`
+	F217 []byte `ssz-max:"4"`
+	F218 []byte `ssz-max:"4"`
+	F219 []byte `ssz-max:"4"`
+	F220 []byte `ssz-max:"4"`
+	F221 []byte `ssz-max:"4"`
+	F222 []byte `ssz-max:"4"`
+	F223 []byte `ssz-max:"4"`
+	F224 []byte `ssz-max:"4"`
+	F225 []byte `ssz-max:"4"`
+	F226 []byte `ssz-max:"4"`
+	F227 []byte `ssz-max:"4"`
+	F228 []byte `ssz-max:"4"`
+	F229 []byte `ssz-max:"4"`
+	F230 []byte `ssz-max:"4"`
+	F231 []byte `ssz-max:"4"`
+	F232 []byte `ssz-max:"4"`
+	F233 []byte `ssz-max:"4"`
+	F234 []byte `ssz-max:"4"`
+	F235 []byte `ssz-max:"4"`
+	F236 []byte `ssz-max:"4"`
+	F237 []byte `ssz-max:"4"`
+	F238 []byte `ssz-max:"4"`
+	F239 []byte `ssz-max:"4"`
+	F240 []byte `ssz-max:"4"`
+	F241 []byte `ssz-max:"4"`
+	F242 []byte `ssz-max:"4"`
+	F243 []byte `ssz-max:"4"`
+	F244 []byte `ssz-max:"4"`
+	F245 []byte `ssz-max:"4"`
+	F246 []byte `ssz-max:"4"`
+	F247 []byte `ssz-max:"4"`
+	F248 []byte `ssz-max:"4"`
+	F249 []byte `ssz-max:"4"`
+	F250 []byte `ssz-max:"4"`
+	F251 []byte `ssz-max:"4"`
+	F252 []byte `ssz-max:"4"`
+	F253 []byte `ssz-max:"4"`
+	F254 []byte `ssz-max:"4"`
+	F255 []byte `ssz-max:"4"`
+	F256 []byte `ssz-max:"4"`
+}
+
+// streamOnlyCustom carries the fastssz set plus only the streaming-flavored
+// dynamic methods: the dynamic flags unforce the fastssz delegation, so the
+// buffer generators fall through to their custom-type returns while the
+// streaming generators delegate.
+type streamOnlyCustom struct{ A uint32 }
+
+func (e *streamOnlyCustom) MarshalSSZ() ([]byte, error) {
+	return e.MarshalSSZTo(nil)
+}
+
+func (e *streamOnlyCustom) MarshalSSZTo(buf []byte) ([]byte, error) {
+	return sszutils.MarshalUint32(buf, e.A), nil
+}
+
+func (e *streamOnlyCustom) SizeSSZ() int { return 4 }
+
+func (e *streamOnlyCustom) UnmarshalSSZ(data []byte) error {
+	e.A = sszutils.UnmarshallUint32(data)
+	return nil
+}
+
+func (e *streamOnlyCustom) HashTreeRoot() ([32]byte, error) {
+	return [32]byte{}, nil
+}
+
+func (e *streamOnlyCustom) SizeSSZDyn(_ sszutils.DynamicSpecs) int { return 4 }
+
+func (e *streamOnlyCustom) MarshalSSZEncoder(_ sszutils.DynamicSpecs, enc sszutils.Encoder) error {
+	enc.EncodeUint32(e.A)
+	return nil
+}
+
+func (e *streamOnlyCustom) UnmarshalSSZDecoder(_ sszutils.DynamicSpecs, dec sszutils.Decoder) error {
+	v, err := dec.DecodeUint32()
+	e.A = v
+	return err
+}
+
+func (e *streamOnlyCustom) HashTreeRootWithDyn(_ sszutils.DynamicSpecs, _ sszutils.HashWalker) error {
+	return nil
+}
+
+// bufOnlyCustom mirrors streamOnlyCustom with only the buffer-flavored
+// dynamic methods, so the streaming generators fall through instead.
+type bufOnlyCustom struct{ A uint32 }
+
+func (e *bufOnlyCustom) MarshalSSZ() ([]byte, error) {
+	return e.MarshalSSZTo(nil)
+}
+
+func (e *bufOnlyCustom) MarshalSSZTo(buf []byte) ([]byte, error) {
+	return sszutils.MarshalUint32(buf, e.A), nil
+}
+
+func (e *bufOnlyCustom) SizeSSZ() int { return 4 }
+
+func (e *bufOnlyCustom) UnmarshalSSZ(data []byte) error {
+	e.A = sszutils.UnmarshallUint32(data)
+	return nil
+}
+
+func (e *bufOnlyCustom) HashTreeRoot() ([32]byte, error) {
+	return [32]byte{}, nil
+}
+
+func (e *bufOnlyCustom) SizeSSZDyn(_ sszutils.DynamicSpecs) int { return 4 }
+
+func (e *bufOnlyCustom) MarshalSSZDyn(_ sszutils.DynamicSpecs, buf []byte) ([]byte, error) {
+	return sszutils.MarshalUint32(buf, e.A), nil
+}
+
+func (e *bufOnlyCustom) UnmarshalSSZDyn(_ sszutils.DynamicSpecs, data []byte) error {
+	e.A = sszutils.UnmarshallUint32(data)
+	return nil
+}
+
+func (e *bufOnlyCustom) HashTreeRootWithDyn(_ sszutils.DynamicSpecs, _ sszutils.HashWalker) error {
+	return nil
+}
+
+// GenCovCustomHolder2 pairs stream-only, buffer-only and statically sized
+// fastssz-only custom fields with a dynamic sibling, driving each generator
+// through its delegation fallbacks.
+type GenCovCustomHolder2 struct {
+	C  streamOnlyCustom `ssz-type:"custom"`
+	CB bufOnlyCustom    `ssz-type:"custom"`
+	CS CustomType1      `ssz-type:"custom" ssz-size:"8"`
+	D  []byte           `ssz-max:"8"`
+}
+
+// namedCovBytes is unwrapped against the plain view schema field.
+type namedCovBytes []byte
+
+// aliasCovBytes is unaliased against the plain view schema field.
+type aliasCovBytes = []byte
+
+// View-mix bases: ChildA keeps only the buffer-flavored view methods, ChildB
+// only the streaming-flavored ones, so the holder generators exercise the
+// cross-flavored delegation branches.
+type ViewMixChildA struct {
+	X []byte `ssz-max:"8"`
+	Y uint32
+}
+
+type ViewMixChildB struct {
+	X []byte `ssz-max:"8"`
+	Z uint64
+}
+
+type ViewMixHolder struct {
+	A ViewMixChildA
+	B ViewMixChildB
+	C ViewMixChildC
+	N namedCovBytes `ssz-max:"8"`
+	L aliasCovBytes `ssz-max:"8"`
+	U dynssz.CompatibleUnion[struct {
+		V1 uint64
+		V2 ViewMixChildA
+	}]
+	D []byte `ssz-max:"8"`
+}
+
+type ViewMixChildA_View struct {
+	X []byte `ssz-max:"8"`
+	Y uint32
+}
+
+type ViewMixChildB_View struct {
+	X []byte `ssz-max:"8"`
+	Z uint64
+}
+
+// ViewMixChildC is fully static, so the sized delegate-buffer branches run
+// for its buffer-only view methods.
+type ViewMixChildC struct {
+	Y uint32
+	Z uint64
+}
+
+type ViewMixChildC_View struct {
+	Y uint32
+	Z uint64
+}
+
+type ViewMixHolder_View struct {
+	A ViewMixChildA_View
+	B ViewMixChildB_View
+	C ViewMixChildC_View
+	N []byte `ssz-max:"8"`
+	L []byte `ssz-max:"8"`
+	U dynssz.CompatibleUnion[struct {
+		V1 uint64
+		V2 ViewMixChildA_View
+	}]
+	D []byte `ssz-max:"8"`
+}
+
+var GenCovBranches_Payload = GenCovBranches{
+	RootsVec:  [][32]byte{{1}, {2}},
+	RootsList: [][32]byte{{3}, {4}},
+	HugeLimit: []uint64{7, 8},
+	SpecStr:   "abc",
+	BitsArr:   [4]byte{0xaa, 0xbb, 0xcc, 0x2d},
+	Bits2:     []byte{0xff, 0xee, 0xdd, 0x2c},
+	HintA:     []byte{1, 2, 3},
+	HintB:     []byte{4, 5, 6},
+	Fast:      CustomType1(0x1122),
+	WrapSpec: dynssz.TypeWrapper[struct {
+		Data []byte `ssz-size:"32" dynssz-size:"TEST_SPEC"`
+	}, []byte]{
+		Data: []byte{1, 2, 3, 4, 5, 6, 7, 8},
+	},
+	UnionList: []dynssz.CompatibleUnion[struct {
+		V1 uint64
+		V2 []byte `ssz-max:"8"`
+	}]{
+		{Variant: 1, Data: uint64(5)},
+		{Variant: 2, Data: []byte{1, 2}},
+	},
+	SpecVecList: [][2]genCovSpecInner{{
+		{A: []byte{1, 2, 3, 4, 5, 6, 7, 8}, B: []byte{1}},
+		{A: []byte{8, 7, 6, 5, 4, 3, 2, 1}},
+	}},
+	VecOfList: [][2][]uint8{{{1}, {2, 3}}},
+	Dyn:       []byte{9},
+}
+
+var GenCovBranches_Specs = map[string]any{
+	"TEST_SPEC": uint64(8),
+	"SPEC_A":    uint64(32),
+	"SPEC_B":    uint64(32),
+}
+
+var GenCovCustomHolder_Payload = GenCovCustomHolder{
+	C: CustomType1(0x33445566),
+	D: []byte{1, 2, 3},
+}
+
+var GenCovCustomHolder2_Payload = GenCovCustomHolder2{
+	C:  streamOnlyCustom{A: 3},
+	CB: bufOnlyCustom{A: 4},
+	CS: CustomType1(9),
+	D:  []byte{7},
+}
+
+var GenCovWideOffsets_Payload = GenCovWideOffsets{
+	F000: []byte{1},
+	F128: []byte{2, 3},
+	F256: []byte{4},
+}
+
+var ViewMixHolder_Payload = ViewMixHolder{
+	A: ViewMixChildA{X: []byte{1}, Y: 2},
+	B: ViewMixChildB{X: []byte{3}, Z: 4},
+	C: ViewMixChildC{Y: 5, Z: 6},
+	N: namedCovBytes{7},
+	L: aliasCovBytes{8},
+	U: dynssz.CompatibleUnion[struct {
+		V1 uint64
+		V2 ViewMixChildA
+	}]{Variant: 2, Data: ViewMixChildA{X: []byte{9}, Y: 10}},
+	D: []byte{11},
+}

--- a/dynssz.go
+++ b/dynssz.go
@@ -387,13 +387,15 @@ func (d *DynSsz) MarshalSSZTo(source any, buf []byte, opts ...CallOption) ([]byt
 	if err != nil {
 		return nil, err
 	}
-	// SSZ sizes are uint32; reject only what cannot be represented as an int on
-	// this platform, accounting for the existing buffer length so len(buf)+size
-	// cannot overflow int. SizeSSZ applies the same ceiling so the paths agree.
-	if uint64(size) > uint64(math.MaxInt)-uint64(len(buf)) {
+	// Reject a size that cannot be represented as an int on this platform,
+	// accounting for the existing buffer length so len(buf)+size cannot
+	// overflow int. SizeSSZ applies the same ceiling so the paths agree. The
+	// bound stays in the signed domain so the int conversion below is provably
+	// within range.
+	if size < 0 || size > int64(math.MaxInt)-int64(len(buf)) {
 		return nil, fmt.Errorf("SSZ size %d exceeds platform int max", size)
 	}
-	needed := len(buf) + int(size)
+	needed := len(buf) + sszutils.CapToInt(uint64(size))
 	if cap(buf) < needed {
 		grown := make([]byte, len(buf), needed)
 		copy(grown, buf)
@@ -644,16 +646,13 @@ func (d *DynSsz) SizeSSZ(source any, opts ...CallOption) (int, error) {
 		return 0, err
 	}
 
-	// SSZ sizes are uint32; only reject what cannot be represented as an int on
-	// this platform. On 64-bit the full uint32 range is valid; on 32-bit a size
-	// above the int max cannot be returned safely. int64 holds every uint32, so
-	// the bound check and conversion operate on the same value.
-	sz := int64(size)
-	if sz > math.MaxInt {
+	// Reject a size that cannot be represented as an int on this platform; the
+	// bound stays in the signed domain so the conversion is provably in range.
+	if size < 0 || size > math.MaxInt {
 		return 0, fmt.Errorf("SSZ size %d exceeds platform int max", size)
 	}
 
-	return int(sz), nil
+	return int(size), nil
 }
 
 // UnmarshalSSZ decodes the given SSZ-encoded data into the target object.

--- a/dynssz.go
+++ b/dynssz.go
@@ -306,7 +306,7 @@ func (d *DynSsz) MarshalSSZ(source any, opts ...CallOption) ([]byte, error) {
 	}
 
 	newBuf := encoder.GetBuffer()
-	if uint32(len(newBuf)) != size {
+	if int64(len(newBuf)) != size {
 		return nil, fmt.Errorf("ssz length does not match expected length (expected: %v, got: %v)", size, len(newBuf))
 	}
 
@@ -407,7 +407,7 @@ func (d *DynSsz) MarshalSSZTo(source any, buf []byte, opts ...CallOption) ([]byt
 	}
 
 	newBuf := encoder.GetBuffer()
-	if uint32(len(newBuf)-len(buf)) != size {
+	if int64(len(newBuf)-len(buf)) != size {
 		return nil, fmt.Errorf("ssz length does not match expected length (expected: %v, got: %v)", size, len(newBuf)-len(buf))
 	}
 
@@ -557,7 +557,7 @@ func (d *DynSsz) MarshalSSZWriter(source any, w io.Writer, opts ...CallOption) e
 	// Parity with the buffer path: reject output whose length disagrees with the
 	// precomputed size (e.g. a nested delegated marshaler whose SizeSSZ contradicts
 	// the bytes it writes), which would otherwise stream malformed SSZ silently.
-	if uint32(encoder.GetPosition()) != size {
+	if int64(encoder.GetPosition()) != size {
 		return fmt.Errorf("ssz length does not match expected length (expected: %v, got: %v)", size, encoder.GetPosition())
 	}
 	return nil

--- a/dynssz_test.go
+++ b/dynssz_test.go
@@ -849,8 +849,8 @@ func TestMarshalSSZLargeObjectOverflow(t *testing.T) {
 	container := &testLargeContainer{}
 
 	_, err := ds.MarshalSSZ(container)
-	if err == nil || !strings.Contains(err.Error(), "exceeds platform int max") {
-		t.Fatalf("expected 'exceeds platform int max' error, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "platform int") {
+		t.Fatalf("expected a platform integer range error, got: %v", err)
 	}
 }
 
@@ -860,8 +860,8 @@ func TestMarshalSSZToLargeObjectOverflow(t *testing.T) {
 	container := &testLargeContainer{}
 
 	_, err := ds.MarshalSSZTo(container, nil)
-	if err == nil || !strings.Contains(err.Error(), "exceeds platform int max") {
-		t.Fatalf("expected 'exceeds platform int max' error, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "platform int") {
+		t.Fatalf("expected a platform integer range error, got: %v", err)
 	}
 }
 
@@ -872,8 +872,8 @@ func TestMarshalSSZWriterLargeObjectOverflow(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := ds.MarshalSSZWriter(container, &buf)
-	if err == nil || !strings.Contains(err.Error(), "exceeds platform int max") {
-		t.Fatalf("expected 'exceeds platform int max' error, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "platform int") {
+		t.Fatalf("expected a platform integer range error, got: %v", err)
 	}
 }
 
@@ -908,8 +908,8 @@ func TestHashTreeRootLargeObjectOverflow(t *testing.T) {
 	container := &testLargeContainer{}
 
 	_, err := ds.HashTreeRoot(container)
-	if err == nil || !strings.Contains(err.Error(), "exceeds platform int max") {
-		t.Fatalf("expected 'exceeds platform int max' error, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "platform int") {
+		t.Fatalf("expected a platform integer range error, got: %v", err)
 	}
 }
 
@@ -4562,12 +4562,18 @@ func TestDescriptorSizeOverflowRejected(t *testing.T) {
 	})
 
 	t.Run("large sizes within the platform range are valid", func(t *testing.T) {
-		// 8 * 8192 * 65536 == 2^32: past the former uint32 bound, valid SSZ.
+		// 8 * 8192 * 65536 == 2^32: past the former uint32 bound, valid SSZ
+		// wherever the platform integer range holds it.
 		type T struct {
 			V [][]uint64 `ssz-size:"65536,8192"`
 		}
-		if err := ds.ValidateType(reflect.TypeOf(T{})); err != nil {
-			t.Fatalf("ValidateType should accept a size within the platform range: %v", err)
+		err := ds.ValidateType(reflect.TypeOf(T{}))
+		if uint64(1)<<32 <= uint64(math.MaxInt) {
+			if err != nil {
+				t.Fatalf("ValidateType should accept a size within the platform range: %v", err)
+			}
+		} else if err == nil {
+			t.Fatal("ValidateType should reject a size past the platform range")
 		}
 	})
 

--- a/dynssz_test.go
+++ b/dynssz_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/pk910/dynamic-ssz/hasher"
+	"github.com/pk910/dynamic-ssz/reflection"
 	"github.com/pk910/dynamic-ssz/ssztypes"
 	"github.com/pk910/dynamic-ssz/sszutils"
 )
@@ -6335,4 +6336,215 @@ func TestWithAsyncHashing(t *testing.T) {
 	if got, err := native.HashTreeRoot(source); err != nil || got != want {
 		t.Errorf("native-hash instance root %x (err %v) != %x", got, err, want)
 	}
+}
+
+// negSizeCustom reports a negative size; the marshal and size entry points
+// reject it before any allocation.
+type negSizeCustom struct{}
+
+var _ = sszutils.Annotate[negSizeCustom](`ssz-type:"custom"`)
+
+func (n *negSizeCustom) SizeSSZDyn(_ sszutils.DynamicSpecs) int { return -1 }
+
+func (n *negSizeCustom) MarshalSSZEncoder(_ sszutils.DynamicSpecs, _ sszutils.Encoder) error {
+	return nil
+}
+
+func (n *negSizeCustom) UnmarshalSSZDecoder(_ sszutils.DynamicSpecs, _ sszutils.Decoder) error {
+	return nil
+}
+
+func (n *negSizeCustom) HashTreeRootWithDyn(_ sszutils.DynamicSpecs, _ sszutils.HashWalker) error {
+	return nil
+}
+
+// hugeSizeCustom claims 2GiB-1 per value while writing a single byte, driving
+// offset arithmetic past the 4-byte range without the memory cost.
+type hugeSizeCustom struct{}
+
+var _ = sszutils.Annotate[hugeSizeCustom](`ssz-type:"custom"`)
+
+func (h *hugeSizeCustom) SizeSSZDyn(_ sszutils.DynamicSpecs) int { return math.MaxInt32 }
+
+func (h *hugeSizeCustom) MarshalSSZEncoder(_ sszutils.DynamicSpecs, e sszutils.Encoder) error {
+	e.EncodeUint8(0)
+	return nil
+}
+
+func (h *hugeSizeCustom) UnmarshalSSZDecoder(_ sszutils.DynamicSpecs, _ sszutils.Decoder) error {
+	return nil
+}
+
+func (h *hugeSizeCustom) HashTreeRootWithDyn(_ sszutils.DynamicSpecs, _ sszutils.HashWalker) error {
+	return nil
+}
+
+// emptyDynCustom claims zero bytes and occupies zero Go bytes, so a billion
+// elements build an offset table past the offset range at no memory cost.
+type emptyDynCustom struct{}
+
+var _ = sszutils.Annotate[emptyDynCustom](`ssz-type:"custom"`)
+
+func (h *emptyDynCustom) SizeSSZDyn(_ sszutils.DynamicSpecs) int { return 0 }
+
+func (h *emptyDynCustom) MarshalSSZEncoder(_ sszutils.DynamicSpecs, _ sszutils.Encoder) error {
+	return nil
+}
+
+func (h *emptyDynCustom) UnmarshalSSZDecoder(_ sszutils.DynamicSpecs, _ sszutils.Decoder) error {
+	return nil
+}
+
+func (h *emptyDynCustom) HashTreeRootWithDyn(_ sszutils.DynamicSpecs, _ sszutils.HashWalker) error {
+	return nil
+}
+
+// A negative size from a delegated sizer must surface as an error from every
+// size-consuming entry point rather than wrapping into an allocation.
+func TestMarshalNegativeDelegatedSize(t *testing.T) {
+	ds := NewDynSsz(nil, WithExtendedTypes(), WithNoDelegation(), WithNoFastSsz())
+	v := &negSizeCustom{}
+
+	if _, err := ds.MarshalSSZ(v); err == nil {
+		t.Error("MarshalSSZ should reject a negative size")
+	}
+	if _, err := ds.MarshalSSZTo(v, nil); err == nil {
+		t.Error("MarshalSSZTo should reject a negative size")
+	}
+	if _, err := ds.SizeSSZ(v); err == nil {
+		t.Error("SizeSSZ should reject a negative size")
+	}
+}
+
+// Claimed element sizes drive the offset tables the streaming marshal writes
+// before the bodies; totals past the 4-byte offset range must reject instead
+// of truncating. The claims come from lying sizers, so no real memory moves.
+func TestMarshalWriterOffsetOverflow(t *testing.T) {
+	ds := NewDynSsz(nil, WithExtendedTypes())
+
+	expectOffsetErr := func(t *testing.T, err error) {
+		t.Helper()
+		if err == nil || !errors.Is(err, sszutils.ErrOffset) {
+			t.Errorf("expected offset range error, got: %v", err)
+		}
+	}
+
+	t.Run("list offset table", func(t *testing.T) {
+		// The reflection context is driven on a bare list root: any wrapper
+		// would size-walk the billion no-op elements before marshaling starts,
+		// while the list path itself rejects at the first offset write.
+		v := make([]emptyDynCustom, (1<<30)+1)
+		desc, err := ds.GetTypeCache().GetTypeDescriptor(reflect.TypeOf(v), nil, []ssztypes.SszMaxSizeHint{{Size: 2000000000}}, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx := reflection.NewReflectionCtx(ds, nil, false, true, false, 0)
+		expectOffsetErr(t, ctx.MarshalSSZ(desc, reflect.ValueOf(v), sszutils.NewStreamEncoder(io.Discard, 0)))
+	})
+
+	t.Run("list offsets accumulate", func(t *testing.T) {
+		type L struct {
+			Items []hugeSizeCustom `ssz-max:"16"`
+		}
+		v := &L{Items: make([]hugeSizeCustom, 3)}
+		expectOffsetErr(t, ds.MarshalSSZWriter(v, io.Discard))
+	})
+
+	t.Run("vector offsets accumulate", func(t *testing.T) {
+		type V struct {
+			Items []hugeSizeCustom `ssz-size:"3"`
+		}
+		v := &V{Items: make([]hugeSizeCustom, 3)}
+		expectOffsetErr(t, ds.MarshalSSZWriter(v, io.Discard))
+	})
+
+	t.Run("vector zero-fill offsets accumulate", func(t *testing.T) {
+		type V struct {
+			Items []hugeSizeCustom `ssz-size:"4"`
+		}
+		v := &V{Items: make([]hugeSizeCustom, 1)}
+		expectOffsetErr(t, ds.MarshalSSZWriter(v, io.Discard))
+	})
+
+	t.Run("container field offsets", func(t *testing.T) {
+		type C struct {
+			A hugeSizeCustom `ssz-type:"custom"`
+			B hugeSizeCustom `ssz-type:"custom"`
+			C hugeSizeCustom `ssz-type:"custom"`
+		}
+		expectOffsetErr(t, ds.MarshalSSZWriter(&C{}, io.Discard))
+	})
+}
+
+// inflatingEncoder is seekable and reports positions far past the bytes it
+// receives, so the post-marshal offset patches see encodings past the 4-byte
+// offset range without the memory cost.
+type inflatingEncoder struct{ pos int }
+
+func (e *inflatingEncoder) Seekable() bool { return true }
+func (e *inflatingEncoder) GetPosition() int {
+	e.pos += 1 << 30
+	return e.pos
+}
+func (e *inflatingEncoder) GetBuffer() []byte              { return nil }
+func (e *inflatingEncoder) SetBuffer(_ []byte)             {}
+func (e *inflatingEncoder) EncodeBool(_ bool)              {}
+func (e *inflatingEncoder) EncodeUint8(_ uint8)            {}
+func (e *inflatingEncoder) EncodeUint16(_ uint16)          {}
+func (e *inflatingEncoder) EncodeUint32(_ uint32)          {}
+func (e *inflatingEncoder) EncodeUint64(_ uint64)          {}
+func (e *inflatingEncoder) EncodeBytes(_ []byte)           {}
+func (e *inflatingEncoder) EncodeOffset(_ uint32)          {}
+func (e *inflatingEncoder) EncodeOffsetAt(_ int, _ uint32) {}
+func (e *inflatingEncoder) EncodeZeroPadding(_ int)        {}
+
+// The seekable marshal paths patch offsets from real encoder positions after
+// each element; positions past the 4-byte offset range must reject instead of
+// truncating.
+func TestMarshalSeekableOffsetOverflow(t *testing.T) {
+	ds := NewDynSsz(nil)
+
+	run := func(t *testing.T, v any) {
+		t.Helper()
+		desc, err := ds.GetTypeCache().GetTypeDescriptor(reflect.TypeOf(v), nil, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx := reflection.NewReflectionCtx(ds, nil, false, true, false, 0)
+		if err := ctx.MarshalSSZ(desc, reflect.ValueOf(v), &inflatingEncoder{}); err == nil || !errors.Is(err, sszutils.ErrOffset) {
+			t.Errorf("expected offset range error, got: %v", err)
+		}
+	}
+
+	t.Run("vector element patches", func(t *testing.T) {
+		type V struct {
+			Items [][]uint8 `ssz-size:"8" ssz-max:"?,16"`
+		}
+		run(t, &V{Items: [][]uint8{{1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}}})
+	})
+
+	t.Run("vector zero-fill patches", func(t *testing.T) {
+		type V struct {
+			Items [][]uint8 `ssz-size:"8" ssz-max:"?,16"`
+		}
+		run(t, &V{Items: [][]uint8{{1}}})
+	})
+
+	t.Run("list element patches", func(t *testing.T) {
+		type L struct {
+			Items [][]uint8 `ssz-max:"16,16"`
+		}
+		run(t, &L{Items: [][]uint8{{1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}}})
+	})
+
+	t.Run("container field patches", func(t *testing.T) {
+		type C struct {
+			A []uint8 `ssz-max:"16"`
+			B []uint8 `ssz-max:"16"`
+			C []uint8 `ssz-max:"16"`
+			D []uint8 `ssz-max:"16"`
+			E []uint8 `ssz-max:"16"`
+		}
+		run(t, &C{})
+	})
 }

--- a/dynssz_test.go
+++ b/dynssz_test.go
@@ -836,6 +836,14 @@ type testLargeContainer struct {
 // SizeSSZ platform behavior for >MaxInt32 sizes is covered by
 // TestSizeAboveMaxInt32 (accepted on 64-bit, rejected on 32-bit).
 
+// skipUnless64Bit skips the test on platforms where int is 32 bits wide.
+func skipUnless64Bit(t *testing.T) {
+	t.Helper()
+	if math.MaxInt <= math.MaxInt32 {
+		t.Skip("requires a 64-bit platform")
+	}
+}
+
 // skipUnless32Bit skips the test on platforms where int is wider than 32 bits.
 func skipUnless32Bit(t *testing.T) {
 	t.Helper()
@@ -6424,6 +6432,15 @@ func TestMarshalWriterOffsetOverflow(t *testing.T) {
 
 	expectOffsetErr := func(t *testing.T, err error) {
 		t.Helper()
+		// On 32-bit platforms the size walk rejects the claimed totals with
+		// the platform range error before any offset write runs; both verdicts
+		// reject the value.
+		if math.MaxInt <= math.MaxInt32 {
+			if err == nil {
+				t.Error("expected an error for the oversized claims")
+			}
+			return
+		}
 		if err == nil || !errors.Is(err, sszutils.ErrOffset) {
 			t.Errorf("expected offset range error, got: %v", err)
 		}
@@ -6538,6 +6555,9 @@ func TestMarshalSeekableOffsetOverflow(t *testing.T) {
 	})
 
 	t.Run("container field patches", func(t *testing.T) {
+		// The container patch accumulator holds encoder positions in int;
+		// positions past the 32-bit range cannot exist on a 32-bit platform.
+		skipUnless64Bit(t)
 		type C struct {
 			A []uint8 `ssz-max:"16"`
 			B []uint8 `ssz-max:"16"`

--- a/dynssz_test.go
+++ b/dynssz_test.go
@@ -4735,9 +4735,15 @@ func TestSizeSSZValueOverflowRejected(t *testing.T) {
 		t.Fatalf("n=1: size=%d err=%v", sz, err)
 	}
 	// 17 elements put the total past the former uint32 bound; sizes are valid
-	// up to the platform integer range.
+	// up to the platform integer range, past which SizeSSZ reports the
+	// platform bound instead of wrapping.
+	const total = int64(4) + 17*268435456
 	sz, err = ds.SizeSSZ(&OuterList{Items: make([]InnerHuge, 17)})
-	if err != nil || sz != 4+17*268435456 {
+	if total > math.MaxInt {
+		if err == nil {
+			t.Errorf("n=17: expected platform overflow error, got size %d", sz)
+		}
+	} else if err != nil || int64(sz) != total {
 		t.Errorf("n=17: size=%d err=%v", sz, err)
 	}
 }

--- a/dynssz_test.go
+++ b/dynssz_test.go
@@ -4498,65 +4498,76 @@ func TestOptionalVectorPaddingSizeAgreement(t *testing.T) {
 func TestDescriptorSizeOverflowRejected(t *testing.T) {
 	ds := NewDynSsz(nil)
 
-	t.Run("vector product wraps", func(t *testing.T) {
-		// 8 (uint64) * 536870912 == 2^32
+	t.Run("vector product exceeds platform range", func(t *testing.T) {
+		// 8 (uint64) * 2^60 == 2^63, past the platform integer range.
 		type T struct {
-			L [][]uint64 `ssz-max:"10" ssz-size:"?,536870912"`
+			L [][]uint64 `ssz-max:"10" ssz-size:"?,1152921504606846976"`
 		}
 		var v T
 		err := ds.UnmarshalSSZ(&v, []byte{4, 0, 0, 0, 0, 0, 0, 0})
 		if err == nil {
-			t.Fatal("expected descriptor error for wrapped vector size")
+			t.Fatal("expected descriptor error for overflowing vector size")
 		}
 	})
 
 	t.Run("vector in container", func(t *testing.T) {
 		type T struct {
 			A uint64
-			V []uint64 `ssz-size:"536870912"`
+			V []uint64 `ssz-size:"1152921504606846976"`
 			B uint64
 		}
 		var v T
 		err := ds.UnmarshalSSZ(&v, make([]byte, 16))
 		if err == nil {
-			t.Fatal("expected descriptor error for wrapped vector size")
+			t.Fatal("expected descriptor error for overflowing vector size")
 		}
 	})
 
-	t.Run("container sum wraps", func(t *testing.T) {
-		// Each field fits in uint32, the sum does not.
+	t.Run("container sum exceeds platform range", func(t *testing.T) {
+		// Each field fits the platform range, the sum does not.
 		type T struct {
-			A []byte `ssz-size:"3000000000"`
-			B []byte `ssz-size:"3000000000"`
+			A []byte `ssz-size:"4611686018427387904"`
+			B []byte `ssz-size:"4611686018427387904"`
 		}
 		var v T
 		err := ds.UnmarshalSSZ(&v, make([]byte, 16))
 		if err == nil {
-			t.Fatal("expected descriptor error for wrapped container size")
+			t.Fatal("expected descriptor error for overflowing container size")
 		}
 	})
 
-	t.Run("multi-dim product wraps", func(t *testing.T) {
-		// 8 * 65536 * 65536 wraps; each nesting level guards its own product,
+	t.Run("multi-dim product exceeds platform range", func(t *testing.T) {
+		// 8 * 2^30 * 2^30 == 2^63; each nesting level guards its own product,
 		// and ValidateType shares the guarded build path.
 		type T struct {
-			V [][]uint64 `ssz-size:"65536,65536"`
+			V [][]uint64 `ssz-size:"1073741824,1073741824"`
 		}
 		if err := ds.ValidateType(reflect.TypeOf(T{})); err == nil {
-			t.Fatal("ValidateType should reject the wrapped multi-dim size")
+			t.Fatal("ValidateType should reject the overflowing multi-dim size")
 		}
 		var v T
 		if err := ds.UnmarshalSSZ(&v, make([]byte, 8)); err == nil {
-			t.Fatal("expected descriptor error for wrapped multi-dim size")
+			t.Fatal("expected descriptor error for overflowing multi-dim size")
 		}
 	})
 
-	t.Run("three-dim product wraps", func(t *testing.T) {
+	t.Run("three-dim product exceeds platform range", func(t *testing.T) {
+		// 4 * 2^21 * 2^21 * 2^21 == 2^65 overflows at the outermost level.
 		type T struct {
-			V [][][]uint32 `ssz-size:"4096,4096,4096"`
+			V [][][]uint32 `ssz-size:"2097152,2097152,2097152"`
 		}
 		if err := ds.ValidateType(reflect.TypeOf(T{})); err == nil {
-			t.Fatal("ValidateType should reject the wrapped three-dim size")
+			t.Fatal("ValidateType should reject the overflowing three-dim size")
+		}
+	})
+
+	t.Run("large sizes within the platform range are valid", func(t *testing.T) {
+		// 8 * 8192 * 65536 == 2^32: past the former uint32 bound, valid SSZ.
+		type T struct {
+			V [][]uint64 `ssz-size:"65536,8192"`
+		}
+		if err := ds.ValidateType(reflect.TypeOf(T{})); err != nil {
+			t.Fatalf("ValidateType should accept a size within the platform range: %v", err)
 		}
 	})
 
@@ -4723,8 +4734,11 @@ func TestSizeSSZValueOverflowRejected(t *testing.T) {
 	if err != nil || sz != 4+268435456 {
 		t.Fatalf("n=1: size=%d err=%v", sz, err)
 	}
-	if _, err := ds.SizeSSZ(&OuterList{Items: make([]InnerHuge, 17)}); err == nil {
-		t.Error("expected error for a value size exceeding the uint32 range")
+	// 17 elements put the total past the former uint32 bound; sizes are valid
+	// up to the platform integer range.
+	sz, err = ds.SizeSSZ(&OuterList{Items: make([]InnerHuge, 17)})
+	if err != nil || sz != 4+17*268435456 {
+		t.Errorf("n=17: size=%d err=%v", sz, err)
 	}
 }
 

--- a/examples/htr-caching/types_ssz.go
+++ b/examples/htr-caching/types_ssz.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"encoding/binary"
+	"math"
 
 	"github.com/pk910/dynamic-ssz/hasher"
 	"github.com/pk910/dynamic-ssz/sszutils"
@@ -236,11 +237,15 @@ func (t *CachedRegistry) MarshalSSZDyn(ds sszutils.DynamicSpecs, buf []byte) (ds
 	// Offset Field #0 'Validators'
 	dst = append(dst, 0, 0, 0, 0)
 	{ // Dynamic Field #0 'Validators'
-		binary.LittleEndian.PutUint32(dst[dstlen:], uint32(len(dst)-dstlen))
+		if off := uint64(len(dst)) - uint64(dstlen); off > math.MaxUint32 {
+			return nil, sszutils.ErrOffsetOverflowFn(off)
+		} else {
+			binary.LittleEndian.PutUint32(dst[dstlen:], uint32(off))
+		}
 		t := t.Validators
 		vlen := len(t)
-		if vlen > int(expr0) {
-			return nil, sszutils.ErrorWithPath(sszutils.ErrListLengthFn(vlen, int(expr0)), "Validators")
+		if uint64(vlen) > expr0 {
+			return nil, sszutils.ErrorWithPath(sszutils.ErrListLengthFn(vlen, expr0), "Validators")
 		}
 		for idx1 := range vlen {
 			t := t[idx1]
@@ -277,8 +282,8 @@ func (t *CachedRegistry) UnmarshalSSZDyn(ds sszutils.DynamicSpecs, buf []byte) (
 		if len(buf)%121 != 0 {
 			return sszutils.ErrorWithPath(sszutils.ErrListNotAlignedFn(len(buf), 121), "Validators")
 		}
-		if itemCount > int(expr0) {
-			return sszutils.ErrorWithPath(sszutils.ErrListLengthFn(itemCount, int(expr0)), "Validators")
+		if uint64(max(itemCount, 0)) > expr0 {
+			return sszutils.ErrorWithPath(sszutils.ErrListLengthFn(itemCount, expr0), "Validators")
 		}
 		val1 = sszutils.ExpandSlice(val1, itemCount)
 		for idx1 := range itemCount {
@@ -342,7 +347,7 @@ func (t *CachedRegistry) HashTreeRootWithDyn(ds sszutils.DynamicSpecs, hh sszuti
 			return sszutils.ErrorWithPath(sszutils.ErrListLengthFn(vlen, expr0), "Validators")
 		}
 		idx := hh.StartTree(sszutils.TreeTypeBinary)
-		for idx1 := range int(vlen) {
+		for idx1 := range len(t) {
 			t := t[idx1]
 			if t == nil {
 				t = new(CachedValidator)
@@ -374,11 +379,15 @@ func (t *PlainRegistry) MarshalSSZDyn(ds sszutils.DynamicSpecs, buf []byte) (dst
 	// Offset Field #0 'Validators'
 	dst = append(dst, 0, 0, 0, 0)
 	{ // Dynamic Field #0 'Validators'
-		binary.LittleEndian.PutUint32(dst[dstlen:], uint32(len(dst)-dstlen))
+		if off := uint64(len(dst)) - uint64(dstlen); off > math.MaxUint32 {
+			return nil, sszutils.ErrOffsetOverflowFn(off)
+		} else {
+			binary.LittleEndian.PutUint32(dst[dstlen:], uint32(off))
+		}
 		t := t.Validators
 		vlen := len(t)
-		if vlen > int(expr0) {
-			return nil, sszutils.ErrorWithPath(sszutils.ErrListLengthFn(vlen, int(expr0)), "Validators")
+		if uint64(vlen) > expr0 {
+			return nil, sszutils.ErrorWithPath(sszutils.ErrListLengthFn(vlen, expr0), "Validators")
 		}
 		for idx1 := range vlen {
 			t := t[idx1]
@@ -415,8 +424,8 @@ func (t *PlainRegistry) UnmarshalSSZDyn(ds sszutils.DynamicSpecs, buf []byte) (e
 		if len(buf)%121 != 0 {
 			return sszutils.ErrorWithPath(sszutils.ErrListNotAlignedFn(len(buf), 121), "Validators")
 		}
-		if itemCount > int(expr0) {
-			return sszutils.ErrorWithPath(sszutils.ErrListLengthFn(itemCount, int(expr0)), "Validators")
+		if uint64(max(itemCount, 0)) > expr0 {
+			return sszutils.ErrorWithPath(sszutils.ErrListLengthFn(itemCount, expr0), "Validators")
 		}
 		val1 = sszutils.ExpandSlice(val1, itemCount)
 		for idx1 := range itemCount {
@@ -480,7 +489,7 @@ func (t *PlainRegistry) HashTreeRootWithDyn(ds sszutils.DynamicSpecs, hh sszutil
 			return sszutils.ErrorWithPath(sszutils.ErrListLengthFn(vlen, expr0), "Validators")
 		}
 		idx := hh.StartTree(sszutils.TreeTypeBinary)
-		for idx1 := range int(vlen) {
+		for idx1 := range len(t) {
 			t := t[idx1]
 			if t == nil {
 				t = new(Validator)

--- a/reflection/common.go
+++ b/reflection/common.go
@@ -136,7 +136,7 @@ func getPtr(v reflect.Value) reflect.Value {
 
 // SizeSSZ computes the SSZ-encoded byte size of targetValue using its type
 // descriptor.
-func (ctx *ReflectionCtx) SizeSSZ(targetType *ssztypes.TypeDescriptor, targetValue reflect.Value) (uint32, error) {
+func (ctx *ReflectionCtx) SizeSSZ(targetType *ssztypes.TypeDescriptor, targetValue reflect.Value) (int64, error) {
 	if targetType == nil {
 		return 0, sszutils.NewSszError(sszutils.ErrInvalidValueRange, "target type must not be nil")
 	}

--- a/reflection/marshal.go
+++ b/reflection/marshal.go
@@ -458,11 +458,11 @@ func (ctx *ReflectionCtx) marshalContainer(sourceType *ssztypes.TypeDescriptor, 
 //   - Byte arrays use reflect.Value.Bytes() for efficient bulk copying
 //   - Non-addressable arrays are made addressable via a temporary pointer
 func (ctx *ReflectionCtx) marshalVector(sourceType *ssztypes.TypeDescriptor, sourceValue reflect.Value, encoder sszutils.Encoder, depth reflectionDepth) error {
-	vecLen := int64(sourceType.Len)
+	vecLen := sourceType.Len
 	if vecLen > math.MaxInt {
 		return sszutils.ErrPlatformOverflowFn("vector length", sourceType.Len)
 	}
-	vecElemSize := int64(sourceType.ElemDesc.Size)
+	vecElemSize := sourceType.ElemDesc.Size
 	if vecElemSize > math.MaxInt {
 		return sszutils.ErrPlatformOverflowFn("element size", sourceType.ElemDesc.Size)
 	}
@@ -553,7 +553,7 @@ func (ctx *ReflectionCtx) marshalVector(sourceType *ssztypes.TypeDescriptor, sou
 // length is less than the expected size. Zero values are efficiently batched
 // to minimize encoding overhead.
 func (ctx *ReflectionCtx) marshalDynamicVector(sourceType *ssztypes.TypeDescriptor, sourceValue reflect.Value, encoder sszutils.Encoder, depth reflectionDepth) error {
-	dynVecLen := int64(sourceType.Len)
+	dynVecLen := sourceType.Len
 	if dynVecLen > math.MaxInt {
 		return sszutils.ErrPlatformOverflowFn("dynamic vector length", sourceType.Len)
 	}

--- a/reflection/marshal.go
+++ b/reflection/marshal.go
@@ -16,6 +16,26 @@ import (
 	"github.com/pk910/dynamic-ssz/sszutils"
 )
 
+// encodeOffsetChecked writes offset as a 4-byte SSZ offset, rejecting values
+// beyond the offset range instead of truncating them.
+func encodeOffsetChecked(encoder sszutils.Encoder, offset int64) error {
+	if offset > math.MaxUint32 {
+		return sszutils.ErrOffsetOverflowFn(offset)
+	}
+	encoder.EncodeOffset(uint32(offset))
+	return nil
+}
+
+// encodeOffsetAtChecked patches offset into position pos as a 4-byte SSZ
+// offset, rejecting values beyond the offset range instead of truncating them.
+func encodeOffsetAtChecked(encoder sszutils.Encoder, pos int, offset int64) error {
+	if offset > math.MaxUint32 {
+		return sszutils.ErrOffsetOverflowFn(offset)
+	}
+	encoder.EncodeOffsetAt(pos, uint32(offset))
+	return nil
+}
+
 // marshalType is the core recursive generic function for marshalling Go values into SSZ-encoded data.
 //
 // This function serves as the primary dispatcher within the marshalling process, handling both primitive
@@ -375,7 +395,11 @@ func (ctx *ReflectionCtx) marshalContainer(sourceType *ssztypes.TypeDescriptor, 
 					return sszutils.ErrorWithPathf(err, "%s:o", field.Name)
 				}
 
-				encoder.EncodeOffset(sourceType.Len + uint32(dynObjOffset))
+				fieldOffset := sourceType.Len + int64(dynObjOffset)
+				if fieldOffset > math.MaxUint32 {
+					return sszutils.ErrOffsetOverflowFn(fieldOffset)
+				}
+				encoder.EncodeOffset(uint32(fieldOffset))
 				dynObjOffset += int(size)
 			}
 			// fmt.Printf("%sfield %d:\t offset [%v:%v] %v\t %v\n", strings.Repeat(" ", int(depth.idt)*2+1), i, offset, offset+fieldSize, fieldSize, field.Name)
@@ -387,8 +411,10 @@ func (ctx *ReflectionCtx) marshalContainer(sourceType *ssztypes.TypeDescriptor, 
 	for _, field := range sourceType.ContainerDesc.DynFields {
 		// set field offset
 		if canSeek {
-			fieldOffset := int(field.HeaderOffset)
-			encoder.EncodeOffsetAt(fieldOffset+startLen, uint32(offset))
+			if int64(offset) > math.MaxUint32 {
+				return sszutils.ErrOffsetOverflowFn(offset)
+			}
+			encoder.EncodeOffsetAt(int(field.HeaderOffset)+startLen, uint32(offset))
 		}
 
 		// fmt.Printf("%sfield %d:\t dynamic [%v:]\t %v\n", strings.Repeat(" ", int(depth.idt)*2+1), field.Index[0], offset, field.Name)
@@ -442,7 +468,7 @@ func (ctx *ReflectionCtx) marshalVector(sourceType *ssztypes.TypeDescriptor, sou
 	}
 
 	sliceLen := sourceValue.Len()
-	if uint32(sliceLen) > sourceType.Len {
+	if int64(sliceLen) > sourceType.Len {
 		if sourceType.Kind == reflect.Array {
 			sliceLen = int(vecLen)
 		} else {
@@ -452,7 +478,7 @@ func (ctx *ReflectionCtx) marshalVector(sourceType *ssztypes.TypeDescriptor, sou
 
 	appendZero := 0
 	dataLen := int(vecLen)
-	if uint32(sliceLen) < sourceType.Len {
+	if int64(sliceLen) < sourceType.Len {
 		appendZero = int(vecLen) - sliceLen
 		dataLen = sliceLen
 	}
@@ -538,10 +564,10 @@ func (ctx *ReflectionCtx) marshalDynamicVector(sourceType *ssztypes.TypeDescript
 	appendZero := 0
 	if sourceType.Kind == reflect.Slice || sourceType.Kind == reflect.String {
 		innerSliceLen := sourceValue.Len()
-		if uint32(innerSliceLen) > sourceType.Len {
+		if int64(innerSliceLen) > sourceType.Len {
 			return sszutils.ErrVectorLengthFn(innerSliceLen, sourceType.Len)
 		}
-		if uint32(innerSliceLen) < sourceType.Len {
+		if int64(innerSliceLen) < sourceType.Len {
 			appendZero = int(dynVecLen) - innerSliceLen
 		}
 	}
@@ -549,7 +575,7 @@ func (ctx *ReflectionCtx) marshalDynamicVector(sourceType *ssztypes.TypeDescript
 	canSeek := encoder.Seekable()
 	startOffset := encoder.GetPosition()
 	totalOffsets := sliceLen + appendZero
-	offset := uint32(4 * totalOffsets)
+	offset := int64(totalOffsets) * 4
 
 	var zeroVal reflect.Value
 	if appendZero > 0 {
@@ -567,7 +593,9 @@ func (ctx *ReflectionCtx) marshalDynamicVector(sourceType *ssztypes.TypeDescript
 				return sszutils.ErrorWithPathf(err, "[%d]", i)
 			}
 
-			encoder.EncodeOffset(offset)
+			if err := encodeOffsetChecked(encoder, offset); err != nil {
+				return err
+			}
 			offset += size
 		}
 		if appendZero > 0 {
@@ -577,7 +605,9 @@ func (ctx *ReflectionCtx) marshalDynamicVector(sourceType *ssztypes.TypeDescript
 			}
 
 			for i := 0; i < appendZero; i++ {
-				encoder.EncodeOffset(offset)
+				if err := encodeOffsetChecked(encoder, offset); err != nil {
+					return err
+				}
 				offset += size
 			}
 		}
@@ -594,10 +624,12 @@ func (ctx *ReflectionCtx) marshalDynamicVector(sourceType *ssztypes.TypeDescript
 		}
 
 		if canSeek {
-			encoder.EncodeOffsetAt(startOffset+(i*4), offset)
+			if err := encodeOffsetAtChecked(encoder, startOffset+(i*4), offset); err != nil {
+				return err
+			}
 
 			newPos := encoder.GetPosition()
-			offset += uint32(newPos - bufLen)
+			offset += int64(newPos - bufLen)
 			bufLen = newPos
 		}
 	}
@@ -609,10 +641,12 @@ func (ctx *ReflectionCtx) marshalDynamicVector(sourceType *ssztypes.TypeDescript
 		}
 
 		if canSeek {
-			encoder.EncodeOffsetAt(startOffset+((sliceLen+i)*4), offset)
+			if err := encodeOffsetAtChecked(encoder, startOffset+((sliceLen+i)*4), offset); err != nil {
+				return err
+			}
 
 			newPos := encoder.GetPosition()
-			offset += uint32(newPos - bufLen)
+			offset += int64(newPos - bufLen)
 			bufLen = newPos
 		}
 	}
@@ -697,13 +731,15 @@ func (ctx *ReflectionCtx) marshalDynamicList(sourceType *ssztypes.TypeDescriptor
 	canSeek := encoder.Seekable()
 	startOffset := encoder.GetPosition()
 	totalOffsets := sliceLen
-	offset := uint32(4 * totalOffsets)
+	offset := int64(totalOffsets) * 4
 
 	if canSeek {
 		encoder.EncodeZeroPadding(4 * totalOffsets) // Reserve space for offsets
 	} else if sliceLen > 0 {
 		// need to calculate the object sizes now
-		encoder.EncodeOffset(offset)
+		if err := encodeOffsetChecked(encoder, offset); err != nil {
+			return err
+		}
 
 		for i := 0; i < sliceLen-1; i++ {
 			itemVal := sourceValue.Index(i)
@@ -713,7 +749,9 @@ func (ctx *ReflectionCtx) marshalDynamicList(sourceType *ssztypes.TypeDescriptor
 			}
 
 			offset += size
-			encoder.EncodeOffset(offset)
+			if err := encodeOffsetChecked(encoder, offset); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -728,10 +766,12 @@ func (ctx *ReflectionCtx) marshalDynamicList(sourceType *ssztypes.TypeDescriptor
 		}
 
 		if canSeek {
-			encoder.EncodeOffsetAt(startOffset+(i*4), offset)
+			if err := encodeOffsetAtChecked(encoder, startOffset+(i*4), offset); err != nil {
+				return err
+			}
 
 			newPos := encoder.GetPosition()
-			offset += uint32(newPos - bufLen)
+			offset += int64(newPos - bufLen)
 			bufLen = newPos
 		}
 	}

--- a/reflection/overflow_internal_test.go
+++ b/reflection/overflow_internal_test.go
@@ -288,7 +288,7 @@ func TestMarshalLargeVectorStreaming(t *testing.T) {
 	}
 
 	ctx := newCtx()
-	vectorLen := uint32(math.MaxInt32 + 1) // 2GB vector
+	vectorLen := int64(math.MaxInt32 + 1) // 2GB vector
 	td := &ssztypes.TypeDescriptor{
 		SszType:     ssztypes.SszVectorType,
 		Kind:        reflect.Slice,

--- a/reflection/overflow_internal_test.go
+++ b/reflection/overflow_internal_test.go
@@ -327,12 +327,12 @@ func TestMarshalLargeVectorStreaming(t *testing.T) {
 
 // --- unknown-length decode overflow tests ---
 //
-// These guards live on the read-to-EOF path, which derives allocations from
-// ssz-max rather than from a region length. Like the others here they are only
-// active on 32-bit platforms, where a uint64 limit can exceed math.MaxInt.
+// The read-to-EOF path derives its read caps from ssz-max. A limit past the
+// platform integer range clamps to the cap instead of erroring: the cap only
+// bounds reads, which cannot reach that magnitude, while the limit itself
+// keeps its full uint64 range.
 
-func TestUnmarshalListUntilEOFLimitOverflow(t *testing.T) {
-	skipUnless32Bit(t)
+func TestUnmarshalListUntilEOFLimitClamped(t *testing.T) {
 	ctx := newCtx()
 	elemDesc := &ssztypes.TypeDescriptor{
 		Size:    4,
@@ -354,13 +354,15 @@ func TestUnmarshalListUntilEOFLimitOverflow(t *testing.T) {
 	val := reflect.New(td.Type).Elem()
 
 	err := ctx.unmarshalType(td, val, dec, reflectionDepth{})
-	if err == nil || !strings.Contains(err.Error(), "exceeds platform int max") {
-		t.Fatalf("expected overflow error for list limit, got: %v", err)
+	if err != nil {
+		t.Fatalf("expected the clamped limit to decode, got: %v", err)
+	}
+	if val.Len() != 2 {
+		t.Fatalf("expected 2 elements, got %d", val.Len())
 	}
 }
 
-func TestUnmarshalBitlistLimitOverflow(t *testing.T) {
-	skipUnless32Bit(t)
+func TestUnmarshalBitlistLimitClamped(t *testing.T) {
 	ctx := newCtx()
 	td := &ssztypes.TypeDescriptor{
 		SszType:      ssztypes.SszBitlistType,
@@ -373,8 +375,11 @@ func TestUnmarshalBitlistLimitOverflow(t *testing.T) {
 	val := reflect.New(td.Type).Elem()
 
 	err := ctx.unmarshalType(td, val, dec, reflectionDepth{})
-	if err == nil || !strings.Contains(err.Error(), "exceeds platform int max") {
-		t.Fatalf("expected overflow error for bitlist limit, got: %v", err)
+	if err != nil {
+		t.Fatalf("expected the clamped limit to decode, got: %v", err)
+	}
+	if val.Len() != 1 {
+		t.Fatalf("expected 1 byte, got %d", val.Len())
 	}
 }
 

--- a/reflection/sszsize.go
+++ b/reflection/sszsize.go
@@ -31,14 +31,14 @@ import (
 //   - targetValue: The reflect.Value containing the actual data to size
 //
 // Returns:
-//   - uint32: The exact number of bytes needed to encode this value
+//   - int64: The exact number of bytes needed to encode this value
 //   - error: An error if sizing fails (e.g., slice exceeds maximum size)
 //
 // Special handling:
 //   - Nil pointers are sized as zero-valued instances
 //   - Dynamic slices include padding for size hint compliance
 //   - Struct fields are sized based on their static/dynamic nature
-func (ctx *ReflectionCtx) getSszValueSize(targetType *ssztypes.TypeDescriptor, targetValue reflect.Value, depth reflectionDepth) (uint32, error) { //nolint:gocyclo // SSZ size computation handles many type cases
+func (ctx *ReflectionCtx) getSszValueSize(targetType *ssztypes.TypeDescriptor, targetValue reflect.Value, depth reflectionDepth) (int64, error) { //nolint:gocyclo // SSZ size computation handles many type cases
 	// The outermost value is never charged: a level costs only what a caller
 	// descends into, which is what the generated code counts — its public entry
 	// points carry depth zero and every charge is a caller advancing for a
@@ -55,8 +55,8 @@ func (ctx *ReflectionCtx) getSszValueSize(targetType *ssztypes.TypeDescriptor, t
 	depth.idt++
 
 	// Accumulated in uint64: the descriptor-build guards bound static sizes,
-	// but products and sums with runtime lengths can still exceed the uint32
-	// SSZ size range and must be rejected instead of wrapping.
+	// but products and sums with runtime lengths can still exceed the platform
+	// integer range and must be rejected instead of wrapping.
 	staticSize := uint64(0)
 
 	if targetType.GoTypeFlags&ssztypes.GoTypeFlagIsPointer != 0 && targetType.SszType != ssztypes.SszOptionalType && targetType.SszType != ssztypes.SszOptionalListType {
@@ -79,7 +79,7 @@ func (ctx *ReflectionCtx) getSszValueSize(targetType *ssztypes.TypeDescriptor, t
 		if !ctx.noDelegation && targetType.SszCompatFlags&ssztypes.SszCompatFlagDynamicViewSizer != 0 {
 			if sizer, ok := getPtr(targetValue).Interface().(sszutils.DynamicViewSizer); ok {
 				if sizeFn := sizer.SizeSSZDynView(*targetType.CodegenInfo); sizeFn != nil {
-					return uint32(sizeFn(ctx.ds)), nil
+					return int64(sizeFn(ctx.ds)), nil
 				}
 			}
 		}
@@ -96,14 +96,14 @@ func (ctx *ReflectionCtx) getSszValueSize(targetType *ssztypes.TypeDescriptor, t
 
 		if useFastSsz {
 			if marshaller, ok := getPtr(targetValue).Interface().(sszutils.FastsszMarshaler); ok {
-				return uint32(marshaller.SizeSSZ()), nil
+				return int64(marshaller.SizeSSZ()), nil
 			}
 		}
 
 		if targetType.SszCompatFlags&ssztypes.SszCompatFlagDynamicSizer != 0 &&
 			(!ctx.noDelegation || targetType.SszType == ssztypes.SszCustomType) {
 			if sizer, ok := getPtr(targetValue).Interface().(sszutils.DynamicSizer); ok {
-				return uint32(sizer.SizeSSZDyn(ctx.ds)), nil
+				return int64(sizer.SizeSSZDyn(ctx.ds)), nil
 			}
 		}
 	}
@@ -142,7 +142,7 @@ func (ctx *ReflectionCtx) getSszValueSize(targetType *ssztypes.TypeDescriptor, t
 		// Over-length slices cannot be serialized (arrays are truncated to the
 		// declared length instead, matching marshal/HTR), so reject them like
 		// marshal does rather than returning a size it will never produce.
-		if targetType.Kind != reflect.Array && uint32(targetValue.Len()) > targetType.Len {
+		if targetType.Kind != reflect.Array && int64(targetValue.Len()) > targetType.Len {
 			return 0, sszutils.ErrVectorLengthFn(targetValue.Len(), targetType.Len)
 		}
 
@@ -163,12 +163,12 @@ func (ctx *ReflectionCtx) getSszValueSize(targetType *ssztypes.TypeDescriptor, t
 				staticSize += uint64(size) + 4
 			}
 
-			if uint32(dataLen) < targetType.Len {
-				appendZero := targetType.Len - uint32(dataLen)
+			if int64(dataLen) < targetType.Len {
+				appendZero := targetType.Len - int64(dataLen)
 				zeroVal := newZeroElem(fieldType)
 				size, err := ctx.getSszValueSize(fieldType, zeroVal, depth)
 				if err != nil {
-					return 0, sszutils.ErrorWithPathf(err, "[+%d:%d]", dataLen, uint32(dataLen)+appendZero-1)
+					return 0, sszutils.ErrorWithPathf(err, "[+%d:%d]", dataLen, int64(dataLen)+appendZero-1)
 				}
 
 				staticSize += (uint64(size) + 4) * uint64(appendZero)
@@ -357,9 +357,9 @@ func (ctx *ReflectionCtx) getSszValueSize(targetType *ssztypes.TypeDescriptor, t
 		return 0, sszutils.ErrUnknownTypeFn(targetType.Kind)
 	}
 
-	if staticSize > math.MaxUint32 {
-		return 0, sszutils.NewSszErrorf(sszutils.ErrInvalidValueRange, "SSZ size %d exceeds the uint32 size range", staticSize)
+	if staticSize > uint64(math.MaxInt) {
+		return 0, sszutils.NewSszErrorf(sszutils.ErrInvalidValueRange, "SSZ size %d exceeds the platform integer range", staticSize)
 	}
 
-	return uint32(staticSize), nil
+	return int64(staticSize), nil
 }

--- a/reflection/sszsize.go
+++ b/reflection/sszsize.go
@@ -195,7 +195,7 @@ func (ctx *ReflectionCtx) getSszValueSize(targetType *ssztypes.TypeDescriptor, t
 		}
 	case ssztypes.SszListType, ssztypes.SszBitlistType, ssztypes.SszProgressiveListType, ssztypes.SszProgressiveBitlistType:
 		fieldType := targetType.ElemDesc
-		sliceLen := uint32(targetValue.Len())
+		sliceLen := targetValue.Len()
 
 		// Enforce ssz-max like marshalList: a list longer than its limit cannot be
 		// serialized, so return the same error instead of a size for an
@@ -203,7 +203,7 @@ func (ctx *ReflectionCtx) getSszValueSize(targetType *ssztypes.TypeDescriptor, t
 		// their own encode path, so they are excluded here.
 		if (targetType.SszType == ssztypes.SszListType || targetType.SszType == ssztypes.SszProgressiveListType) &&
 			targetType.SszTypeFlags&ssztypes.SszTypeFlagHasLimit != 0 && uint64(sliceLen) > targetType.Limit {
-			return 0, sszutils.ErrListLengthFn(int(sliceLen), targetType.Limit)
+			return 0, sszutils.ErrListLengthFn(sliceLen, targetType.Limit)
 		}
 
 		if sliceLen > 0 {
@@ -212,7 +212,7 @@ func (ctx *ReflectionCtx) getSszValueSize(targetType *ssztypes.TypeDescriptor, t
 				staticSize = uint64(sliceLen)
 			case fieldType.SszTypeFlags&ssztypes.SszTypeFlagIsDynamic != 0:
 				// slice with dynamic size items, so we have to go through each item
-				for i := 0; i < int(sliceLen); i++ {
+				for i := 0; i < sliceLen; i++ {
 					size, err := ctx.getSszValueSize(fieldType, targetValue.Index(i), depth)
 					if err != nil {
 						return 0, sszutils.ErrorWithPathf(err, "[%d]", i)

--- a/reflection/treeroot.go
+++ b/reflection/treeroot.go
@@ -356,7 +356,7 @@ func (ctx *ReflectionCtx) buildRootFromLargeUint(sourceType *ssztypes.TypeDescri
 		sourceValue = sourceValPtr.Elem()
 	}
 
-	sourceLen := uint32(sourceValue.Len())
+	sourceLen := int64(sourceValue.Len())
 	expectedLen := sourceType.Size / sourceType.ElemDesc.Size
 	if sourceLen > expectedLen {
 		return sszutils.ErrVectorLengthFn(sourceLen, expectedLen)
@@ -369,7 +369,7 @@ func (ctx *ReflectionCtx) buildRootFromLargeUint(sourceType *ssztypes.TypeDescri
 	isUint64 := sourceType.ElemDesc.Kind == reflect.Uint64
 	if isUint64 {
 		for i := 0; i < int(sourceType.Size/8); i++ {
-			if uint32(i) < sourceLen {
+			if int64(i) < sourceLen {
 				hh.AppendUint64(sourceValue.Index(i).Uint())
 			} else {
 				hh.AppendUint64(0)
@@ -635,7 +635,7 @@ func (ctx *ReflectionCtx) buildRootFromVector(sourceType *ssztypes.TypeDescripto
 	hashIndex := hh.StartTree(sszutils.TreeTypeBinary)
 
 	sliceLen := sourceValue.Len()
-	if uint32(sliceLen) > sourceType.Len {
+	if int64(sliceLen) > sourceType.Len {
 		if sourceType.Kind == reflect.Array {
 			sliceLen = int(vecLen)
 		} else {
@@ -644,7 +644,7 @@ func (ctx *ReflectionCtx) buildRootFromVector(sourceType *ssztypes.TypeDescripto
 	}
 
 	appendZero := 0
-	if uint32(sliceLen) < sourceType.Len {
+	if int64(sliceLen) < sourceType.Len {
 		appendZero = int(vecLen) - sliceLen
 	}
 

--- a/reflection/treeroot.go
+++ b/reflection/treeroot.go
@@ -378,10 +378,10 @@ func (ctx *ReflectionCtx) buildRootFromLargeUint(sourceType *ssztypes.TypeDescri
 	} else {
 		b := sourceValue.Bytes()
 		hh.Append(b)
-		// int64 keeps the widening conversion from the uint32 size safe on every
-		// platform (a large-uint width is only ever 16 or 32, but the size is a
-		// spec-derived uint32 the compiler cannot bound).
-		if pad := int64(sourceType.Size) - int64(len(b)); pad > 0 {
+		// The subtraction runs in int64 so an over-long value yields a negative
+		// pad instead of wrapping (a large-uint width is only ever 16 or 32,
+		// but the size is spec-derived and the compiler cannot bound it).
+		if pad := sourceType.Size - int64(len(b)); pad > 0 {
 			hh.Append(sszutils.ZeroBytes()[:pad])
 		}
 	}
@@ -627,7 +627,7 @@ func (ctx *ReflectionCtx) buildRootFromUnion(sourceType *ssztypes.TypeDescriptor
 //   - Byte arrays use PutBytes for efficient chunk-based hashing
 //   - Arrays with max size hints include length mixing for proper limits
 func (ctx *ReflectionCtx) buildRootFromVector(sourceType *ssztypes.TypeDescriptor, sourceValue reflect.Value, hh sszutils.HashWalker, depth reflectionDepth) error {
-	vecLen := int64(sourceType.Len)
+	vecLen := sourceType.Len
 	if vecLen > math.MaxInt {
 		return sszutils.ErrPlatformOverflowFn("vector length", sourceType.Len)
 	}

--- a/reflection/unmarshal.go
+++ b/reflection/unmarshal.go
@@ -391,7 +391,7 @@ func (ctx *ReflectionCtx) unmarshalTypeWrapper(targetType *ssztypes.TypeDescript
 func (ctx *ReflectionCtx) unmarshalContainer(targetType *ssztypes.TypeDescriptor, targetValue reflect.Value, decoder sszutils.Decoder, depth reflectionDepth) error {
 	// Fast path: containers with no dynamic fields (e.g. Validator)
 	if len(targetType.ContainerDesc.DynFields) == 0 {
-		sszSize := uint32(decoder.GetLength())
+		sszSize := int64(decoder.GetLength())
 		if sszSize < targetType.Len {
 			return sszutils.ErrFixedFieldsEOFFn(sszSize, targetType.Len)
 		}
@@ -430,7 +430,7 @@ func (ctx *ReflectionCtx) unmarshalContainer(targetType *ssztypes.TypeDescriptor
 	// check is skipped; a short input surfaces as ErrUnexpectedEOF when the
 	// fixed section is read.
 	lengthKnown := decoder.LengthKnown()
-	sszSize := uint32(decoder.GetLength())
+	sszSize := int64(decoder.GetLength())
 	if lengthKnown && sszSize < targetType.Len {
 		return sszutils.ErrFixedFieldsEOFFn(sszSize, targetType.Len)
 	}
@@ -493,7 +493,7 @@ func (ctx *ReflectionCtx) unmarshalContainer(targetType *ssztypes.TypeDescriptor
 			dynOffset = dynamicOffsets[0]
 		}
 
-		if dynOffset != targetType.Len { // check first dynamic field offset
+		if int64(dynOffset) != targetType.Len { // check first dynamic field offset
 			return sszutils.ErrorWithPathf(
 				sszutils.ErrFirstOffsetMismatchFn(dynOffset, targetType.Len),
 				"%s:o", targetType.ContainerDesc.DynFields[0].Field.Name,
@@ -501,14 +501,14 @@ func (ctx *ReflectionCtx) unmarshalContainer(targetType *ssztypes.TypeDescriptor
 		}
 
 		for i, field := range targetType.ContainerDesc.DynFields {
-			startOffset := dynOffset
+			startOffset := int64(dynOffset)
 
 			// The trailing dynamic field runs to the end of the container, so in
 			// an open region it is the one field whose extent is unknown.
 			isTrailing := i == dynamicFieldCount-1
 			openField := isTrailing && !lengthKnown
 
-			var endOffset uint32
+			var endOffset int64
 			if !isTrailing {
 				if canSeek {
 					dynOffset = decoder.DecodeOffsetAt(startPos + int(targetType.ContainerDesc.DynFields[i+1].HeaderOffset))
@@ -516,7 +516,7 @@ func (ctx *ReflectionCtx) unmarshalContainer(targetType *ssztypes.TypeDescriptor
 					dynOffset = dynamicOffsets[i+1]
 				}
 
-				endOffset = dynOffset
+				endOffset = int64(dynOffset)
 			} else {
 				endOffset = sszSize
 			}
@@ -536,8 +536,7 @@ func (ctx *ReflectionCtx) unmarshalContainer(targetType *ssztypes.TypeDescriptor
 			if openField {
 				decoder.PushOpenLimit()
 			} else {
-				sszSize := endOffset - startOffset
-				decoder.PushLimit(int(sszSize))
+				decoder.PushLimit(int(endOffset - startOffset))
 			}
 
 			fieldDescriptor := field.Field

--- a/reflection/unmarshal.go
+++ b/reflection/unmarshal.go
@@ -1021,10 +1021,10 @@ func (ctx *ReflectionCtx) unmarshalListUntilEOF(targetType *ssztypes.TypeDescrip
 
 	maxItems := -1
 	if targetType.SszTypeFlags&ssztypes.SszTypeFlagHasLimit != 0 {
-		if targetType.Limit > math.MaxInt {
-			return sszutils.ErrPlatformOverflowFn("list limit", targetType.Limit)
-		}
-		maxItems = int(targetType.Limit)
+		// A limit above the platform integer range caps to MaxInt: the cap only
+		// bounds reads and allocations, which cannot reach that magnitude, while
+		// the limit itself keeps its full uint64 range.
+		maxItems = sszutils.CapToInt(targetType.Limit)
 	}
 
 	fieldT := targetType.Type
@@ -1422,11 +1422,10 @@ func (ctx *ReflectionCtx) unmarshalBitlist(targetType *ssztypes.TypeDescriptor, 
 	// stream) from forcing an arbitrarily large allocation.
 	maxBytes := -1
 	if targetType.SszTypeFlags&ssztypes.SszTypeFlagHasLimit != 0 {
-		limitBytes := targetType.Limit/8 + 1
-		if limitBytes > math.MaxInt {
-			return sszutils.ErrPlatformOverflowFn("bitlist limit", targetType.Limit)
-		}
-		maxBytes = int(limitBytes)
+		// A byte cap above the platform integer range caps to MaxInt: it only
+		// bounds the read, which cannot reach that magnitude, while the limit
+		// itself keeps its full uint64 range.
+		maxBytes = sszutils.CapToInt(targetType.Limit/8 + 1)
 	}
 
 	if decoder.LengthKnown() {

--- a/reflection/unmarshal.go
+++ b/reflection/unmarshal.go
@@ -326,7 +326,7 @@ func (ctx *ReflectionCtx) unmarshalType(targetType *ssztypes.TypeDescriptor, tar
 // incremental — and is bounded by the decoder's maximum stream size.
 func delegationBuffer(targetType *ssztypes.TypeDescriptor, decoder sszutils.Decoder) ([]byte, error) {
 	if targetType.Size > 0 {
-		typeSize := int64(targetType.Size)
+		typeSize := targetType.Size
 		if typeSize > math.MaxInt {
 			return nil, sszutils.ErrPlatformOverflowFn("type size", targetType.Size)
 		}
@@ -635,7 +635,7 @@ func expandSliceValue(target reflect.Value, sliceType reflect.Type, size int) re
 //   - Pointer elements are automatically initialized
 //   - Each element must consume exactly itemSize bytes
 func (ctx *ReflectionCtx) unmarshalVector(targetType *ssztypes.TypeDescriptor, targetValue reflect.Value, decoder sszutils.Decoder, depth reflectionDepth) error {
-	vecLen := int64(targetType.Len)
+	vecLen := targetType.Len
 	if vecLen > math.MaxInt {
 		return sszutils.ErrPlatformOverflowFn("vector length", targetType.Len)
 	}
@@ -739,7 +739,7 @@ func (ctx *ReflectionCtx) unmarshalVector(targetType *ssztypes.TypeDescriptor, t
 //   - No offset points outside the data bounds
 //   - Each element consumes exactly the expected bytes
 func (ctx *ReflectionCtx) unmarshalDynamicVector(targetType *ssztypes.TypeDescriptor, targetValue reflect.Value, decoder sszutils.Decoder, depth reflectionDepth) error {
-	dynVecLen := int64(targetType.Len)
+	dynVecLen := targetType.Len
 	if dynVecLen > math.MaxInt {
 		return sszutils.ErrPlatformOverflowFn("dynamic vector length", targetType.Len)
 	}
@@ -879,7 +879,7 @@ func (ctx *ReflectionCtx) unmarshalDynamicVector(targetType *ssztypes.TypeDescri
 // unmarshalFixedElements decodes a sequence of fixed-size elements into target slice/array positions.
 // It handles both pointer and non-pointer element types.
 func (ctx *ReflectionCtx) unmarshalFixedElements(fieldType *ssztypes.TypeDescriptor, newValue reflect.Value, count int, decoder sszutils.Decoder, depth reflectionDepth) error {
-	fieldSize := int64(fieldType.Size)
+	fieldSize := fieldType.Size
 	if fieldSize > math.MaxInt {
 		return sszutils.ErrPlatformOverflowFn("field size", fieldType.Size)
 	}
@@ -934,7 +934,7 @@ func (ctx *ReflectionCtx) unmarshalFixedElements(fieldType *ssztypes.TypeDescrip
 func (ctx *ReflectionCtx) unmarshalList(targetType *ssztypes.TypeDescriptor, targetValue reflect.Value, decoder sszutils.Decoder, depth reflectionDepth) error {
 	fieldType := targetType.ElemDesc
 
-	elemSize := int64(fieldType.Size)
+	elemSize := fieldType.Size
 	if elemSize > math.MaxInt {
 		return sszutils.ErrPlatformOverflowFn("field size", fieldType.Size)
 	}

--- a/ssztypes/descriptor.go
+++ b/ssztypes/descriptor.go
@@ -71,8 +71,8 @@ type TypeDescriptor struct {
 	SchemaType             reflect.Type              `json:"-"`                       // Schema type that defines SSZ layout (may differ from Type for view descriptors)
 	CodegenInfo            *any                      `json:"-"`                       // Codegen information or view pointer
 	Kind                   reflect.Kind              `json:"kind"`                    // Reflect kind of the type
-	Size                   uint32                    `json:"size"`                    // SSZ size (-1 if dynamic)
-	Len                    uint32                    `json:"len"`                     // Length of array/slice / static size of container
+	Size                   int64                     `json:"size"`                    // SSZ size (-1 if dynamic)
+	Len                    int64                     `json:"len"`                     // Length of array/slice / static size of container
 	Limit                  uint64                    `json:"limit"`                   // Limit of array/slice (ssz-max tag)
 	ContainerDesc          *ContainerDescriptor      `json:"container,omitempty"`     // For structs
 	UnionVariants          map[uint8]*TypeDescriptor `json:"union,omitempty"`         // Union variant types by index (for CompatibleUnion)
@@ -80,8 +80,8 @@ type TypeDescriptor struct {
 	HashTreeRootWithMethod *reflect.Method           `json:"-"`                       // Cached HashTreeRootWith method for performance
 	SizeExpression         *string                   `json:"size_expr,omitempty"`     // The dynamic expression used to calculate the size of the type
 	MaxExpression          *string                   `json:"max_expr,omitempty"`      // The dynamic expression used to calculate the max size of the type
-	BitSize                uint32                    `json:"bit_size,omitempty"`      // Bit size for bit vector types (ssz-bitsize tag)
-	MinSize                uint32                    `json:"min_size,omitempty"`      // Smallest serialization of this type; 0 when it has no floor (see SetMinSize)
+	BitSize                int64                     `json:"bit_size,omitempty"`      // Bit size for bit vector types (ssz-bitsize tag)
+	MinSize                int64                     `json:"min_size,omitempty"`      // Smallest serialization of this type; 0 when it has no floor (see SetMinSize)
 	WrapperFieldIndex      uint8                     `json:"wrapper_field,omitempty"` // Index of the wrapped value field in a wrapper struct (excluded fields may precede it)
 	SszType                SszType                   `json:"type"`                    // SSZ type of the type
 	SszTypeFlags           SszTypeFlag               `json:"flags"`                   // SSZ type flags
@@ -109,6 +109,6 @@ type FieldDescriptor struct {
 // DynFieldDescriptor represents a dynamic field descriptor for a struct
 type DynFieldDescriptor struct {
 	Field        *FieldDescriptor `json:"field"`
-	HeaderOffset uint32           `json:"offset"`
+	HeaderOffset int64            `json:"offset"`
 	Index        int16            `json:"index"` // Index of the field in the struct
 }

--- a/ssztypes/ssztags.go
+++ b/ssztypes/ssztags.go
@@ -214,7 +214,7 @@ func getSszTypeTag(field *reflect.StructField) ([]SszTypeHint, error) {
 //   - bits: A boolean flag indicating whether the size is in bits rather than bytes.
 //   - expr: The dynamic expression used to calculate the size of the field, typically through 'dynssz-size' annotations.
 type SszSizeHint struct {
-	Size    uint32
+	Size    int64
 	Dynamic bool
 	Custom  bool
 	Bits    bool
@@ -266,18 +266,18 @@ func getSszSizeTag(ds sszutils.DynamicSpecs, field *reflect.StructField) ([]SszS
 
 			switch {
 			case sszBitsizeStr != "?":
-				sszSizeInt, err := strconv.ParseUint(sszBitsizeStr, 10, 32)
+				sszSizeInt, err := strconv.ParseUint(sszBitsizeStr, 10, 63)
 				if err != nil {
 					return sszSizes, sszutils.NewSszErrorf(sszutils.ErrInvalidTag, "error parsing ssz-bitsize tag for '%v' field: %v", field.Name, err)
 				}
-				sszSize.Size = uint32(sszSizeInt)
+				sszSize.Size = int64(sszSizeInt)
 				sszSize.Bits = true
 			case sszSizeStr != "?":
-				sszSizeInt, err := strconv.ParseUint(sszSizeStr, 10, 32)
+				sszSizeInt, err := strconv.ParseUint(sszSizeStr, 10, 63)
 				if err != nil {
 					return sszSizes, sszutils.NewSszErrorf(sszutils.ErrInvalidTag, "error parsing ssz-size tag for '%v' field: %v", field.Name, err)
 				}
-				sszSize.Size = uint32(sszSizeInt)
+				sszSize.Size = int64(sszSizeInt)
 			default:
 				sszSize.Dynamic = true
 			}
@@ -329,8 +329,8 @@ func getSszSizeTag(ds sszutils.DynamicSpecs, field *reflect.StructField) ([]SszS
 
 			if sizeExpr == "?" {
 				sszSize.Dynamic = true
-			} else if sszSizeInt, err := strconv.ParseUint(sizeExpr, 10, 32); err == nil {
-				sszSize.Size = uint32(sszSizeInt)
+			} else if sszSizeInt, err := strconv.ParseUint(sizeExpr, 10, 63); err == nil {
+				sszSize.Size = int64(sszSizeInt)
 			} else {
 				ok, specVal, err := ds.ResolveSpecValue(sizeExpr)
 				if err != nil {
@@ -340,8 +340,8 @@ func getSszSizeTag(ds sszutils.DynamicSpecs, field *reflect.StructField) ([]SszS
 				isExpr = true
 				if ok {
 					// dynamic value from spec
-					if specVal > math.MaxUint32 {
-						return sszSizes, sszutils.NewSszErrorf(sszutils.ErrInvalidTag, "dynssz-size value %d for field %q exceeds the uint32 size range", specVal, field.Name)
+					if specVal > math.MaxInt {
+						return sszSizes, sszutils.ErrPlatformOverflowFn(fmt.Sprintf("dynssz-size value for field %q", field.Name), specVal)
 					}
 					if specVal == 0 {
 						// A dynssz-size that resolves to 0 would form a zero-length
@@ -353,7 +353,7 @@ func getSszSizeTag(ds sszutils.DynamicSpecs, field *reflect.StructField) ([]SszS
 						}
 						return sszSizes, sszutils.NewSszErrorf(sszutils.ErrInvalidConstraint, "dynssz-size for field %q resolved to 0 with no positive static fallback", field.Name)
 					}
-					sszSize.Size = uint32(specVal)
+					sszSize.Size = int64(specVal)
 					sszSize.Custom = true
 				} else {
 					// Unknown spec value: keep the fastssz default for this dimension,
@@ -663,20 +663,20 @@ func ParseTags(tag string) (typeHints []SszTypeHint, sizeHints []SszSizeHint, ma
 
 			switch {
 			case sszBitsizeStr != "?":
-				sizeInt, parseErr := strconv.ParseUint(strings.TrimSpace(sszBitsizeStr), 10, 32)
+				sizeInt, parseErr := strconv.ParseUint(strings.TrimSpace(sszBitsizeStr), 10, 63)
 				if parseErr != nil {
 					return nil, nil, nil, fmt.Errorf("error parsing ssz-size tag: %v", parseErr)
 				}
 
-				hint.Size = uint32(sizeInt)
+				hint.Size = int64(sizeInt)
 				hint.Bits = true
 			case sszSizeStr != "?":
-				sizeInt, parseErr := strconv.ParseUint(strings.TrimSpace(sszSizeStr), 10, 32)
+				sizeInt, parseErr := strconv.ParseUint(strings.TrimSpace(sszSizeStr), 10, 63)
 				if parseErr != nil {
 					return nil, nil, nil, fmt.Errorf("error parsing ssz-size tag: %v", parseErr)
 				}
 
-				hint.Size = uint32(sizeInt)
+				hint.Size = int64(sizeInt)
 			default:
 				hint.Dynamic = true
 			}
@@ -724,8 +724,8 @@ func ParseTags(tag string) (typeHints []SszTypeHint, sizeHints []SszSizeHint, ma
 
 			if sizeExpr == "?" {
 				sszSize.Dynamic = true
-			} else if sszSizeInt, parseErr := strconv.ParseUint(sizeExpr, 10, 32); parseErr == nil {
-				sszSize.Size = uint32(sszSizeInt)
+			} else if sszSizeInt, parseErr := strconv.ParseUint(sizeExpr, 10, 63); parseErr == nil {
+				sszSize.Size = int64(sszSizeInt)
 			} else {
 				// An expression names a length, so the dimension is a vector;
 				// only `?` declares it dynamic.

--- a/ssztypes/typecache.go
+++ b/ssztypes/typecache.go
@@ -482,11 +482,11 @@ func (tc *TypeCache) buildTypeDescriptor(desc *TypeDescriptor, runtimeType, sche
 						// The range check guards the conversion directly rather
 						// than standing as a separate condition, so that what
 						// makes the narrowing safe is visible at the narrowing.
-						if val > math.MaxUint32 {
-							return nil, sszutils.NewSszErrorf(sszutils.ErrInvalidTag, "ssz-size value %d exceeds the uint32 size range", val)
+						if val > math.MaxInt {
+							return nil, sszutils.ErrPlatformOverflowFn("ssz-size annotation value", val)
 						}
 
-						sizeHints[i].Size = uint32(val)
+						sizeHints[i].Size = int64(val)
 						sizeHints[i].Custom = true
 
 						continue
@@ -1089,8 +1089,8 @@ func (td *TypeDescriptor) SetMinSize() {
 			// An overflowing product would bound the region above the true floor
 			// and refuse valid input, so it states no bound instead.
 			minSize := uint64(td.Len) * (4 + uint64(td.ElemDesc.MinSize))
-			if minSize <= math.MaxUint32 {
-				td.MinSize = uint32(minSize)
+			if minSize <= math.MaxInt64 {
+				td.MinSize = int64(minSize)
 			}
 		}
 	default:
@@ -1191,17 +1191,17 @@ func fullyDelegatesSSZView(runtimeType reflect.Type) bool {
 // derives its result from constants and spec values only — never from field data
 // — so a zero value yields the correct size, and spec-dependent fixed sizes are
 // resolved against the cache's specs. View descriptors use the view sizer.
-func (tc *TypeCache) delegatedStaticSize(desc *TypeDescriptor, runtimeType reflect.Type) (uint32, error) {
+func (tc *TypeCache) delegatedStaticSize(desc *TypeDescriptor, runtimeType reflect.Type) (int64, error) {
 	specs := tc.specs // never nil: NewTypeCache substitutes emptySpecs{}
 	zero := reflect.New(runtimeType).Interface()
 
-	// A sizer returns int; a negative or >uint32 value would wrap on conversion
-	// and corrupt downstream sizing/offset math, so validate the range.
-	validate := func(n int) (uint32, error) {
-		if n < 0 || int64(n) > math.MaxUint32 {
+	// A sizer returns int; a negative value would corrupt downstream
+	// sizing/offset math, so validate the range.
+	validate := func(n int) (int64, error) {
+		if n < 0 {
 			return 0, sszutils.NewSszErrorf(sszutils.ErrInvalidValueRange, "sizer for static type %v returned out-of-range size %d", runtimeType, n)
 		}
-		return uint32(n), nil
+		return int64(n), nil
 	}
 
 	if desc.GoTypeFlags&GoTypeFlagIsView != 0 {
@@ -1374,7 +1374,7 @@ func wrapperTypeCompatible(actual, expected reflect.Type) bool {
 }
 
 // buildUint128Descriptor builds a descriptor for uint128 types
-func (tc *TypeCache) buildUintDescriptor(desc *TypeDescriptor, t reflect.Type, byteLen uint32, typeName string) error {
+func (tc *TypeCache) buildUintDescriptor(desc *TypeDescriptor, t reflect.Type, byteLen int64, typeName string) error {
 	if desc.Kind != reflect.Slice && desc.Kind != reflect.Array {
 		return sszutils.NewSszErrorf(sszutils.ErrTypeMismatch, "%s ssz type can only be represented by slice or array types, got %v", typeName, desc.Kind)
 	}
@@ -1397,7 +1397,7 @@ func (tc *TypeCache) buildUintDescriptor(desc *TypeDescriptor, t reflect.Type, b
 	desc.Len = desc.Size / elemDesc.Size
 
 	if desc.Kind == reflect.Array {
-		dstLen := uint32(t.Len())
+		dstLen := int64(t.Len())
 		// A fixed-width uint (uint128/uint256) occupies exactly desc.Len array
 		// elements. A smaller array cannot hold it; a larger array carries trailing
 		// elements that marshal silently drops (truncating to desc.Len) while
@@ -1471,7 +1471,7 @@ func (tc *TypeCache) buildContainerDescriptor(desc *TypeDescriptor, runtimeType,
 		DynFields: make([]DynFieldDescriptor, 0),
 	}
 
-	totalSize := uint32(0)
+	totalSize := int64(0)
 	isDynamic := false
 
 	// Check for progressive container detection
@@ -1575,10 +1575,11 @@ func (tc *TypeCache) buildContainerDescriptor(desc *TypeDescriptor, runtimeType,
 		}
 
 		desc.SszTypeFlags |= fieldDesc.Type.SszTypeFlags & (SszTypeFlagHasDynamicSize | SszTypeFlagHasDynamicMax | SszTypeFlagHasSizeExpr | SszTypeFlagHasMaxExpr)
-		// SSZ sizes are uint32; a wrapped sum would defeat the fixed-section
-		// length checks that are derived from it.
-		if totalSize > math.MaxUint32-sszSize {
-			return sszutils.NewSszErrorf(sszutils.ErrInvalidValueRange, "container byte size exceeds the uint32 SSZ size range")
+		// A wrapped sum would defeat the fixed-section length checks that are
+		// derived from it, so bound the static size to the platform integer
+		// range like every other size.
+		if totalSize > math.MaxInt-sszSize {
+			return sszutils.NewSszErrorf(sszutils.ErrInvalidValueRange, "container byte size exceeds the platform integer range")
 		}
 		totalSize += sszSize
 		desc.ContainerDesc.Fields[fi] = fieldDesc
@@ -1901,7 +1902,7 @@ func (tc *TypeCache) buildVectorDescriptor(desc *TypeDescriptor, runtimeType, sc
 		if runtimeType.Kind() == reflect.Array && runtimeType.Len() < t.Len() {
 			return sszutils.NewSszErrorf(sszutils.ErrInvalidConstraint, "view schema array length (%d) exceeds the backing array length (%d)", t.Len(), runtimeType.Len())
 		}
-		desc.Len = uint32(t.Len())
+		desc.Len = int64(t.Len())
 		// A dynamic placeholder hint — e.g. dynssz-size:"?" on an outer dimension
 		// whose Go type is a fixed array — carries Size 0 (and no Bits) and must
 		// not zero the array's intrinsic length: a Go array cannot be relaxed to
@@ -2006,14 +2007,14 @@ func (tc *TypeCache) buildVectorDescriptor(desc *TypeDescriptor, runtimeType, sc
 		desc.Size = 0
 		desc.SszTypeFlags |= SszTypeFlagIsDynamic
 	} else {
-		// SSZ sizes are uint32; an unchecked product would wrap silently and
-		// downstream length checks would then divide by or allocate from a
-		// bogus size.
-		totalSize := uint64(elemDesc.Size) * uint64(desc.Len)
-		if totalSize > math.MaxUint32 {
-			return sszutils.NewSszErrorf(sszutils.ErrInvalidValueRange, "vector byte size %d exceeds the uint32 SSZ size range", totalSize)
+		// An unchecked product would wrap silently and downstream length
+		// checks would then divide by or allocate from a bogus size, so bound
+		// it to the platform integer range like every other size. The bound is
+		// checked by division so the product itself cannot wrap first.
+		if desc.Len > 0 && elemDesc.Size > math.MaxInt/desc.Len {
+			return sszutils.NewSszErrorf(sszutils.ErrInvalidValueRange, "vector byte size %d*%d exceeds the platform integer range", elemDesc.Size, desc.Len)
 		}
-		desc.Size = uint32(totalSize)
+		desc.Size = elemDesc.Size * desc.Len
 	}
 
 	return nil

--- a/ssztypes/typecache_test.go
+++ b/ssztypes/typecache_test.go
@@ -709,7 +709,7 @@ func TestTypeDescriptor_MinSize(t *testing.T) {
 	tests := []struct {
 		name string
 		typ  reflect.Type
-		want uint32
+		want int64
 	}{
 		// Fixed sections: 4 bytes per dynamic field, the field's own size otherwise.
 		{"dynamic container", reflect.TypeFor[dynElem](), 4},
@@ -868,9 +868,9 @@ func TestTypeCache_SizeHintExpressions(t *testing.T) {
 
 // A dynssz-size field tag resolving to a value beyond the uint32 size range
 // must error rather than silently truncate during conversion.
-func TestTypeCache_SizeHintExpressionExceedsUint32(t *testing.T) {
+func TestTypeCache_SizeHintExpressionExceedsPlatformInt(t *testing.T) {
 	ds := &dummyDynamicSpecs{
-		specValues: map[string]uint64{"HUGE_SIZE": uint64(math.MaxUint32) + 1},
+		specValues: map[string]uint64{"HUGE_SIZE": uint64(math.MaxInt) + 1},
 	}
 	cache := NewTypeCache(ds)
 
@@ -880,33 +880,33 @@ func TestTypeCache_SizeHintExpressionExceedsUint32(t *testing.T) {
 
 	_, err := cache.GetTypeDescriptor(reflect.TypeOf(TestStruct{}), nil, nil, nil)
 	if err == nil {
-		t.Fatal("expected error for dynssz-size value exceeding uint32 range")
+		t.Fatal("expected error for dynssz-size value exceeding the platform integer range")
 	}
-	if !strings.Contains(err.Error(), "exceeds the uint32 size range") {
+	if !errors.Is(err, sszutils.ErrPlatformOverflow) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
 
 // annotatedOverflowSize carries a registered annotation whose dynssz-size
-// expression resolves beyond uint32, exercising the annotation-registry
-// resolution path (distinct from struct field tags).
+// expression resolves beyond the platform integer range, exercising the
+// annotation-registry resolution path (distinct from struct field tags).
 type annotatedOverflowSize []byte
 
 var _ = sszutils.Annotate[annotatedOverflowSize](`dynssz-size:"HUGE_SIZE"`)
 
-// A registered annotation whose dynssz-size resolves beyond the uint32 size
-// range must error during the deferred spec resolution.
-func TestTypeCache_AnnotationSizeHintExceedsUint32(t *testing.T) {
+// A registered annotation whose dynssz-size resolves beyond the platform
+// integer range must error during the deferred spec resolution.
+func TestTypeCache_AnnotationSizeHintExceedsPlatformInt(t *testing.T) {
 	ds := &dummyDynamicSpecs{
-		specValues: map[string]uint64{"HUGE_SIZE": uint64(math.MaxUint32) + 1},
+		specValues: map[string]uint64{"HUGE_SIZE": uint64(math.MaxInt) + 1},
 	}
 	cache := NewTypeCache(ds)
 
 	_, err := cache.GetTypeDescriptor(reflect.TypeOf(annotatedOverflowSize{}), nil, nil, nil)
 	if err == nil {
-		t.Fatal("expected error for annotation dynssz-size value exceeding uint32 range")
+		t.Fatal("expected error for annotation dynssz-size value exceeding the platform integer range")
 	}
-	if !strings.Contains(err.Error(), "exceeds the uint32 size range") {
+	if !errors.Is(err, sszutils.ErrPlatformOverflow) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/sszutils/error.go
+++ b/sszutils/error.go
@@ -432,6 +432,15 @@ func ErrVectorSizeExceedsArrayFn(dynamicSize, arrayLen any) error {
 	}
 }
 
+// ErrOffsetOverflowFn is returned when a computed offset exceeds the 4-byte
+// SSZ offset range, i.e. the encoded object grew past 2^32-1 bytes.
+func ErrOffsetOverflowFn(offset any) error {
+	return &sszError{
+		err:     ErrOffset,
+		message: fmt.Sprintf("offset %v exceeds the 4-byte SSZ offset range", offset),
+	}
+}
+
 // --- ErrInvalidValueRange constructors ---
 
 // ErrBitvectorPaddingFn is returned when a bitvector's padding bits

--- a/sszutils/error_test.go
+++ b/sszutils/error_test.go
@@ -273,6 +273,7 @@ func TestErrorConstructorFunctions(t *testing.T) {
 		{"ErrElementOffsetOutOfRangeFn", ErrElementOffsetOutOfRangeFn(99, 10, 50), ErrOffset, "element offset 99 out of range (start 10, max 50)"},
 		{"ErrStaticElementNotConsumedFn", ErrStaticElementNotConsumedFn(6, 8), ErrOffset, "element consumed to position 6, expected 8"},
 		{"ErrListRegionTooSmallFn", ErrListRegionTooSmallFn(512, 65540, 0), ErrOffset, "list declares 512 elements of at least 65540 bytes, but only 0 bytes remain for them"},
+		{"ErrOffsetOverflowFn", ErrOffsetOverflowFn(int64(5000000000)), ErrOffset, "offset 5000000000 exceeds the 4-byte SSZ offset range"},
 
 		// ErrVectorLength constructors
 		{"ErrVectorLengthFn", ErrVectorLengthFn(10, 5), ErrVectorLength, "vector length 10 exceeds limit 5"},

--- a/sszutils/unmarshal.go
+++ b/sszutils/unmarshal.go
@@ -5,8 +5,10 @@
 package sszutils
 
 import (
+	"cmp"
 	"encoding/binary"
 	"errors"
+	"math"
 	"unsafe"
 )
 
@@ -131,6 +133,30 @@ func ReadOffset(buf []byte) uint64 {
 }
 
 // ---- expansion functions ----
+
+// CapToInt caps a uint64 value to the platform integer range. Allocation
+// capacities and read caps derived from SSZ limits pass through int while the
+// limits themselves span the full uint64 range; nothing above math.MaxInt is
+// reachable in memory, so the cap loses nothing.
+func CapToInt(v uint64) int {
+	if v > math.MaxInt {
+		return math.MaxInt
+	}
+
+	return int(v)
+}
+
+// Min returns the smaller of a and b. Generated code calls the qualified
+// helpers instead of the min/max builtins, which a target package can shadow
+// with its own function.
+func Min[T cmp.Ordered](a, b T) T {
+	return min(a, b)
+}
+
+// Max returns the larger of a and b. See Min.
+func Max[T cmp.Ordered](a, b T) T {
+	return max(a, b)
+}
 
 // ExpandSlice grows or shrinks src to length size, zeroing any newly added elements.
 // For size == 0 it returns a non-nil empty slice.


### PR DESCRIPTION
## Summary

CodeQL flagged a large number of unsafe integer conversions in the generated code. This hardens the emitters so every SSZ quantity stays in its proper domain, with explicit local checks instead of blind conversions.

### Sizes (dynssz-size)

Size expressions resolve as `uint64` through the existing `ResolveSpecValueWithDefault` and are rejected above the platform integer range right after resolution (`ErrPlatformOverflow`). The plain `int(expr)` conversions at the use sites are unchanged but now sit behind that guard, so they cannot truncate. One guard per expression per call — no clamping, no value changes.

### Limits (dynssz-max)

Limit checks compare in `uint64` against the raw spec value (`uint64(vlen) > expr0`), so limits keep their full 64-bit range and a limit beyond the int range never truncates through a conversion. Where a limit feeds an int capacity argument (`GrowSlice` growth caps, byte/uint64-list read caps, the bitlist byte cap) it clamps to `math.MaxInt` — a capacity bound loses nothing there, while the previous plain conversion could wrap negative. Generation-time handling covers `uint64`-range *literals*, which previously produced uncompilable output in int contexts.

### Offsets

Decoder/unmarshal offset and length handling sticks to plain `int` (the `uint32(sszLen)` / `uint32(dec.GetLength())` round-trips are gone). The 4-byte SSZ offset format bound is enforced exactly where offsets are written: marshal offset patches and encoder offset writes guard against values past 2^32-1 bytes and return the new `sszutils.ErrOffsetOverflowFn` instead of silently writing truncated offsets. Encoder offset accumulators run in `uint64`.

## Test plan

- Full suite passes with `-count=1`, including all codegen compat tests (old generated code still compiles and runs against the updated library)
- Differential fuzzing across a freshly generated 74-type corpus: 14.9M iterations with zero marshal/unmarshal/HTR/streaming mismatches vs the reflection engine, at unchanged throughput
- gosec G115 findings in the generated fixtures drop from 1888 to ~305; the remainder are guard-dominated conversions its dataflow cannot track (array-element guards, guarded arithmetic) plus intentional same-width sign reinterpretation in the extended types — the CodeQL run on this PR is the arbiter for the guarded forms

### Reflection engine parity

The reflection path carried a structural uint32 size bound (descriptor `Size`/`Len`/`BitSize`/`MinSize` fields, `getSszValueSize`, and dynssz-size resolution all capped at 2^32-1) and wrote silently truncated offsets past 4 GiB. Both engines now follow the same doctrine:

- Descriptor size fields widen to `int64`; size products and container sums are bounded to the platform integer range with wrap-safe (division-based) checks.
- dynssz-size resolution and size annotations reject values above `math.MaxInt` with `ErrPlatformOverflow`, identical to the generated guard.
- Reflection marshal writes offsets through checked helpers returning `ErrOffsetOverflowFn` past the 4-byte range, in the container, vector, and list paths.
- Sizes past the former uint32 bound (e.g. a 2^32-byte vector type) are now valid in both engines; tests asserting the old bound moved to the platform-range doctrine.
