### PR TITLE
fix: panic on HashTreeRoot/UnmarshalSSZ when bitsize spec value is very large

### DIFF
--- a/codegen/parser.go
+++ b/codegen/parser.go
@@ -997,7 +997,7 @@ func (p *Parser) buildTypeDescriptor(dataType, schemaType types.Type, typeHints 
 			desc.Size = sizeHints[0].Size
 			if sizeHints[0].Bits {
 				desc.BitSize = sizeHints[0].Size
-				desc.Size = (desc.Size + 7) / 8 // ceil up to the next multiple of 8
+				desc.Size = int64((uint64(desc.Size) + 7) / 8) // ceil up to the next multiple of 8
 			}
 		} else {
 			desc.Size = 0
@@ -1455,7 +1455,8 @@ func (p *Parser) buildVectorDescriptor(desc *ssztypes.TypeDescriptor, dataType, 
 		if len(sizeHints) > 0 && sizeHints[0].Size > 0 {
 			byteSize := sizeHints[0].Size
 			if sizeHints[0].Bits {
-				byteSize = (byteSize + 7) / 8 // ceil up to the next multiple of 8
+				// See the SszCustomType branch above: bounded input, uint64 domain avoids overflow.
+				byteSize = int64((uint64(byteSize) + 7) / 8) // ceil up to the next multiple of 8
 			}
 			if byteSize > length {
 				return fmt.Errorf("size hint for vector type is greater than the length of the array (%d > %d)", byteSize, length)
@@ -1468,7 +1469,8 @@ func (p *Parser) buildVectorDescriptor(desc *ssztypes.TypeDescriptor, dataType, 
 		case len(sizeHints) > 0 && sizeHints[0].Size > 0:
 			length = sizeHints[0].Size
 			if sizeHints[0].Bits {
-				length = (length + 7) / 8 // ceil up to the next multiple of 8
+				// See the SszCustomType branch above: bounded input, uint64 domain avoids overflow.
+				length = int64((uint64(length) + 7) / 8) // ceil up to the next multiple of 8
 			}
 		case len(sizeHints) > 0 && sizeHints[0].Expr != "":
 			// Length comes purely from a runtime dynssz-size expression with no
@@ -1485,7 +1487,8 @@ func (p *Parser) buildVectorDescriptor(desc *ssztypes.TypeDescriptor, dataType, 
 			case len(sizeHints) > 0 && sizeHints[0].Size > 0:
 				length = sizeHints[0].Size
 				if sizeHints[0].Bits {
-					length = (length + 7) / 8 // ceil up to the next multiple of 8
+					// See the SszCustomType branch above: bounded input, uint64 domain avoids overflow.
+					length = int64((uint64(length) + 7) / 8) // ceil up to the next multiple of 8
 				}
 				desc.GoTypeFlags |= ssztypes.GoTypeFlagIsByteArray
 				schemaElemType = byteType

--- a/dynssz_test.go
+++ b/dynssz_test.go
@@ -922,37 +922,6 @@ func TestHashTreeRootLargeObjectOverflow(t *testing.T) {
 	}
 }
 
-// A dynssz-bitsize expression resolving near math.MaxInt64 previously overflowed
-// the internal (bits+7)/8 byte-length conversion in
-// ssztypes/typecache.go:buildVectorDescriptor: byteLen+7 wrapped past MaxInt64
-// into a large negative number, and that negative desc.Len/desc.BitSize was
-// cached in the type's TypeDescriptor forever, panicking on every later
-// HashTreeRoot ("slice bounds out of range") or UnmarshalSSZ
-// ("unsafe.Slice: len out of range") call against the type.
-type bitsizeOverflowContainer struct {
-	Items [][4]byte `ssz-type:"list,bitvector" ssz-size:"?,4" ssz-max:"8" dynssz-bitsize:"?,HUGE_BITS"`
-}
-
-func TestHashTreeRootBitsizeOverflowDoesNotPanic(t *testing.T) {
-	specs := map[string]any{"HUGE_BITS": uint64(math.MaxInt64)}
-	ds := NewDynSsz(specs)
-
-	_, err := ds.HashTreeRoot(&bitsizeOverflowContainer{Items: [][4]byte{{1, 2, 3, 4}}})
-	if err == nil || !strings.Contains(err.Error(), "platform int") {
-		t.Fatalf("expected a platform integer range error, got: %v", err)
-	}
-}
-
-func TestUnmarshalSSZBitsizeOverflowDoesNotPanic(t *testing.T) {
-	specs := map[string]any{"HUGE_BITS": uint64(math.MaxInt64)}
-	ds := NewDynSsz(specs)
-
-	err := ds.UnmarshalSSZ(&bitsizeOverflowContainer{}, []byte{})
-	if err == nil || !strings.Contains(err.Error(), "platform int") {
-		t.Fatalf("expected a platform integer range error, got: %v", err)
-	}
-}
-
 // ---------------------------------------------------------------------------
 // Mock types for DynamicMarshaler / DynamicSizer / DynamicUnmarshaler / DynamicHashRoot
 // ---------------------------------------------------------------------------

--- a/dynssz_test.go
+++ b/dynssz_test.go
@@ -922,6 +922,37 @@ func TestHashTreeRootLargeObjectOverflow(t *testing.T) {
 	}
 }
 
+// A dynssz-bitsize expression resolving near math.MaxInt64 previously overflowed
+// the internal (bits+7)/8 byte-length conversion in
+// ssztypes/typecache.go:buildVectorDescriptor: byteLen+7 wrapped past MaxInt64
+// into a large negative number, and that negative desc.Len/desc.BitSize was
+// cached in the type's TypeDescriptor forever, panicking on every later
+// HashTreeRoot ("slice bounds out of range") or UnmarshalSSZ
+// ("unsafe.Slice: len out of range") call against the type.
+type bitsizeOverflowContainer struct {
+	Items [][4]byte `ssz-type:"list,bitvector" ssz-size:"?,4" ssz-max:"8" dynssz-bitsize:"?,HUGE_BITS"`
+}
+
+func TestHashTreeRootBitsizeOverflowDoesNotPanic(t *testing.T) {
+	specs := map[string]any{"HUGE_BITS": uint64(math.MaxInt64)}
+	ds := NewDynSsz(specs)
+
+	_, err := ds.HashTreeRoot(&bitsizeOverflowContainer{Items: [][4]byte{{1, 2, 3, 4}}})
+	if err == nil || !strings.Contains(err.Error(), "platform int") {
+		t.Fatalf("expected a platform integer range error, got: %v", err)
+	}
+}
+
+func TestUnmarshalSSZBitsizeOverflowDoesNotPanic(t *testing.T) {
+	specs := map[string]any{"HUGE_BITS": uint64(math.MaxInt64)}
+	ds := NewDynSsz(specs)
+
+	err := ds.UnmarshalSSZ(&bitsizeOverflowContainer{}, []byte{})
+	if err == nil || !strings.Contains(err.Error(), "platform int") {
+		t.Fatalf("expected a platform integer range error, got: %v", err)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Mock types for DynamicMarshaler / DynamicSizer / DynamicUnmarshaler / DynamicHashRoot
 // ---------------------------------------------------------------------------

--- a/ssztypes/typecache.go
+++ b/ssztypes/typecache.go
@@ -1937,10 +1937,7 @@ func (tc *TypeCache) buildVectorDescriptor(desc *TypeDescriptor, runtimeType, sc
 			byteLen := sizeHints[0].Size
 			if sizeHints[0].Bits {
 				desc.BitSize = sizeHints[0].Size
-				if byteLen > math.MaxInt64-7 {
-					return sszutils.ErrPlatformOverflowFn("bit-size hint for vector type", uint64(byteLen))
-				}
-				byteLen = (byteLen + 7) / 8 // ceil up to the next multiple of 8
+				byteLen = int64((uint64(byteLen) + 7) / 8) // ceil up to the next multiple of 8
 			}
 			if byteLen > desc.Len {
 				return sszutils.NewSszErrorf(sszutils.ErrInvalidConstraint, "size hint for vector type is greater than the length of the array (%d > %d)", byteLen, desc.Len)
@@ -1951,10 +1948,7 @@ func (tc *TypeCache) buildVectorDescriptor(desc *TypeDescriptor, runtimeType, sc
 		byteLen := sizeHints[0].Size
 		if sizeHints[0].Bits {
 			desc.BitSize = sizeHints[0].Size
-			if byteLen > math.MaxInt64-7 {
-				return sszutils.ErrPlatformOverflowFn("bit-size hint for vector type", uint64(byteLen))
-			}
-			byteLen = (byteLen + 7) / 8 // ceil up to the next multiple of 8
+			byteLen = int64((uint64(byteLen) + 7) / 8) // ceil up to the next multiple of 8
 		}
 		desc.Len = byteLen
 	case len(sizeHints) > 0 && sizeHints[0].Expr != "":

--- a/ssztypes/typecache.go
+++ b/ssztypes/typecache.go
@@ -1937,6 +1937,9 @@ func (tc *TypeCache) buildVectorDescriptor(desc *TypeDescriptor, runtimeType, sc
 			byteLen := sizeHints[0].Size
 			if sizeHints[0].Bits {
 				desc.BitSize = sizeHints[0].Size
+				if byteLen > math.MaxInt64-7 {
+					return sszutils.ErrPlatformOverflowFn("bit-size hint for vector type", uint64(byteLen))
+				}
 				byteLen = (byteLen + 7) / 8 // ceil up to the next multiple of 8
 			}
 			if byteLen > desc.Len {
@@ -1948,6 +1951,9 @@ func (tc *TypeCache) buildVectorDescriptor(desc *TypeDescriptor, runtimeType, sc
 		byteLen := sizeHints[0].Size
 		if sizeHints[0].Bits {
 			desc.BitSize = sizeHints[0].Size
+			if byteLen > math.MaxInt64-7 {
+				return sszutils.ErrPlatformOverflowFn("bit-size hint for vector type", uint64(byteLen))
+			}
 			byteLen = (byteLen + 7) / 8 // ceil up to the next multiple of 8
 		}
 		desc.Len = byteLen

--- a/ssztypes/typecache_test.go
+++ b/ssztypes/typecache_test.go
@@ -911,6 +911,52 @@ func TestTypeCache_AnnotationSizeHintExceedsPlatformInt(t *testing.T) {
 	}
 }
 
+// A dynssz-bitsize expression resolving near math.MaxInt64 must error rather
+// than overflow int64 when converted to a byte length via (bits+7)/8: without
+// a guard, byteLen+7 wraps to a large negative number, silently caching a
+// negative desc.Len/desc.BitSize that panics on every later HashTreeRoot or
+// UnmarshalSSZ call against the type. Covers the slice/non-array vector branch.
+func TestTypeCache_BitsizeExpressionOverflowsByteConversion(t *testing.T) {
+	ds := &dummyDynamicSpecs{
+		specValues: map[string]uint64{"HUGE_BITS": uint64(math.MaxInt64)},
+	}
+	cache := NewTypeCache(ds)
+
+	type TestStruct struct {
+		BV []byte `ssz-type:"bitvector" dynssz-bitsize:"HUGE_BITS"`
+	}
+
+	_, err := cache.GetTypeDescriptor(reflect.TypeOf(TestStruct{}), nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error for dynssz-bitsize value overflowing the byte-length conversion")
+	}
+	if !errors.Is(err, sszutils.ErrPlatformOverflow) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// Same overflow, but on the fixed Go array (schema-length) branch of
+// buildVectorDescriptor, which converts bits to bytes independently of the
+// slice branch above.
+func TestTypeCache_BitsizeExpressionOverflowsByteConversion_Array(t *testing.T) {
+	ds := &dummyDynamicSpecs{
+		specValues: map[string]uint64{"HUGE_BITS": uint64(math.MaxInt64)},
+	}
+	cache := NewTypeCache(ds)
+
+	type TestStruct struct {
+		BV [8]byte `ssz-type:"bitvector" dynssz-bitsize:"HUGE_BITS"`
+	}
+
+	_, err := cache.GetTypeDescriptor(reflect.TypeOf(TestStruct{}), nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error for dynssz-bitsize value overflowing the byte-length conversion")
+	}
+	if !errors.Is(err, sszutils.ErrPlatformOverflow) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 // annotatedArrayDim carries an annotation whose first dimension is fixed by the
 // Go type. Tags are positional, so skipping it in both families is the only way
 // to reach the dimensions that do need a length and a limit.

--- a/ssztypes/typecache_test.go
+++ b/ssztypes/typecache_test.go
@@ -911,12 +911,9 @@ func TestTypeCache_AnnotationSizeHintExceedsPlatformInt(t *testing.T) {
 	}
 }
 
-// A dynssz-bitsize expression resolving near math.MaxInt64 must error rather
-// than overflow int64 when converted to a byte length via (bits+7)/8: without
-// a guard, byteLen+7 wraps to a large negative number, silently caching a
-// negative desc.Len/desc.BitSize that panics on every later HashTreeRoot or
-// UnmarshalSSZ call against the type. Covers the slice/non-array vector branch.
-func TestTypeCache_BitsizeExpressionOverflowsByteConversion(t *testing.T) {
+// A bitsize of math.MaxInt64 must convert to a positive byte length, not
+// overflow int64 into a negative one (bits-to-bytes: []byte field).
+func TestTypeCache_BitsizeMaxInt64NoOverflow(t *testing.T) {
 	ds := &dummyDynamicSpecs{
 		specValues: map[string]uint64{"HUGE_BITS": uint64(math.MaxInt64)},
 	}
@@ -926,19 +923,27 @@ func TestTypeCache_BitsizeExpressionOverflowsByteConversion(t *testing.T) {
 		BV []byte `ssz-type:"bitvector" dynssz-bitsize:"HUGE_BITS"`
 	}
 
-	_, err := cache.GetTypeDescriptor(reflect.TypeOf(TestStruct{}), nil, nil, nil)
-	if err == nil {
-		t.Fatal("expected error for dynssz-bitsize value overflowing the byte-length conversion")
+	desc, err := cache.GetTypeDescriptor(reflect.TypeOf(TestStruct{}), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if !errors.Is(err, sszutils.ErrPlatformOverflow) {
-		t.Errorf("unexpected error: %v", err)
+
+	const wantByteLen = int64(1152921504606846976) // ceil(math.MaxInt64 / 8), computed in the uint64 domain
+
+	field := desc.ContainerDesc.Fields[0]
+	if field.Type.BitSize != math.MaxInt64 {
+		t.Errorf("expected BitSize %d, got %d", int64(math.MaxInt64), field.Type.BitSize)
+	}
+	if field.Type.Len != wantByteLen {
+		t.Errorf("expected Len %d, got %d", wantByteLen, field.Type.Len)
+	}
+	if field.Type.Len < 0 {
+		t.Fatal("Len went negative: the byte-length conversion overflowed")
 	}
 }
 
-// Same overflow, but on the fixed Go array (schema-length) branch of
-// buildVectorDescriptor, which converts bits to bytes independently of the
-// slice branch above.
-func TestTypeCache_BitsizeExpressionOverflowsByteConversion_Array(t *testing.T) {
+// Same as above, but for the fixed Go array field variant.
+func TestTypeCache_BitsizeMaxInt64NoOverflowArray(t *testing.T) {
 	ds := &dummyDynamicSpecs{
 		specValues: map[string]uint64{"HUGE_BITS": uint64(math.MaxInt64)},
 	}
@@ -950,9 +955,9 @@ func TestTypeCache_BitsizeExpressionOverflowsByteConversion_Array(t *testing.T) 
 
 	_, err := cache.GetTypeDescriptor(reflect.TypeOf(TestStruct{}), nil, nil, nil)
 	if err == nil {
-		t.Fatal("expected error for dynssz-bitsize value overflowing the byte-length conversion")
+		t.Fatal("expected error: converted byte length exceeds the 8-byte backing array")
 	}
-	if !errors.Is(err, sszutils.ErrPlatformOverflow) {
+	if !errors.Is(err, sszutils.ErrInvalidConstraint) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/ssztypes/typecache_test.go
+++ b/ssztypes/typecache_test.go
@@ -913,7 +913,13 @@ func TestTypeCache_AnnotationSizeHintExceedsPlatformInt(t *testing.T) {
 
 // A bitsize of math.MaxInt64 must convert to a positive byte length, not
 // overflow int64 into a negative one (bits-to-bytes: []byte field).
+// 64-bit only: on 32-bit, math.MaxInt64 already exceeds math.MaxInt and is
+// rejected earlier by ResolveSpecValue's platform-range check, before ever
+// reaching the conversion this test targets.
 func TestTypeCache_BitsizeMaxInt64NoOverflow(t *testing.T) {
+	if math.MaxInt == math.MaxInt32 {
+		t.Skip("requires 64-bit platform")
+	}
 	ds := &dummyDynamicSpecs{
 		specValues: map[string]uint64{"HUGE_BITS": uint64(math.MaxInt64)},
 	}
@@ -944,6 +950,9 @@ func TestTypeCache_BitsizeMaxInt64NoOverflow(t *testing.T) {
 
 // Same as above, but for the fixed Go array field variant.
 func TestTypeCache_BitsizeMaxInt64NoOverflowArray(t *testing.T) {
+	if math.MaxInt == math.MaxInt32 {
+		t.Skip("requires 64-bit platform")
+	}
 	ds := &dummyDynamicSpecs{
 		specValues: map[string]uint64{"HUGE_BITS": uint64(math.MaxInt64)},
 	}


### PR DESCRIPTION
If someone configures a `dynssz-bitsize` (or `ssz-bitsize`) spec value that is very close to `math.MaxInt64`, the library was crashing with a panic instead of returning a proper error.

The root cause is simple, internally we convert bit size to byte size using `(byteLen + 7) / 8`. If `byteLen` is already near the `max int64` value, adding 7 overflows and wraps around to a large negative number. This negative length then gets cached permanently in the type descriptor, so every future call to HashTreeRoot or UnmarshalSSZ for that type would panic (slice bounds out of range, unsafe.Slice: len out of range).

#### How it is resolved

Added a bounds check before doing the +7 conversion at both places this math happens (fixed-array bitvector and slice/vector bitvector). Now, if the value would overflow, it fails cleanly with a platform-overflow error instead of silently producing a bad negative length.