### PR TITLE
fix: data race in treeproof.Node hash caching under concurrent Prove/Hash

### DIFF
--- a/dynssz.go
+++ b/dynssz.go
@@ -1179,9 +1179,10 @@ func (d *DynSsz) HashTreeRootWith(source any, hh sszutils.HashWalker, opts ...Ca
 // Note: For progressive containers (with ssz-index tags), the tree structure will be
 // progressive rather than binary, which affects the generalized indices of fields.
 //
-// The returned tree lazily caches node hashes on first proof, so it is not safe
-// to share across goroutines before it is finalized. Call tree.Hash() once before
-// handing it to concurrent Prove/ProveMulti callers.
+// The returned tree computes and saves node hashes as they're needed. This
+// is done safely, so the tree can be shared with and used by multiple
+// goroutines at the same time, whether or not Hash() has been called on it
+// yet.
 func (d *DynSsz) GetTree(source any, opts ...CallOption) (*treeproof.Node, error) {
 	if source == nil {
 		return nil, sszutils.NewSszError(sszutils.ErrInvalidValueRange, "source must not be nil")

--- a/treeproof/tree.go
+++ b/treeproof/tree.go
@@ -148,11 +148,19 @@ func (c *CompressedMultiproof) Decompress() *Multiproof {
 //
 // The isEmpty field indicates whether this is a "zero" node used for padding
 // incomplete trees to maintain proper binary tree structure.
+//
+// Multiple goroutines: a leaf's value never changes after the node is
+// created, so reading it is always safe. A branch node's value, on the other
+// hand, is computed the first time it's needed and then reused (see
+// hashNode) — if two goroutines both need it at the same time, they could
+// try to compute and save it at the same time too. mu prevents that: it's a
+// small lock that makes sure only one goroutine writes value at a time.
 type Node struct {
-	left    *Node  // Left child node (nil for leaves)
-	right   *Node  // Right child node (nil for leaves)
-	isEmpty bool   // True if this is a zero-padding node
-	value   []byte // 32-byte value (data for leaves, hash for branches)
+	left    *Node      // Left child node (nil for leaves)
+	right   *Node      // Right child node (nil for leaves)
+	isEmpty bool       // True if this is a zero-padding node
+	value   []byte     // 32-byte value (data for leaves, hash for branches)
+	mu      sync.Mutex // keeps value safe to read/write from multiple goroutines
 }
 
 var (
@@ -677,12 +685,19 @@ func (n *Node) IsEmpty() bool {
 	return n.isEmpty
 }
 
-// Value returns a copy of the 32-byte value stored in this node. A copy is
+// Value returns a copy of the 32-byte value stored in this node, or nil if a
+// branch node's value has not been computed yet (see Hash). A copy is
 // returned because empty (zero-padding) nodes alias the process-wide zero-hash
 // table and cached empty nodes are shared across trees; handing out the raw
 // slice would let a caller's mutation corrupt every other tree and root.
+//
+// We lock before reading value because another goroutine might be computing
+// and saving it at this exact moment (see the Node.mu comment).
 func (n *Node) Value() []byte {
-	return bytes.Clone(n.value)
+	n.mu.Lock()
+	v := n.value
+	n.mu.Unlock()
+	return bytes.Clone(v)
 }
 
 func getEmptyNode(depth int) *Node {
@@ -700,6 +715,8 @@ func hashNode(n *Node) []byte {
 	}
 
 	if n.left == nil && n.right == nil {
+		// Leaf node: its value was set once when the node was created and
+		// never changes after that, so it's always safe to read.
 		return n.value
 	}
 
@@ -707,34 +724,55 @@ func hashNode(n *Node) []byte {
 		panic("Tree incomplete")
 	}
 
-	if n.value != nil {
+	// Branch node: its value is computed the first time it's needed and
+	// reused after that. More than one goroutine could ask for it at the
+	// same time, so we lock while reading it instead of touching the field
+	// directly.
+	n.mu.Lock()
+	cached := n.value
+	n.mu.Unlock()
+	if cached != nil {
 		// This value has already been hashed, don't do the work again.
-		return n.value
+		return cached
 	}
 
 	if n.right == nil {
 		panic("Tree incomplete")
 	}
 
+	// The actual hashing happens without the lock held, so one goroutine
+	// computing a big subtree doesn't block others from working on
+	// different, unrelated nodes. Each node has its own lock, so this is
+	// also safe from deadlocks.
+	var result []byte
 	if n.right.isEmpty {
-		result := hashPair(hashNode(n.left), n.right.value)
-		n.value = result // Set the hash result on each node so that proofs can be generated for any level
-		return result
+		result = hashPair(hashNode(n.left), n.right.value)
+	} else {
+		result = hashPair(hashNode(n.left), hashNode(n.right))
 	}
 
-	result := hashPair(hashNode(n.left), hashNode(n.right))
-	n.value = result
+	n.mu.Lock()
+	if n.value == nil {
+		// Save the result so we don't redo this work next time.
+		n.value = result
+	} else {
+		// Another goroutine already finished computing and saving this same
+		// value while we were working. Use that saved copy instead of ours
+		// (both are the same hash either way) so everyone ends up agreeing
+		// on the exact same value for this node.
+		result = n.value
+	}
+	n.mu.Unlock()
 	return result
 }
 
 // Prove returns a list of sibling values and hashes needed
 // to compute the root hash for a given general index.
 //
-// Thread-safety: Prove lazily computes and caches intermediate node hashes on
-// first use, so it is not safe to call concurrently on a freshly built,
-// unfinalized tree. Finalize the tree once by calling Hash() before sharing it
-// across goroutines; afterwards concurrent Prove/ProveMulti calls only read the
-// cached hashes.
+// Multiple goroutines: Prove computes and saves node hashes as it needs
+// them. That work is protected by a lock (see hashNode/Node.mu), so it's
+// safe to call Prove, ProveMulti, Hash, and Value on the same tree from
+// several goroutines at once, even if Hash() hasn't been called yet.
 func (n *Node) Prove(index int) (*Proof, error) {
 	if index < 1 {
 		return nil, fmt.Errorf("invalid generalized index %d (must be >= 1)", index)
@@ -783,11 +821,12 @@ func (n *Node) Prove(index int) (*Proof, error) {
 	}
 
 	proof.Hashes = hashes
-	if cur.value == nil {
-		// This is an intermediate node without a value; add the hash to it so that we're providing a suitable leaf value.
-		cur.value = hashNode(cur)
-	}
-	proof.Leaf = bytes.Clone(cur.value)
+	// We use hashNode(cur) here instead of reading cur.value directly. cur
+	// might be a node whose value hasn't been computed yet, and hashNode
+	// knows how to compute it if needed, or safely read it if it's already
+	// saved. Reading cur.value directly would skip that safety and could
+	// clash with another goroutine computing the same value at the same time.
+	proof.Leaf = bytes.Clone(hashNode(cur))
 
 	return proof, nil
 }
@@ -797,8 +836,8 @@ func (n *Node) Prove(index int) (*Proof, error) {
 // hashes needed to reconstruct the root. Returns an error if any index cannot
 // be found in the tree.
 //
-// Thread-safety: like Prove, this lazily caches node hashes, so finalize the tree
-// with Hash() before sharing it across goroutines (see Prove).
+// Multiple goroutines: like Prove, this is safe to call from several
+// goroutines at once, even before Hash() has been called (see Prove).
 func (n *Node) ProveMulti(indices []int) (*Multiproof, error) {
 	for _, gi := range indices {
 		if gi < 1 {

--- a/treeproof/tree_test.go
+++ b/treeproof/tree_test.go
@@ -1536,8 +1536,8 @@ func TestConcurrentProveOnUnfinalizedTree(t *testing.T) {
 				errCh <- fmt.Errorf("goroutine %d: Prove(%d): %v", g, leafIdx, err)
 				return
 			}
-			if ok, err := VerifyProof(wantRoot, proof); err != nil || !ok {
-				errCh <- fmt.Errorf("goroutine %d: VerifyProof(%d) = %v, %v; want true, nil", g, leafIdx, ok, err)
+			if ok, verifyErr := VerifyProof(wantRoot, proof); verifyErr != nil || !ok {
+				errCh <- fmt.Errorf("goroutine %d: VerifyProof(%d) = %v, %v; want true, nil", g, leafIdx, ok, verifyErr)
 				return
 			}
 
@@ -1548,8 +1548,8 @@ func TestConcurrentProveOnUnfinalizedTree(t *testing.T) {
 				errCh <- fmt.Errorf("goroutine %d: Prove(%d): %v", g, intIdx, err)
 				return
 			}
-			if ok, err := VerifyProof(wantRoot, intProof); err != nil || !ok {
-				errCh <- fmt.Errorf("goroutine %d: VerifyProof(%d) = %v, %v; want true, nil", g, intIdx, ok, err)
+			if ok, verifyErr := VerifyProof(wantRoot, intProof); verifyErr != nil || !ok {
+				errCh <- fmt.Errorf("goroutine %d: VerifyProof(%d) = %v, %v; want true, nil", g, intIdx, ok, verifyErr)
 				return
 			}
 
@@ -1560,8 +1560,8 @@ func TestConcurrentProveOnUnfinalizedTree(t *testing.T) {
 				errCh <- fmt.Errorf("goroutine %d: ProveMulti(%v): %v", g, multiIndices, err)
 				return
 			}
-			if ok, err := VerifyMultiproof(wantRoot, multiProof.Hashes, multiProof.Leaves, multiProof.Indices); err != nil || !ok {
-				errCh <- fmt.Errorf("goroutine %d: VerifyMultiproof(%v) = %v, %v; want true, nil", g, multiIndices, ok, err)
+			if ok, verifyErr := VerifyMultiproof(wantRoot, multiProof.Hashes, multiProof.Leaves, multiProof.Indices); verifyErr != nil || !ok {
+				errCh <- fmt.Errorf("goroutine %d: VerifyMultiproof(%v) = %v, %v; want true, nil", g, multiIndices, ok, verifyErr)
 				return
 			}
 

--- a/treeproof/tree_test.go
+++ b/treeproof/tree_test.go
@@ -9,6 +9,8 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"errors"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/pk910/dynamic-ssz/hasher"
@@ -1440,8 +1442,9 @@ func TestTreeEdgeCases(t *testing.T) {
 }
 
 func TestProveIntermediateNodeSetsValue(t *testing.T) {
-	// Create a fresh tree and prove an intermediate node FIRST
-	// (before any Hash() calls) to hit the cur.value == nil branch
+	// Create a fresh tree and prove an intermediate node FIRST (before any
+	// Hash() calls), so Prove must compute-and-cache its value via hashNode
+	// rather than reading an already-cached one.
 	chunks := [][]byte{
 		sum256ToBytes([]byte("a")),
 		sum256ToBytes([]byte("b")),
@@ -1464,6 +1467,123 @@ func TestProveIntermediateNodeSetsValue(t *testing.T) {
 	}
 	if len(proof.Leaf) != 32 {
 		t.Fatalf("expected 32-byte leaf, got %d bytes", len(proof.Leaf))
+	}
+}
+
+// TestConcurrentProveOnUnfinalizedTree builds a tree and, WITHOUT calling
+// Hash() on it first, immediately hands it to many goroutines that all call
+// Prove/ProveMulti/Hash/Value on it at the same time.
+//
+// This test needs `-race` to actually catch a data race (this repo's CI and
+// Makefile already run tests with -race). Without -race, it still checks
+// that every goroutine computed the correct, matching result, but a race
+// that doesn't happen to corrupt any value during that particular run would
+// go unnoticed.
+func TestConcurrentProveOnUnfinalizedTree(t *testing.T) {
+	const numLeaves = 32 // 32 leaves -> a few levels of shared parent nodes for goroutines to contend on
+
+	chunks := make([][]byte, numLeaves)
+	for i := range chunks {
+		chunks[i] = sum256ToBytes([]byte{byte(i)})
+	}
+
+	// Build a second, separate tree first and hash it normally (single
+	// goroutine, no concurrency) to get the correct, known-good root to
+	// compare every goroutine's result against.
+	refTree, err := TreeFromChunks(chunks)
+	if err != nil {
+		t.Fatalf("failed to build reference tree: %v", err)
+	}
+	wantRoot := refTree.Hash()
+
+	// This is the tree the goroutines below will actually hammer on. It is
+	// deliberately left un-hashed so its node values still need to be
+	// computed while multiple goroutines are using it.
+	tree, err := TreeFromChunks(chunks)
+	if err != nil {
+		t.Fatalf("failed to build tree: %v", err)
+	}
+
+	leafIndices := make([]int, numLeaves)
+	for i := range leafIndices {
+		leafIndices[i] = numLeaves + i
+	}
+	// A few positions closer to the root. Having every goroutine's Prove/
+	// Value calls repeatedly land on these same few nodes (instead of each
+	// goroutine working on its own separate part of the tree) is what
+	// creates the contention needed to trigger the race.
+	internalIndices := []int{1, 2, 3, 4, 5, 6, 7}
+
+	const numGoroutines = 32
+	var wg sync.WaitGroup
+	errCh := make(chan error, numGoroutines)
+
+	for g := range numGoroutines {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+
+			// Compute the whole tree's root hash.
+			if root := tree.Hash(); !bytes.Equal(root, wantRoot) {
+				errCh <- fmt.Errorf("goroutine %d: Hash() = %x, want %x", g, root, wantRoot)
+				return
+			}
+
+			// Prove a single leaf, then check the proof against the correct root.
+			leafIdx := leafIndices[g%numLeaves]
+			proof, err := tree.Prove(leafIdx)
+			if err != nil {
+				errCh <- fmt.Errorf("goroutine %d: Prove(%d): %v", g, leafIdx, err)
+				return
+			}
+			if ok, err := VerifyProof(wantRoot, proof); err != nil || !ok {
+				errCh <- fmt.Errorf("goroutine %d: VerifyProof(%d) = %v, %v; want true, nil", g, leafIdx, ok, err)
+				return
+			}
+
+			// Prove a node closer to the root, shared by several goroutines at once.
+			intIdx := internalIndices[g%len(internalIndices)]
+			intProof, err := tree.Prove(intIdx)
+			if err != nil {
+				errCh <- fmt.Errorf("goroutine %d: Prove(%d): %v", g, intIdx, err)
+				return
+			}
+			if ok, err := VerifyProof(wantRoot, intProof); err != nil || !ok {
+				errCh <- fmt.Errorf("goroutine %d: VerifyProof(%d) = %v, %v; want true, nil", g, intIdx, ok, err)
+				return
+			}
+
+			// Prove several leaves at once with a single multiproof call.
+			multiIndices := []int{leafIndices[g%numLeaves], leafIndices[(g+1)%numLeaves], leafIndices[(g+7)%numLeaves]}
+			multiProof, err := tree.ProveMulti(multiIndices)
+			if err != nil {
+				errCh <- fmt.Errorf("goroutine %d: ProveMulti(%v): %v", g, multiIndices, err)
+				return
+			}
+			if ok, err := VerifyMultiproof(wantRoot, multiProof.Hashes, multiProof.Leaves, multiProof.Indices); err != nil || !ok {
+				errCh <- fmt.Errorf("goroutine %d: VerifyMultiproof(%v) = %v, %v; want true, nil", g, multiIndices, ok, err)
+				return
+			}
+
+			// Also read a node's value directly through Value(), the other
+			// place that reads this same, possibly-still-being-computed field.
+			node, err := tree.Get(internalIndices[g%len(internalIndices)])
+			if err != nil {
+				errCh <- fmt.Errorf("goroutine %d: Get: %v", g, err)
+				return
+			}
+			// Value() is allowed to return nil here if this node's hash
+			// hasn't been computed by anyone yet -- that's not a failure.
+			// What matters is that reading it never races with another
+			// goroutine computing and saving it; -race is what checks that.
+			_ = node.Value()
+		}(g)
+	}
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Error(err)
 	}
 }
 


### PR DESCRIPTION
#### What was the issue

When you build a Merkle tree with `GetTree()` and then use it from multiple goroutines at the same time - calling `Prove`, `ProveMulti`, `Hash`, or `Value` - before `Hash()` had been called even once on it, we were getting a data race.

The reason is simple – each tree node caches its computed hash the first time it's needed, so the next call doesn't have to recompute it. That caching was just a plain field read and write (`if n.value == nil { n.value = compute() }`), with no protection. So if two goroutines both reached the same node at the same time, both would try to compute and save its hash at the same moment - Go's race detector correctly flags this as unsafe, even though both goroutines would compute the exact same correct hash.

There was also a second, separate place (inside Prove) doing the same kind of unsafe read/write, duplicating work hashNode was already doing.

#### How it is resolved

Added a small lock (`sync.Mutex`) to each tree node, used only around reading or saving that node's cached hash. The lock is released before the actual hashing work happens, so it's never held during expensive computation - this also means it can't deadlock, since every node has its own separate lock.

Removed the second, redundant unsafe write in `Prove()` - it was doing the same job the lock-protected code now does correctly, so it just goes through that instead.