### PR TITLE
GetProofs: direct Merkle proof generation without tree materialization

### DIFF
--- a/dynssz.go
+++ b/dynssz.go
@@ -6,6 +6,7 @@
 package dynssz
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"log/slog"
@@ -1195,6 +1196,10 @@ func (d *DynSsz) GetTree(source any, opts ...CallOption) (*treeproof.Node, error
 	return w.Node(), nil
 }
 
+// nativeBatchHashFn hashes with the standard library sha256, serving tree
+// finalization for instances configured with WithNoFastHash.
+var nativeBatchHashFn = hasher.NativeHashWrapperFactory(sha256.New)
+
 // ValidateType validates whether a given type is compatible with SSZ encoding/decoding.
 //
 // This method performs a comprehensive analysis of the provided type to determine if it can be
@@ -1266,4 +1271,75 @@ func (d *DynSsz) ValidateType(t reflect.Type, opts ...CallOption) error {
 	}
 
 	return nil
+}
+
+// GetProofs generates Merkle proofs for the given generalized indices
+// without materializing the value's proof tree. The value is hashed through
+// the regular optimized hashing path while a proof capture shadows just the
+// subtrees the requested paths descend into, so the cost stays close to a
+// plain HashTreeRoot and memory stays bounded by the retained proof paths
+// (plus any subtree whose layout depends on runtime data, which is kept
+// whole). All SSZ shapes are supported, and the walk delegates to generated
+// code exactly like HashTreeRoot does.
+//
+// The proofs are returned in the order of the given indices and verify
+// against the value's HashTreeRoot via treeproof.VerifyProof.
+func (d *DynSsz) GetProofs(source any, gindices []int, opts ...CallOption) ([]*treeproof.Proof, error) {
+	if source == nil {
+		return nil, sszutils.NewSszError(sszutils.ErrInvalidValueRange, "source must not be nil")
+	}
+
+	cfg := applyCallOptions(opts)
+	sourceType := reflect.TypeOf(source)
+	schemaType := d.resolveSchemaType(sourceType, cfg)
+
+	sourceTypeDesc, err := d.typeCache.GetTypeDescriptorWithSchema(sourceType, schemaType, nil, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	sched, err := treeproof.BuildProofSchedule(sourceTypeDesc, gindices)
+	if err != nil {
+		return nil, err
+	}
+
+	var pool *hasher.HasherPool
+	if d.options.NoFastHash {
+		pool = &hasher.DefaultHasherPool
+	} else {
+		pool = &hasher.FastHasherPool
+	}
+	hh := pool.Get()
+	defer pool.Put(hh)
+	if d.options.AsyncHashing {
+		hh.SetAsyncHashing(true)
+	}
+
+	// NoFastHash keeps its promise for the proof capture too: sibling-range
+	// reduction then runs on the native Go sha256 implementation.
+	var proofHashFn hasher.HashFn
+	if d.options.NoFastHash {
+		proofHashFn = nativeBatchHashFn
+	}
+
+	w := treeproof.NewProofHasher(sched, hh, proofHashFn)
+	err = d.HashTreeRootWith(source, w, opts...)
+	if err != nil {
+		return nil, err
+	}
+	tree, err := w.ProofTree()
+	if err != nil {
+		return nil, err
+	}
+
+	proofs := make([]*treeproof.Proof, len(gindices))
+	for i, gindex := range gindices {
+		proof, err := tree.Prove(gindex)
+		if err != nil {
+			return nil, err
+		}
+		proofs[i] = proof
+	}
+
+	return proofs, nil
 }

--- a/hasher/hasher.go
+++ b/hasher/hasher.go
@@ -530,6 +530,18 @@ func (h *Hasher) CurrentIndex() int {
 	return len(h.buf)
 }
 
+// BufferSince returns the buffer contents from the given index (a value
+// previously returned by StartTree) to the current position, draining any
+// background reduction overlapping the region first. The returned slice is
+// only valid until the next walker operation. Intended for stream observers
+// reading a non-incremental scope's completed chunks: incremental scopes
+// collapse and defer within their region, so their contents are not the
+// plain chunk sequence this returns.
+func (h *Hasher) BufferSince(indx int) []byte {
+	h.drainJobsFor(indx)
+	return h.buf[indx:]
+}
+
 // Collapse hints the hasher to collapse accumulated chunks in the current
 // layer if the batch threshold is reached. This is a no-op for
 // non-incremental layers or when no layer is active.

--- a/hasher/hasher_test.go
+++ b/hasher/hasher_test.go
@@ -2172,3 +2172,15 @@ func TestZeroHashAccessorsSelfInitialize(t *testing.T) {
 		t.Fatalf("GetZeroHashLevel = (%d, %v); want (2, true)", lvl, ok)
 	}
 }
+
+// BufferSince exposes a non-incremental scope's completed chunks.
+func TestBufferSince(t *testing.T) {
+	h := NewHasher()
+	idx := h.StartTree(sszutils.TreeTypeNone)
+	h.PutUint64(7)
+	h.PutUint64(9)
+	region := h.BufferSince(idx)
+	if len(region) != 64 || region[0] != 7 || region[32] != 9 {
+		t.Fatalf("BufferSince = %x", region)
+	}
+}

--- a/proofs_test.go
+++ b/proofs_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the dynamic-ssz library.
+
+package dynssz
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/pk910/dynamic-ssz/treeproof"
+)
+
+type proofsEntryInner struct {
+	A uint64
+	B [32]byte `ssz-size:"32"`
+}
+
+type proofsEntryContainer struct {
+	Items []*proofsEntryInner `ssz-max:"8"`
+	Count uint64
+}
+
+// GetProofs must return verifiable proofs matching the tree-based path; the
+// reflection engine itself is tested in the reflection package.
+func TestGetProofs(t *testing.T) {
+	ds := NewDynSsz(nil)
+	source := &proofsEntryContainer{
+		Items: []*proofsEntryInner{{A: 1, B: [32]byte{1}}, {A: 2, B: [32]byte{2}}},
+		Count: 2,
+	}
+
+	tree, err := ds.GetTree(source)
+	if err != nil {
+		t.Fatalf("GetTree: %v", err)
+	}
+	root := tree.Hash()
+
+	// Items element 0: field 0 of 2 slots -> chunks side -> slot 0 of 8.
+	gindices := []int{1, 2*2*8 + 0, 3}
+	proofs, err := ds.GetProofs(source, gindices)
+	if err != nil {
+		t.Fatalf("GetProofs: %v", err)
+	}
+	if len(proofs) != len(gindices) {
+		t.Fatalf("got %d proofs, want %d", len(proofs), len(gindices))
+	}
+	for i, gindex := range gindices {
+		want, proveErr := tree.Prove(gindex)
+		if proveErr != nil {
+			t.Fatalf("tree.Prove(%d): %v", gindex, proveErr)
+		}
+		if proofs[i].Index != gindex || !bytes.Equal(proofs[i].Leaf, want.Leaf) {
+			t.Fatalf("gindex %d: proof mismatch", gindex)
+		}
+		if ok, verifyErr := treeproof.VerifyProof(root, proofs[i]); verifyErr != nil || !ok {
+			t.Fatalf("VerifyProof(%d) = %v, %v", gindex, ok, verifyErr)
+		}
+	}
+}
+
+func TestGetProofsInvalidInput(t *testing.T) {
+	ds := NewDynSsz(nil)
+
+	if _, err := ds.GetProofs(nil, []int{1}); err == nil {
+		t.Fatal("GetProofs(nil) unexpectedly succeeded")
+	}
+	if _, err := ds.GetProofs(&proofsEntryContainer{}, []int{0}); err == nil {
+		t.Fatal("GetProofs with gindex 0 unexpectedly succeeded")
+	}
+	if _, err := ds.GetProofs(make(chan int), []int{1}); err == nil {
+		t.Fatal("GetProofs with unsupported type unexpectedly succeeded")
+	}
+}

--- a/treeproof/getproofs_test.go
+++ b/treeproof/getproofs_test.go
@@ -1,0 +1,555 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the dynamic-ssz library.
+
+package treeproof_test
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	dynssz "github.com/pk910/dynamic-ssz"
+	"github.com/pk910/dynamic-ssz/sszutils"
+	"github.com/pk910/dynamic-ssz/treeproof"
+)
+
+type proofTestInner struct {
+	A uint64
+	B [32]byte `ssz-size:"32"`
+}
+
+type proofTestContainer struct {
+	F0  uint64
+	F1  [48]byte          `ssz-size:"48"`
+	F2  []*proofTestInner `ssz-max:"10"`
+	F3  []uint64          `ssz-max:"100"`
+	F4  []byte            `ssz-max:"70"`
+	F5  [][32]byte        `ssz-size:"4,32"`
+	F6  []uint64          `ssz-size:"6"`
+	F7  [5]byte           `ssz-size:"5"`
+	F8  bool
+	F9  []proofTestInner  `ssz-max:"3"`
+	F10 []uint16          `ssz-max:"20"`
+	F11 []uint32          `ssz-max:"20"`
+	F12 []bool            `ssz-max:"20"`
+	F13 string            `ssz-max:"64"`
+	F14 [2]proofTestInner `ssz-size:"2"`
+	F15 *proofTestInner
+	F16 [][]byte `ssz-type:"?,uint128" ssz-size:"?,16" ssz-max:"4"`
+	F17 [][]byte `ssz-type:"?,uint256" ssz-size:"?,32" ssz-max:"4"`
+}
+
+func proofTestValue() *proofTestContainer {
+	v := &proofTestContainer{
+		F0:  0x1122334455667788,
+		F3:  []uint64{9, 8, 7, 6, 5, 4, 3, 2, 1},
+		F4:  bytes.Repeat([]byte{0xaa, 0xbb}, 33),
+		F6:  []uint64{60, 61, 62, 63, 64, 65},
+		F7:  [5]byte{1, 2, 3, 4, 5},
+		F8:  true,
+		F10: []uint16{10, 11, 12},
+		F11: []uint32{20, 21},
+		F12: []bool{true, false, true},
+		F13: "a string that spans multiple chunks of merkleized data",
+	}
+	for i := range v.F1 {
+		v.F1[i] = byte(i + 1)
+	}
+	for i := range 3 {
+		inner := &proofTestInner{A: uint64(i + 100)}
+		for j := range inner.B {
+			inner.B[j] = byte(i*32 + j)
+		}
+		v.F2 = append(v.F2, inner)
+	}
+	v.F5 = make([][32]byte, 4)
+	for i := range v.F5 {
+		for j := range v.F5[i] {
+			v.F5[i][j] = byte(i + j)
+		}
+	}
+	v.F14[0] = proofTestInner{A: 200}
+	v.F14[1] = proofTestInner{A: 201}
+	v.F16 = [][]byte{bytes.Repeat([]byte{1}, 16), bytes.Repeat([]byte{2}, 16), bytes.Repeat([]byte{3}, 16)}
+	v.F17 = [][]byte{bytes.Repeat([]byte{4}, 32)}
+	return v
+}
+
+// proofTestSetup builds the reference full proof tree and a proof generator
+// for a source value.
+func proofTestSetup(t *testing.T, ds *dynssz.DynSsz, source any) (*treeproof.Node, []byte, func(gindices []int) ([]*treeproof.Proof, error)) {
+	t.Helper()
+
+	tree, err := ds.GetTree(source)
+	if err != nil {
+		t.Fatalf("GetTree: %v", err)
+	}
+	root := tree.Hash()
+
+	getProofs := func(gindices []int) ([]*treeproof.Proof, error) {
+		return ds.GetProofs(source, gindices)
+	}
+
+	return tree, root, getProofs
+}
+
+// collectGindices walks the proof tree and returns every reachable
+// generalized index, including zero-padding nodes.
+func collectGindices(node *treeproof.Node, gindex int, gindices *[]int) {
+	if node == nil {
+		return
+	}
+	*gindices = append(*gindices, gindex)
+	collectGindices(node.Left(), gindex*2, gindices)
+	collectGindices(node.Right(), gindex*2+1, gindices)
+}
+
+func assertProofEqual(t *testing.T, gindex int, want, got *treeproof.Proof) {
+	t.Helper()
+	if got.Index != gindex {
+		t.Fatalf("gindex %d: result gindex = %d", gindex, got.Index)
+	}
+	if !bytes.Equal(got.Leaf, want.Leaf) {
+		t.Fatalf("gindex %d: leaf = %x, want %x", gindex, got.Leaf, want.Leaf)
+	}
+	if len(got.Hashes) != len(want.Hashes) {
+		t.Fatalf("gindex %d: %d hashes, want %d", gindex, len(got.Hashes), len(want.Hashes))
+	}
+	for i := range got.Hashes {
+		if !bytes.Equal(got.Hashes[i], want.Hashes[i]) {
+			t.Fatalf("gindex %d: hash %d = %x, want %x", gindex, i, got.Hashes[i], want.Hashes[i])
+		}
+	}
+}
+
+// GetProofs must produce byte-identical proofs to the tree-based Prove for
+// every generalized index of the tree, both individually and in one shared
+// batch.
+func TestGetProofsMatchesTree(t *testing.T) {
+	tests := []struct {
+		name   string
+		source *proofTestContainer
+	}{
+		{"filled", proofTestValue()},
+		{"zero value", &proofTestContainer{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds := dynssz.NewDynSsz(nil)
+			tree, root, getProofs := proofTestSetup(t, ds, tt.source)
+
+			var gindices []int
+			collectGindices(tree, 1, &gindices)
+			if len(gindices) < 50 {
+				t.Fatalf("expected a richer tree, got %d nodes", len(gindices))
+			}
+
+			for _, gindex := range gindices {
+				want, proveErr := tree.Prove(gindex)
+				if proveErr != nil {
+					t.Fatalf("tree.Prove(%d): %v", gindex, proveErr)
+				}
+				got, proofErr := getProofs([]int{gindex})
+				if proofErr != nil {
+					t.Fatalf("GetProofs(%d): %v", gindex, proofErr)
+				}
+				assertProofEqual(t, gindex, want, got[0])
+
+				if ok, verifyErr := treeproof.VerifyProof(root, got[0]); verifyErr != nil || !ok {
+					t.Fatalf("VerifyProof(%d) = %v, %v", gindex, ok, verifyErr)
+				}
+			}
+
+			// The whole set in one batch shares paths but must match too.
+			batch, err := getProofs(gindices)
+			if err != nil {
+				t.Fatalf("batched GetProofs: %v", err)
+			}
+			for i, gindex := range gindices {
+				want, proveErr := tree.Prove(gindex)
+				if proveErr != nil {
+					t.Fatalf("tree.Prove(%d): %v", gindex, proveErr)
+				}
+				assertProofEqual(t, gindex, want, batch[i])
+			}
+		})
+	}
+}
+
+// Paths with no nodes must be rejected: below zero-padding chunks, below
+// data chunks, below a list length chunk, and invalid indices.
+func TestGetProofsInvalidPaths(t *testing.T) {
+	ds := dynssz.NewDynSsz(nil)
+	source := proofTestValue()
+	tree, _, getProofs := proofTestSetup(t, ds, source)
+
+	var gindices []int
+	collectGindices(tree, 1, &gindices)
+	maxGindex := 0
+	for _, gindex := range gindices {
+		if gindex > maxGindex {
+			maxGindex = gindex
+		}
+	}
+
+	// Deep below any existing node; below F4's first data chunk (field 4 of
+	// 32 slots, chunks side, first chunk); below F2's length chunk.
+	f4Chunk := (32+4)*2*4 + 0
+	f2Length := (32+2)*2 + 1
+	for _, gindex := range []int{maxGindex * 1024, f4Chunk * 2, f2Length * 2} {
+		if _, err := tree.Prove(gindex); err == nil {
+			t.Fatalf("tree.Prove(%d) unexpectedly succeeded", gindex)
+		}
+		if _, err := getProofs([]int{gindex}); err == nil {
+			t.Fatalf("GetProofs(%d) unexpectedly succeeded", gindex)
+		}
+	}
+
+	if _, err := getProofs([]int{0}); err == nil {
+		t.Fatal("GetProofs(0) unexpectedly succeeded")
+	}
+}
+
+type proofTestBitlist struct {
+	Bits []byte `ssz-type:"bitlist" ssz-max:"50"`
+}
+
+type proofTestProgressive struct {
+	Slot   uint64   `ssz-index:"0"`
+	Root   [32]byte `ssz-index:"1" ssz-size:"32"`
+	Values []uint64 `ssz-index:"3" ssz-max:"64"`
+}
+
+type proofTestProgList struct {
+	L []uint64 `ssz-type:"progressive-list" ssz-max:"4096"`
+	B []byte   `ssz-type:"progressive-bitlist" ssz-max:"4096"`
+}
+
+type proofTestUnionDesc struct {
+	VarA proofTestInner
+	VarB proofTestBadList
+}
+
+type proofTestUnionHolder struct {
+	U dynssz.CompatibleUnion[proofTestUnionDesc]
+}
+
+type proofTestOptional struct {
+	Opt  *uint32           `ssz-type:"optional"`
+	Node *proofTestInner   `ssz-type:"optional"`
+	L    []*proofTestInner `ssz-max:"4"`
+}
+
+// Shapes without a native descent (bitlists, progressive containers and
+// lists, unions, optionals) prove through subtree materialization; every
+// generalized index must still match the tree-based Prove path.
+func TestGetProofsExoticShapes(t *testing.T) {
+	union, err := dynssz.NewCompatibleUnion[proofTestUnionDesc](1, proofTestInner{A: 9, B: [32]byte{1, 2}})
+	if err != nil {
+		t.Fatalf("NewCompatibleUnion: %v", err)
+	}
+	optVal := uint32(42)
+
+	tests := []struct {
+		name     string
+		source   any
+		extended bool
+	}{
+		{"bitlist", &proofTestBitlist{Bits: []byte{0xff, 0x35, 0x01}}, false},
+		{"progressive container", &proofTestProgressive{Slot: 3, Root: [32]byte{9}, Values: []uint64{1, 2, 3, 4, 5}}, false},
+		{"progressive list and bitlist", &proofTestProgList{L: []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9}, B: []byte{0xaa, 0x55, 0x01}}, false},
+		{"union", &proofTestUnionHolder{U: *union}, false},
+		{"optional", &proofTestOptional{Opt: &optVal, Node: &proofTestInner{A: 5}, L: []*proofTestInner{{A: 6}}}, true},
+		{"optional empty", &proofTestOptional{}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var opts []dynssz.DynSszOption
+			if tt.extended {
+				opts = append(opts, dynssz.WithExtendedTypes())
+			}
+			ds := dynssz.NewDynSsz(nil, opts...)
+			tree, root, getProofs := proofTestSetup(t, ds, tt.source)
+
+			var gindices []int
+			collectGindices(tree, 1, &gindices)
+
+			batch, err := getProofs(gindices)
+			if err != nil {
+				t.Fatalf("batched GetProofs: %v", err)
+			}
+			for i, gindex := range gindices {
+				want, proveErr := tree.Prove(gindex)
+				if proveErr != nil {
+					t.Fatalf("tree.Prove(%d): %v", gindex, proveErr)
+				}
+				assertProofEqual(t, gindex, want, batch[i])
+
+				if ok, verifyErr := treeproof.VerifyProof(root, batch[i]); verifyErr != nil || !ok {
+					t.Fatalf("VerifyProof(%d) = %v, %v", gindex, ok, verifyErr)
+				}
+			}
+		})
+	}
+}
+
+type proofTestBadList struct {
+	Good uint64
+	Bad  []uint64 `ssz-max:"2"`
+}
+
+// An over-limit list fails both when descended into and when its root is
+// needed as an off-path sibling.
+func TestGetProofsOverLimitList(t *testing.T) {
+	ds := dynssz.NewDynSsz(nil)
+	source := &proofTestBadList{Good: 1, Bad: []uint64{1, 2, 3}}
+
+	// The walk hashes the whole value, so the over-limit list fails the
+	// proof generation regardless of which path is requested.
+	if _, err := ds.GetProofs(source, []int{3 * 2}); !errors.Is(err, sszutils.ErrListTooBig) {
+		t.Fatalf("expected ErrListTooBig for list descent, got %v", err)
+	}
+	if _, err := ds.GetProofs(source, []int{2}); !errors.Is(err, sszutils.ErrListTooBig) {
+		t.Fatalf("expected ErrListTooBig for sibling path, got %v", err)
+	}
+}
+
+type proofTestBadElem struct {
+	Inner []*proofTestBadList `ssz-max:"4"`
+	Vec   [2]proofTestBadList `ssz-size:"2"`
+}
+
+// A failing element root surfaces both from off-path range gathering and
+// from on-path descents in lists and vectors.
+func TestGetProofsBadElementRoots(t *testing.T) {
+	ds := dynssz.NewDynSsz(nil)
+	source := &proofTestBadElem{
+		Inner: []*proofTestBadList{
+			{Good: 1},
+			{Good: 2, Bad: []uint64{1, 2, 3}},
+		},
+	}
+	vecSource := &proofTestBadElem{Inner: []*proofTestBadList{{Good: 1}}}
+	vecSource.Vec[1].Bad = []uint64{1, 2, 3}
+
+	// Inner is field 0 of a 2-slot container; element 1's over-limit inner
+	// list fails the walk for any requested path.
+	elem0 := (2+0)*2*4 + 0
+	if _, err := ds.GetProofs(source, []int{elem0 * 2}); err == nil {
+		t.Fatal("expected error from off-path element root")
+	}
+	elem1Bad := ((2+0)*2*4 + 1) * 2 * 2
+	if _, err := ds.GetProofs(source, []int{elem1Bad}); err == nil {
+		t.Fatal("expected error from on-path element descent")
+	}
+	// Same through the vector: element 1 of the 2-slot vector at field 1.
+	vecElem1Bad := ((2+1)*2 + 1) * 2 * 2
+	if _, err := ds.GetProofs(vecSource, []int{vecElem1Bad}); err == nil {
+		t.Fatal("expected error from vector element descent")
+	}
+}
+
+type proofTestNoLimit struct {
+	L []uint64
+}
+
+// A list without a declared limit has no SSZ root to descend into.
+func TestGetProofsNoLimitList(t *testing.T) {
+	ds := dynssz.NewDynSsz(nil)
+	source := &proofTestNoLimit{L: []uint64{1, 2, 3}}
+
+	if _, err := ds.GetProofs(source, []int{2}); err == nil {
+		t.Fatal("expected error for descent into a list without ssz root")
+	}
+}
+
+type proofTestExtInner struct {
+	V uint64
+}
+
+type proofTestExtList struct {
+	L []proofTestExtInner
+}
+
+// With extended types, a composite list without a limit merkleizes to its
+// occupied chunks; descents must match the tree.
+func TestGetProofsExtendedNoLimitList(t *testing.T) {
+	ds := dynssz.NewDynSsz(nil, dynssz.WithExtendedTypes())
+	source := &proofTestExtList{L: []proofTestExtInner{{V: 1}, {V: 2}, {V: 3}}}
+	tree, _, getProofs := proofTestSetup(t, ds, source)
+
+	var gindices []int
+	collectGindices(tree, 1, &gindices)
+	for _, gindex := range gindices {
+		want, proveErr := tree.Prove(gindex)
+		if proveErr != nil {
+			t.Fatalf("tree.Prove(%d): %v", gindex, proveErr)
+		}
+		got, proofErr := getProofs([]int{gindex})
+		if proofErr != nil {
+			t.Fatalf("GetProofs(%d): %v", gindex, proofErr)
+		}
+		assertProofEqual(t, gindex, want, got[0])
+	}
+}
+
+type proofTestWrapperDesc struct {
+	Data []uint64 `ssz-max:"16"`
+}
+
+// A type wrapper is transparent to proof paths: descents pass through to the
+// wrapped value.
+func TestGetProofsTypeWrapper(t *testing.T) {
+	ds := dynssz.NewDynSsz(nil)
+	source, err := dynssz.NewTypeWrapper[proofTestWrapperDesc]([]uint64{1, 2, 3, 4, 5})
+	if err != nil {
+		t.Fatalf("NewTypeWrapper: %v", err)
+	}
+	tree, _, getProofs := proofTestSetup(t, ds, source)
+
+	var gindices []int
+	collectGindices(tree, 1, &gindices)
+	for _, gindex := range gindices {
+		want, proveErr := tree.Prove(gindex)
+		if proveErr != nil {
+			t.Fatalf("tree.Prove(%d): %v", gindex, proveErr)
+		}
+		got, proofErr := getProofs([]int{gindex})
+		if proofErr != nil {
+			t.Fatalf("GetProofs(%d): %v", gindex, proofErr)
+		}
+		assertProofEqual(t, gindex, want, got[0])
+	}
+}
+
+type proofTestBadBitvector struct {
+	BV []byte `ssz-type:"bitvector" ssz-bitsize:"4"`
+}
+
+// A value that fails validation during the walk (stray bitvector padding
+// bits) surfaces the error from proof generation.
+func TestGetProofsPackedMarshalError(t *testing.T) {
+	ds := dynssz.NewDynSsz(nil)
+	source := &proofTestBadBitvector{BV: []byte{0xff}}
+
+	if _, err := ds.GetProofs(source, []int{2}); err == nil {
+		t.Fatal("expected error from bitvector with stray padding bits")
+	}
+}
+
+type proofWrapU64Desc struct {
+	V uint64
+}
+
+type proofTestWrapElemList struct {
+	L []*dynssz.TypeWrapper[proofWrapU64Desc, uint64] `ssz-max:"8"`
+}
+
+// Wrapped basic elements pack like their inner type; descents must match the
+// tree.
+func TestGetProofsWrappedElements(t *testing.T) {
+	ds := dynssz.NewDynSsz(nil)
+	source := &proofTestWrapElemList{}
+	for i := range 5 {
+		w, err := dynssz.NewTypeWrapper[proofWrapU64Desc](uint64(i + 1))
+		if err != nil {
+			t.Fatalf("NewTypeWrapper: %v", err)
+		}
+		source.L = append(source.L, w)
+	}
+	tree, _, getProofs := proofTestSetup(t, ds, source)
+
+	var gindices []int
+	collectGindices(tree, 1, &gindices)
+	for _, gindex := range gindices {
+		want, proveErr := tree.Prove(gindex)
+		if proveErr != nil {
+			t.Fatalf("tree.Prove(%d): %v", gindex, proveErr)
+		}
+		got, proofErr := getProofs([]int{gindex})
+		if proofErr != nil {
+			t.Fatalf("GetProofs(%d): %v", gindex, proofErr)
+		}
+		assertProofEqual(t, gindex, want, got[0])
+	}
+}
+
+type proofTestAsyncElem struct {
+	V uint64
+	W uint64
+}
+
+type proofTestAsyncContainer struct {
+	Count uint64
+	Items []proofTestAsyncElem `ssz-max:"65536"`
+	Tail  [32]byte             `ssz-size:"32"`
+}
+
+// With async hashing enabled, proofs must stay byte-identical to the tree
+// path: a muted large list reduces through background jobs while a
+// scheduled one runs non-incrementally, and both agree with GetTree+Prove.
+func TestGetProofsAsyncHashing(t *testing.T) {
+	ds := dynssz.NewDynSsz(nil, dynssz.WithAsyncHashing(4))
+	source := &proofTestAsyncContainer{Count: 7}
+	source.Items = make([]proofTestAsyncElem, 40000)
+	for i := range source.Items {
+		source.Items[i].V = uint64(i)
+		source.Items[i].W = uint64(i * 2)
+	}
+	tree, root, getProofs := proofTestSetup(t, ds, source)
+
+	// Count and Tail leave the big list muted; the element target schedules
+	// the list scope itself.
+	countG := 4 + 0
+	tailG := 4 + 2
+	elemG := (4+1)*2*65536 + 31337
+	lengthG := (4+1)*2 + 1
+
+	proofs, err := getProofs([]int{countG, tailG, elemG, elemG * 2, lengthG, 1})
+	if err != nil {
+		t.Fatalf("GetProofs: %v", err)
+	}
+	for i, gindex := range []int{countG, tailG, elemG, elemG * 2, lengthG, 1} {
+		want, proveErr := tree.Prove(gindex)
+		if proveErr != nil {
+			t.Fatalf("tree.Prove(%d): %v", gindex, proveErr)
+		}
+		assertProofEqual(t, gindex, want, proofs[i])
+		if ok, verifyErr := treeproof.VerifyProof(root, proofs[i]); verifyErr != nil || !ok {
+			t.Fatalf("VerifyProof(%d) = %v, %v", gindex, ok, verifyErr)
+		}
+	}
+}
+
+// WithNoFastHash covers proof generation too: sibling-range reduction runs
+// on the native Go sha256 implementation and stays byte-identical to the
+// tree path.
+func TestGetProofsNoFastHash(t *testing.T) {
+	ds := dynssz.NewDynSsz(nil, dynssz.WithNoFastHash())
+	source := &proofTestAsyncContainer{Count: 3}
+	source.Items = make([]proofTestAsyncElem, 500)
+	for i := range source.Items {
+		source.Items[i].V = uint64(i)
+		source.Items[i].W = uint64(i * 3)
+	}
+	tree, root, getProofs := proofTestSetup(t, ds, source)
+
+	elemG := (4+1)*2*65536 + 123
+	for _, gindex := range []int{4, elemG, elemG * 2} {
+		want, proveErr := tree.Prove(gindex)
+		if proveErr != nil {
+			t.Fatalf("tree.Prove(%d): %v", gindex, proveErr)
+		}
+		got, err := getProofs([]int{gindex})
+		if err != nil {
+			t.Fatalf("GetProofs(%d): %v", gindex, err)
+		}
+		assertProofEqual(t, gindex, want, got[0])
+		if ok, verifyErr := treeproof.VerifyProof(root, got[0]); verifyErr != nil || !ok {
+			t.Fatalf("VerifyProof(%d) = %v, %v", gindex, ok, verifyErr)
+		}
+	}
+}

--- a/treeproof/proofhasher.go
+++ b/treeproof/proofhasher.go
@@ -1,0 +1,606 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the dynamic-ssz library.
+
+package treeproof
+
+import (
+	"bytes"
+
+	"github.com/pk910/dynamic-ssz/hasher"
+	"github.com/pk910/dynamic-ssz/sszutils"
+)
+
+var _ sszutils.HashWalker = (*ProofHasher)(nil)
+
+// ProofHasher is a HashWalker that computes a value's hash tree root through
+// an embedded hasher while capturing just enough of the tree to serve proofs
+// for a schedule of generalized indices. Off-path subtrees pass straight
+// through the hasher's flat, batched merkleization and never materialize
+// nodes. Scheduled scopes run on the hasher's non-incremental path, so their
+// completed children lie as a plain chunk sequence in the hasher's buffer;
+// when such a scope closes, its pruned node tree is assembled directly from
+// that buffer region, with off-path sibling ranges reduced in batched level
+// order. Subtrees whose layout depends on runtime data (retainAll in the
+// schedule) are captured whole through a tree wrapper fed in parallel.
+// Async hashing is supported: the buffer reads drain any background
+// reduction overlapping the region.
+type ProofHasher struct {
+	*hasher.Hasher
+
+	scopes []proofHasherScope
+
+	// mute counts scope nesting inside an off-path subtree: the stream is
+	// forwarded untouched, and the subtree's root lands in the enclosing
+	// scope's buffer region by itself.
+	mute int
+
+	// retain captures a retainAll subtree through a tree wrapper fed in
+	// parallel with the hasher. retainIdx maps the wrapper's scope indices
+	// to the nesting, retainOrdinal is the subtree's child ordinal in the
+	// enclosing scheduled scope.
+	retain        *Wrapper
+	retainIdx     []int
+	retainOrdinal uint64
+
+	hashFn  hasher.HashFn
+	scratch []byte
+}
+
+// proofHasherScope is one open scheduled scope: its start position in the
+// hasher's buffer, its child ordinal in the enclosing scope, the schedule
+// that applies to its children, and the pruned nodes of children that were
+// themselves scheduled.
+type proofHasherScope struct {
+	sched      *ProofSchedule
+	start      int
+	ordinal    uint64
+	childNodes map[uint64]*Node
+	slots      []uint64
+}
+
+// NewProofHasher creates a HashWalker that computes the hash tree root on
+// the given hasher while capturing a pruned proof tree for the given
+// retention schedule. The hasher must be freshly reset. hashFn is used for
+// the capture's own sibling-range reductions and must be safe for
+// concurrent use; nil selects the fast hashing backend.
+func NewProofHasher(sched *ProofSchedule, hh *hasher.Hasher, hashFn hasher.HashFn) *ProofHasher {
+	// The base scope hands the root schedule to the value's own top-level
+	// scope, which opens as its first child.
+	base := &ProofSchedule{children: map[uint64]*ProofSchedule{0: sched}}
+	return &ProofHasher{
+		Hasher: hh,
+		hashFn: hashFn,
+		scopes: []proofHasherScope{{sched: base}},
+	}
+}
+
+// ProofTree returns the pruned proof tree after the walk completed. A
+// stream without a captured top-level subtree (a bare basic value) serves
+// its root as a single leaf. The tree's root is verified against the
+// hasher's root, so a divergence in the capture bookkeeping surfaces as an
+// error instead of a wrong proof.
+func (ph *ProofHasher) ProofTree() (*Node, error) {
+	root, err := ph.HashRoot()
+	if err != nil {
+		return nil, err
+	}
+
+	tree := ph.scopes[0].childNodes[0]
+	if tree == nil {
+		tree = newOwnedLeaf(bytes.Clone(root[:]))
+	}
+
+	if !bytes.Equal(tree.value, root[:]) {
+		return nil, sszutils.NewSszError(sszutils.ErrInvalidValueRange, "proof tree root diverges from hash tree root")
+	}
+
+	return tree, nil
+}
+
+// scheduledScope returns the scheduled scope receiving current children,
+// nil while the stream is inside a muted or retained subtree.
+func (ph *ProofHasher) scheduledScope() *proofHasherScope {
+	if ph.mute > 0 || ph.retain != nil {
+		return nil
+	}
+	return &ph.scopes[len(ph.scopes)-1]
+}
+
+// childOrdinal returns the ordinal the next child takes in the given scope:
+// the number of 32-byte chunks its completed children occupy in the
+// hasher's buffer.
+func (ph *ProofHasher) childOrdinal(scope *proofHasherScope) uint64 {
+	return uint64(ph.CurrentIndex()-scope.start) / 32
+}
+
+// --- retained-subtree stream mirroring ---
+
+func (ph *ProofHasher) Append(i []byte) {
+	ph.Hasher.Append(i)
+	if ph.retain != nil {
+		ph.retain.Append(i)
+	}
+}
+
+func (ph *ProofHasher) AppendBool(b bool) {
+	ph.Hasher.AppendBool(b)
+	if ph.retain != nil {
+		ph.retain.AppendBool(b)
+	}
+}
+
+func (ph *ProofHasher) AppendUint8(i uint8) {
+	ph.Hasher.AppendUint8(i)
+	if ph.retain != nil {
+		ph.retain.AppendUint8(i)
+	}
+}
+
+func (ph *ProofHasher) AppendUint16(i uint16) {
+	ph.Hasher.AppendUint16(i)
+	if ph.retain != nil {
+		ph.retain.AppendUint16(i)
+	}
+}
+
+func (ph *ProofHasher) AppendUint32(i uint32) {
+	ph.Hasher.AppendUint32(i)
+	if ph.retain != nil {
+		ph.retain.AppendUint32(i)
+	}
+}
+
+func (ph *ProofHasher) AppendUint64(i uint64) {
+	ph.Hasher.AppendUint64(i)
+	if ph.retain != nil {
+		ph.retain.AppendUint64(i)
+	}
+}
+
+func (ph *ProofHasher) AppendBytes32(b []byte) {
+	ph.Hasher.AppendBytes32(b)
+	if ph.retain != nil {
+		ph.retain.AppendBytes32(b)
+	}
+}
+
+func (ph *ProofHasher) FillUpTo32() {
+	ph.Hasher.FillUpTo32()
+	if ph.retain != nil {
+		ph.retain.FillUpTo32()
+	}
+}
+
+func (ph *ProofHasher) PutBool(b bool) {
+	ph.Hasher.PutBool(b)
+	if ph.retain != nil {
+		ph.retain.PutBool(b)
+	}
+}
+
+func (ph *ProofHasher) PutUint8(i uint8) {
+	ph.Hasher.PutUint8(i)
+	if ph.retain != nil {
+		ph.retain.PutUint8(i)
+	}
+}
+
+func (ph *ProofHasher) PutUint16(i uint16) {
+	ph.Hasher.PutUint16(i)
+	if ph.retain != nil {
+		ph.retain.PutUint16(i)
+	}
+}
+
+func (ph *ProofHasher) PutUint32(i uint32) {
+	ph.Hasher.PutUint32(i)
+	if ph.retain != nil {
+		ph.retain.PutUint32(i)
+	}
+}
+
+func (ph *ProofHasher) PutUint64(i uint64) {
+	ph.Hasher.PutUint64(i)
+	if ph.retain != nil {
+		ph.retain.PutUint64(i)
+	}
+}
+
+// WithTemp serves the callback from the hasher's scratch buffer only; the
+// callback runs once regardless of capture state.
+func (ph *ProofHasher) WithTemp(fn func(tmp []byte) []byte) {
+	ph.Hasher.WithTemp(fn)
+}
+
+// --- subtree-valued put calls ---
+
+// putScheduled looks up the schedule of the child the next Put-style
+// subtree call produces. Must be called before forwarding the call.
+func (ph *ProofHasher) putScheduled() (uint64, *ProofSchedule) {
+	scope := ph.scheduledScope()
+	if scope == nil {
+		return 0, nil
+	}
+	ordinal := ph.childOrdinal(scope)
+	return ordinal, scope.sched.child(ordinal)
+}
+
+// putSubtree finishes a Put-style call that nets one child subtree: a child
+// the schedule descends into rebuilds its structure through a tree wrapper,
+// matching the full tree's shape for these calls.
+func (ph *ProofHasher) putSubtree(ordinal uint64, sched *ProofSchedule, replay func(w *Wrapper)) {
+	if sched == nil {
+		return
+	}
+	w := NewWrapper()
+	replay(w)
+	node := w.Node()
+	node.Hash()
+	ph.registerChild(ordinal, node)
+}
+
+func (ph *ProofHasher) PutBytes(b []byte) {
+	ordinal, sched := ph.putScheduled()
+	ph.Hasher.PutBytes(b)
+	if ph.retain != nil {
+		ph.retain.PutBytes(b)
+		return
+	}
+	ph.putSubtree(ordinal, sched, func(w *Wrapper) { w.PutBytes(b) })
+}
+
+func (ph *ProofHasher) PutBitlist(bb []byte, maxSize uint64) {
+	ordinal, sched := ph.putScheduled()
+	ph.Hasher.PutBitlist(bb, maxSize)
+	if ph.retain != nil {
+		ph.retain.PutBitlist(bb, maxSize)
+		return
+	}
+	ph.putSubtree(ordinal, sched, func(w *Wrapper) { w.PutBitlist(bb, maxSize) })
+}
+
+func (ph *ProofHasher) PutProgressiveBitlist(bb []byte) {
+	ordinal, sched := ph.putScheduled()
+	ph.Hasher.PutProgressiveBitlist(bb)
+	if ph.retain != nil {
+		ph.retain.PutProgressiveBitlist(bb)
+		return
+	}
+	ph.putSubtree(ordinal, sched, func(w *Wrapper) { w.PutProgressiveBitlist(bb) })
+}
+
+func (ph *ProofHasher) PutUint64Array(b []uint64, maxCapacity ...uint64) {
+	ordinal, sched := ph.putScheduled()
+	ph.Hasher.PutUint64Array(b, maxCapacity...)
+	if ph.retain != nil {
+		ph.retain.PutUint64Array(b, maxCapacity...)
+		return
+	}
+	ph.putSubtree(ordinal, sched, func(w *Wrapper) { w.PutUint64Array(b, maxCapacity...) })
+}
+
+// PutRootVector is not part of the HashWalker interface; it is mirrored for
+// callers holding the concrete type. The retained and scheduled replays
+// reproduce the hasher's root-vector structure through the wrapper's scope
+// calls.
+func (ph *ProofHasher) PutRootVector(b [][]byte, maxCapacity ...uint64) error {
+	ordinal, sched := ph.putScheduled()
+	if err := ph.Hasher.PutRootVector(b, maxCapacity...); err != nil {
+		return err
+	}
+	replay := func(w *Wrapper) {
+		idx := w.Index()
+		for _, root := range b {
+			w.AppendBytes32(root)
+		}
+		if len(maxCapacity) == 0 {
+			w.Merkleize(idx)
+		} else {
+			numItems := uint64(len(b))
+			w.MerkleizeWithMixin(idx, numItems, sszutils.CalculateLimit(maxCapacity[0], numItems, 32))
+		}
+	}
+	if ph.retain != nil {
+		replay(ph.retain)
+		return nil
+	}
+	ph.putSubtree(ordinal, sched, replay)
+	return nil
+}
+
+// --- scope tracking ---
+
+func (ph *ProofHasher) StartTree(treeType sszutils.TreeType) int {
+	return ph.startScope(treeType)
+}
+
+// Index opens a scope like StartTree; legacy generated code uses it as its
+// scope-open call.
+func (ph *ProofHasher) Index() int {
+	return ph.startScope(sszutils.TreeTypeNone)
+}
+
+func (ph *ProofHasher) startScope(treeType sszutils.TreeType) int {
+	if ph.retain != nil {
+		ph.retainIdx = append(ph.retainIdx, ph.retain.StartTree(treeType))
+		return ph.Hasher.StartTree(treeType)
+	}
+	if ph.mute > 0 {
+		ph.mute++
+		return ph.Hasher.StartTree(treeType)
+	}
+
+	parent := &ph.scopes[len(ph.scopes)-1]
+	ordinal := ph.childOrdinal(parent)
+
+	child := parent.sched.child(ordinal)
+	switch {
+	case child == nil:
+		ph.mute = 1
+		return ph.Hasher.StartTree(treeType)
+	case child.retainAll:
+		ph.retain = NewWrapper()
+		ph.retainOrdinal = ordinal
+		ph.retainIdx = append(ph.retainIdx[:0], ph.retain.StartTree(treeType))
+		return ph.Hasher.StartTree(treeType)
+	default:
+		// Scheduled scopes run non-incrementally, so their completed
+		// children stay a plain chunk sequence in the hasher's buffer until
+		// this scope's own merkleization.
+		idx := ph.Hasher.StartTree(sszutils.TreeTypeNone)
+		ph.scopes = append(ph.scopes, proofHasherScope{sched: child, start: idx, ordinal: ordinal})
+		return idx
+	}
+}
+
+// proofClose describes the merkleization variant that closed a scheduled
+// scope, so the pruned assembly reproduces the same tree shape.
+type proofClose struct {
+	kind         sszutils.TreeType
+	mixin        bool
+	num          uint64
+	limit        uint64
+	activeFields []byte
+}
+
+func (ph *ProofHasher) Merkleize(indx int) {
+	ph.closeScope(proofClose{kind: sszutils.TreeTypeNone},
+		func() { ph.Hasher.Merkleize(indx) },
+		func(w *Wrapper, wIdx int) { w.Merkleize(wIdx) })
+}
+
+func (ph *ProofHasher) MerkleizeWithMixin(indx int, num, limit uint64) {
+	ph.closeScope(proofClose{kind: sszutils.TreeTypeNone, mixin: true, num: num, limit: limit},
+		func() { ph.Hasher.MerkleizeWithMixin(indx, num, limit) },
+		func(w *Wrapper, wIdx int) { w.MerkleizeWithMixin(wIdx, num, limit) })
+}
+
+func (ph *ProofHasher) MerkleizeProgressive(indx int) {
+	ph.closeScope(proofClose{kind: sszutils.TreeTypeProgressive},
+		func() { ph.Hasher.MerkleizeProgressive(indx) },
+		func(w *Wrapper, wIdx int) { w.MerkleizeProgressive(wIdx) })
+}
+
+func (ph *ProofHasher) MerkleizeProgressiveWithMixin(indx int, num uint64) {
+	ph.closeScope(proofClose{kind: sszutils.TreeTypeProgressive, mixin: true, num: num},
+		func() { ph.Hasher.MerkleizeProgressiveWithMixin(indx, num) },
+		func(w *Wrapper, wIdx int) { w.MerkleizeProgressiveWithMixin(wIdx, num) })
+}
+
+func (ph *ProofHasher) MerkleizeProgressiveWithActiveFields(indx int, activeFields []byte) {
+	ph.closeScope(proofClose{kind: sszutils.TreeTypeProgressive, mixin: true, activeFields: activeFields},
+		func() { ph.Hasher.MerkleizeProgressiveWithActiveFields(indx, activeFields) },
+		func(w *Wrapper, wIdx int) { w.MerkleizeProgressiveWithActiveFields(wIdx, activeFields) })
+}
+
+// closeScope routes a Merkleize variant through the capture bookkeeping:
+// retained subtrees mirror the call into their wrapper, muted subtrees just
+// unwind, and a closing scheduled scope assembles its pruned node from its
+// buffer region before the forwarded call collapses it.
+func (ph *ProofHasher) closeScope(pc proofClose, fwd func(), retainFn func(w *Wrapper, wIdx int)) {
+	switch {
+	case ph.retain != nil:
+		fwd()
+		wIdx := ph.retainIdx[len(ph.retainIdx)-1]
+		ph.retainIdx = ph.retainIdx[:len(ph.retainIdx)-1]
+		retainFn(ph.retain, wIdx)
+		if len(ph.retainIdx) == 0 {
+			node := ph.retain.Node()
+			node.Hash()
+			ph.retain = nil
+			ph.registerChild(ph.retainOrdinal, node)
+		}
+	case ph.mute > 0:
+		fwd()
+		ph.mute--
+	case len(ph.scopes) > 1:
+		scope := ph.scopes[len(ph.scopes)-1]
+		ph.scopes = ph.scopes[:len(ph.scopes)-1]
+		// The chunk region is only readable until the forwarded call
+		// collapses it.
+		node := ph.assemble(&scope, ph.BufferSince(scope.start), pc)
+		fwd()
+		ph.registerChild(scope.ordinal, node)
+	default:
+		// A Merkleize without a tracked scope (a stream bypassing StartTree)
+		// has nothing to capture.
+		fwd()
+	}
+}
+
+// registerChild records a completed child subtree's pruned node in the
+// innermost scheduled scope. Its root chunk lands in the hasher's buffer
+// through the forwarded stream itself.
+func (ph *ProofHasher) registerChild(ordinal uint64, node *Node) {
+	scope := &ph.scopes[len(ph.scopes)-1]
+	if scope.childNodes == nil {
+		scope.childNodes = make(map[uint64]*Node, 1)
+	}
+	scope.childNodes[ordinal] = node
+}
+
+// alignRegion returns the region as full 32-byte chunks, zero-padding a
+// trailing partial chunk through the scratch buffer. Engine streams close
+// scopes chunk-aligned, so the copy is the exception.
+func (ph *ProofHasher) alignRegion(region []byte) []byte {
+	if len(region)%32 == 0 {
+		return region
+	}
+	need := (len(region)/32 + 1) * 32
+	if cap(ph.scratch) < need {
+		ph.scratch = make([]byte, need)
+	}
+	aligned := ph.scratch[:need]
+	n := copy(aligned, region)
+	for i := n; i < need; i++ {
+		aligned[i] = 0
+	}
+	return aligned
+}
+
+// assemble builds the pruned node tree of a closed scheduled scope from its
+// buffer region, its scheduled children's nodes, and the merkleization
+// variant that closed it.
+func (ph *ProofHasher) assemble(scope *proofHasherScope, region []byte, pc proofClose) *Node {
+	region = ph.alignRegion(region)
+
+	if pc.kind == sszutils.TreeTypeProgressive {
+		// A schedule never descends into progressive shapes, so a scheduled
+		// scope closing progressively means the stream and the descriptor
+		// disagree; replaying the children through a tree wrapper stays
+		// correct either way.
+		return ph.assembleViaWrapper(scope, region, pc)
+	}
+
+	for slot := range scope.sched.children {
+		scope.slots = append(scope.slots, slot)
+	}
+
+	chunkCount := uint64(len(region)) / 32
+	depth := chunkDepthSlots(chunkCount)
+	if pc.mixin && pc.limit != 0 {
+		depth = chunkDepthSlots(pc.limit)
+	}
+
+	node := ph.buildPruned(scope, region, depth, 0)
+	if pc.mixin {
+		var lengthChunk [32]byte
+		sszutils.MarshalUint64(lengthChunk[:0], pc.num)
+		root := hashPair(node.value, lengthChunk[:])
+		node = &Node{left: node, right: newOwnedLeaf(bytes.Clone(lengthChunk[:])), value: root}
+	}
+	return node
+}
+
+// assembleViaWrapper rebuilds a scope through the tree wrapper, used when
+// the closing variant has no static shape.
+func (ph *ProofHasher) assembleViaWrapper(scope *proofHasherScope, region []byte, pc proofClose) *Node {
+	w := NewWrapper()
+	idx := w.StartTree(sszutils.TreeTypeNone)
+	for slot := uint64(0); slot < uint64(len(region))/32; slot++ {
+		if node := scope.childNodes[slot]; node != nil {
+			w.AddNode(node)
+		} else {
+			w.AddNode(newOwnedLeaf(bytes.Clone(region[slot*32 : slot*32+32])))
+		}
+	}
+	switch {
+	case pc.activeFields != nil:
+		w.MerkleizeProgressiveWithActiveFields(idx, pc.activeFields)
+	case pc.mixin:
+		w.MerkleizeProgressiveWithMixin(idx, pc.num)
+	default:
+		w.MerkleizeProgressive(idx)
+	}
+	node := w.Node()
+	node.Hash()
+	return node
+}
+
+// buildPruned builds the pruned subtree of the given height starting at leaf
+// slot base: ranges containing scheduled slots keep their branch structure,
+// everything else reduces to a single value node, and slots beyond the
+// region's chunks become shared zero-padding nodes.
+func (ph *ProofHasher) buildPruned(scope *proofHasherScope, region []byte, level int, base uint64) *Node {
+	chunkCount := uint64(len(region)) / 32
+
+	scheduled := false
+	for _, slot := range scope.slots {
+		if slot >= base && slot < base+uint64(1)<<level {
+			scheduled = true
+			break
+		}
+	}
+
+	if !scheduled {
+		if base >= chunkCount {
+			return getEmptyNode(level)
+		}
+		root := ph.rangeRoot(region, base, level, chunkCount)
+		return newOwnedLeaf(bytes.Clone(root[:]))
+	}
+	if level == 0 {
+		if node := scope.childNodes[base]; node != nil {
+			return node
+		}
+		if base >= chunkCount {
+			return getEmptyNode(0)
+		}
+		return newOwnedLeaf(bytes.Clone(region[base*32 : base*32+32]))
+	}
+
+	left := ph.buildPruned(scope, region, level-1, base)
+	right := ph.buildPruned(scope, region, level-1, base+uint64(1)<<(level-1))
+	return &Node{left: left, right: right, value: hashPair(left.value, right.value)}
+}
+
+// rangeRoot reduces a fully off-path chunk range to its root in batched
+// level order, padding odd tails and missing levels with zero hashes.
+func (ph *ProofHasher) rangeRoot(region []byte, base uint64, level int, chunkCount uint64) [32]byte {
+	if base >= chunkCount {
+		return [32]byte(hasher.GetZeroHash(level))
+	}
+
+	count := chunkCount - base
+	if width := uint64(1) << level; count > width {
+		count = width
+	}
+
+	// One extra chunk keeps room for the odd-tail zero padding. The region
+	// aliases the hasher's buffer, so the reduction runs on a copy.
+	if need := (int(count) + 1) * 32; cap(ph.scratch) < need {
+		ph.scratch = make([]byte, need)
+	}
+	buf := ph.scratch[:count*32]
+	copy(buf, region[base*32:])
+
+	hashFn := ph.hashFn
+	if hashFn == nil {
+		hashFn = hasher.FastHasherPool.HashFn
+	}
+	for l := 0; l < level; l++ {
+		if count == 1 {
+			root := hashPair(buf[:32], hasher.GetZeroHash(l))
+			copy(buf[:32], root)
+			continue
+		}
+		if count%2 == 1 {
+			buf = ph.scratch[:(count+1)*32]
+			copy(buf[count*32:], hasher.GetZeroHash(l))
+			count++
+		}
+		if err := hashFn(buf[:count/2*32], buf[:count*32]); err != nil {
+			// The backend rejects only malformed buffer sizes, which this
+			// packing cannot produce; reduce the level pairwise instead.
+			for i := uint64(0); i < count/2; i++ {
+				root := hashPair(buf[i*64:i*64+32], buf[i*64+32:i*64+64])
+				copy(buf[i*32:], root)
+			}
+		}
+		count /= 2
+		buf = buf[:count*32]
+	}
+
+	return [32]byte(buf[:32])
+}

--- a/treeproof/proofhasher_internal_test.go
+++ b/treeproof/proofhasher_internal_test.go
@@ -1,0 +1,406 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the dynamic-ssz library.
+
+package treeproof
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/pk910/dynamic-ssz/hasher"
+	"github.com/pk910/dynamic-ssz/sszutils"
+)
+
+// proofHasherStream drives every HashWalker method the engines emit: two
+// nested scopes, one Index-opened scope, chunk appends of all widths, and
+// the Put-style subtree calls.
+func proofHasherStream(hh sszutils.HashWalker) {
+	root := hh.StartTree(sszutils.TreeTypeNone)
+
+	// child 0: a scope with mixed appends
+	inner := hh.StartTree(sszutils.TreeTypeNone)
+	hh.AppendUint64(1)
+	hh.AppendUint32(2)
+	hh.AppendUint16(3)
+	hh.AppendUint8(4)
+	hh.AppendBool(true)
+	hh.FillUpTo32()
+	hh.Append([]byte{9, 9})
+	hh.FillUpTo32()
+	hh.AppendBytes32([]byte{5, 6, 7})
+	hh.Merkleize(inner)
+
+	// child 1: an Index-opened scope (legacy style)
+	legacy := hh.Index()
+	hh.PutUint64(11)
+	hh.PutUint32(12)
+	hh.Merkleize(legacy)
+
+	// children 2..8: single-chunk puts and subtree puts
+	hh.PutBool(true)
+	hh.PutUint8(21)
+	hh.PutUint16(22)
+	hh.PutUint64(23)
+	hh.PutBytes([]byte{1, 2, 3})
+	hh.PutBytes(bytes.Repeat([]byte{7}, 96))
+	hh.PutBitlist([]byte{0xaa, 0x01}, 64)
+
+	// child 9: a list scope with a mixin; elements carry a subtree put so
+	// muted regions exercise the subtree-put path too
+	list := hh.StartTree(sszutils.TreeTypeBinary)
+	for i := range 5 {
+		elem := hh.StartTree(sszutils.TreeTypeNone)
+		hh.PutUint64(uint64(100 + i))
+		hh.PutUint64(uint64(200 + i))
+		hh.PutBitlist([]byte{byte(i), 0x01}, 32)
+		hh.Merkleize(elem)
+		hh.Collapse()
+	}
+	hh.MerkleizeWithMixin(list, 5, 8)
+
+	// child 10: a progressive scope (retained whole by any schedule) with a
+	// nested plain-progressive subscope
+	prog := hh.StartTree(sszutils.TreeTypeProgressive)
+	nested := hh.StartTree(sszutils.TreeTypeProgressive)
+	hh.PutUint64(30)
+	hh.MerkleizeProgressive(nested)
+	hh.PutUint64(31)
+	hh.PutUint64(32)
+	hh.PutUint64(33)
+	hh.MerkleizeProgressiveWithMixin(prog, 3)
+
+	// child 11: a uint64 array subtree and a root vector subtree
+	hh.PutUint64Array([]uint64{41, 42, 43}, 16)
+	roots := [][]byte{bytes.Repeat([]byte{3}, 32), bytes.Repeat([]byte{4}, 32)}
+	if rv, ok := hh.(interface {
+		PutRootVector(b [][]byte, maxCapacity ...uint64) error
+	}); ok {
+		if err := rv.PutRootVector(roots, 8); err != nil {
+			panic(err)
+		}
+	} else {
+		// The tree wrapper has no PutRootVector; replay the same structure.
+		idx := hh.Index()
+		for _, r := range roots {
+			hh.AppendBytes32(r)
+		}
+		hh.MerkleizeWithMixin(idx, uint64(len(roots)), sszutils.CalculateLimit(8, uint64(len(roots)), 32))
+	}
+
+	// children 12..13: a progressive bitlist subtree and an uncapped root
+	// vector subtree
+	hh.PutProgressiveBitlist([]byte{0x3c, 0x01})
+	roots2 := [][]byte{bytes.Repeat([]byte{5}, 32)}
+	if rv, ok := hh.(interface {
+		PutRootVector(b [][]byte, maxCapacity ...uint64) error
+	}); ok {
+		if err := rv.PutRootVector(roots2); err != nil {
+			panic(err)
+		}
+	} else {
+		idx := hh.Index()
+		hh.AppendBytes32(roots2[0])
+		hh.Merkleize(idx)
+	}
+
+	hh.Merkleize(root)
+}
+
+// runProofHasher drives the stream through a ProofHasher with the given
+// schedule and returns the pruned tree.
+func runProofHasher(t *testing.T, sched *ProofSchedule) *Node {
+	t.Helper()
+	hh := hasher.FastHasherPool.Get()
+	defer hasher.FastHasherPool.Put(hh)
+	ph := NewProofHasher(sched, hh, nil)
+	proofHasherStream(ph)
+	tree, err := ph.ProofTree()
+	if err != nil {
+		t.Fatalf("ProofTree: %v", err)
+	}
+	return tree
+}
+
+// The pruned tree must reproduce the full wrapper tree's root and proofs for
+// every retained path, across all capture states: scheduled scopes, muted
+// subtrees, retained subtrees, and Put-style subtree children.
+func TestProofHasherStreamParity(t *testing.T) {
+	ref := NewWrapper()
+	proofHasherStream(ref)
+	refTree := ref.Node()
+	refRoot := refTree.Hash()
+
+	var gindices []int
+	collectStreamGindices(refTree, 1, &gindices)
+
+	// Retain everything: the pruned tree must serve every proof of the full
+	// tree.
+	full := runProofHasher(t, retainAllSchedule)
+	if !bytes.Equal(full.Hash(), refRoot) {
+		t.Fatalf("retainAll root = %x, want %x", full.Hash(), refRoot)
+	}
+	for _, gindex := range gindices {
+		want, refErr := refTree.Prove(gindex)
+		got, err := full.Prove(gindex)
+		if refErr != nil {
+			if err == nil {
+				t.Fatalf("gindex %d: reference errored (%v), pruned did not", gindex, refErr)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("gindex %d: %v", gindex, err)
+		}
+		assertSameProof(t, gindex, want, got)
+	}
+
+	// A partial schedule: descend into the mixed-append scope (child 0), the
+	// bitlist subtree (child 8, via retainAll from a manual schedule), and
+	// list element 3 (child 9 -> chunks -> slot 3). Everything else runs
+	// muted through the hasher.
+	sched := &ProofSchedule{children: map[uint64]*ProofSchedule{
+		0:  {children: map[uint64]*ProofSchedule{1: {}}},
+		7:  {children: map[uint64]*ProofSchedule{1: {}}},
+		8:  {retainAll: true},
+		9:  {children: map[uint64]*ProofSchedule{3: {children: map[uint64]*ProofSchedule{0: {}}}}},
+		11: {retainAll: true},
+		12: {retainAll: true},
+		13: {retainAll: true},
+	}}
+	pruned := runProofHasher(t, sched)
+	if !bytes.Equal(pruned.Hash(), refRoot) {
+		t.Fatalf("pruned root = %x, want %x", pruned.Hash(), refRoot)
+	}
+	// The scheduled paths serve the same proofs as the full tree.
+	scopeG := 16 + 0 // child 0 of the 14-child (16-slot) root scope
+	bitlistG := 16 + 8
+	listElemG := (16+9)*2*8 + 3
+	putBytesG := 16 + 7
+	arrayG := 16 + 11
+	progBitsG := 16 + 12
+	rootVecG := 16 + 13
+	for _, gindex := range []int{1, scopeG, scopeG*2 + 1, bitlistG, bitlistG * 2, bitlistG*2 + 1, listElemG, listElemG * 2,
+		putBytesG * 2, putBytesG*2 + 1, arrayG * 2, arrayG*2 + 1, progBitsG * 2, rootVecG * 2} {
+		want, refErr := refTree.Prove(gindex)
+		if refErr != nil {
+			t.Fatalf("reference Prove(%d): %v", gindex, refErr)
+		}
+		got, err := pruned.Prove(gindex)
+		if err != nil {
+			t.Fatalf("pruned Prove(%d): %v", gindex, err)
+		}
+		assertSameProof(t, gindex, want, got)
+	}
+}
+
+func collectStreamGindices(node *Node, gindex int, out *[]int) {
+	if node == nil || gindex > 1<<20 {
+		return
+	}
+	*out = append(*out, gindex)
+	collectStreamGindices(node.left, gindex*2, out)
+	collectStreamGindices(node.right, gindex*2+1, out)
+}
+
+func assertSameProof(t *testing.T, gindex int, want, got *Proof) {
+	t.Helper()
+	if !bytes.Equal(got.Leaf, want.Leaf) {
+		t.Fatalf("gindex %d: leaf = %x, want %x", gindex, got.Leaf, want.Leaf)
+	}
+	if len(got.Hashes) != len(want.Hashes) {
+		t.Fatalf("gindex %d: %d hashes, want %d", gindex, len(got.Hashes), len(want.Hashes))
+	}
+	for i := range got.Hashes {
+		if !bytes.Equal(got.Hashes[i], want.Hashes[i]) {
+			t.Fatalf("gindex %d: hash %d mismatch", gindex, i)
+		}
+	}
+}
+
+// ProofTree reports the walk's failure modes: an unclosed scope, a stream
+// that never produced a root, and a shadow diverging from the hasher root.
+func TestProofHasherProofTreeErrors(t *testing.T) {
+	hh := hasher.FastHasherPool.Get()
+	defer hasher.FastHasherPool.Put(hh)
+
+	// No content at all: HashRoot fails.
+	ph := NewProofHasher(&ProofSchedule{}, hh, nil)
+	if _, err := ph.ProofTree(); err == nil {
+		t.Fatal("expected error for empty stream")
+	}
+
+	// A bare chunk without any scope: served as a leaf.
+	hh.Reset()
+	ph = NewProofHasher(&ProofSchedule{}, hh, nil)
+	ph.PutUint64(7)
+	tree, err := ph.ProofTree()
+	if err != nil {
+		t.Fatalf("ProofTree: %v", err)
+	}
+	if !tree.IsLeaf() {
+		t.Fatal("expected leaf tree for bare chunk")
+	}
+
+	// A corrupted captured node diverges from the hasher root.
+	hh.Reset()
+	ph = NewProofHasher(&ProofSchedule{}, hh, nil)
+	idx := ph.StartTree(sszutils.TreeTypeNone)
+	ph.PutUint64(7)
+	ph.PutUint64(8)
+	ph.Merkleize(idx)
+	ph.scopes[0].childNodes[0].value[0] ^= 0xff
+	if _, err := ph.ProofTree(); err == nil {
+		t.Fatal("expected divergence error for corrupted capture")
+	}
+}
+
+// rangeRoot pads odd tails and missing levels with zero hashes and falls
+// back to pairwise hashing when the batched backend fails.
+func TestProofHasherRangeRoot(t *testing.T) {
+	ph := &ProofHasher{}
+	shadow := bytes.Repeat([]byte{1}, 3*32)
+
+	// count 1 with extra levels: zero-hash chain.
+	root := ph.rangeRoot(shadow, 2, 3, 3)
+	want := hashPair(hashPair(hashPair(shadow[64:96], hasher.GetZeroHash(0)), hasher.GetZeroHash(1)), hasher.GetZeroHash(2))
+	if !bytes.Equal(root[:], want) {
+		t.Fatalf("rangeRoot = %x, want %x", root, want)
+	}
+
+	// The pairwise fallback must produce the same root as the backend.
+	viaBackend := ph.rangeRoot(shadow, 0, 2, 3)
+	broken := &ProofHasher{}
+	origFn := hasher.FastHasherPool.HashFn
+	hasher.FastHasherPool.HashFn = func(_, _ []byte) error { return errors.New("backend failure") }
+	viaFallback := broken.rangeRoot(shadow, 0, 2, 3)
+	hasher.FastHasherPool.HashFn = origFn
+	if viaBackend != viaFallback {
+		t.Fatalf("fallback root %x != backend root %x", viaFallback, viaBackend)
+	}
+}
+
+// A scheduled scope closed by a progressive variant means the stream and
+// the descriptor-derived schedule disagree; the wrapper replay keeps the
+// pruned tree correct for all three progressive variants.
+func TestProofHasherProgressiveMismatch(t *testing.T) {
+	variants := []struct {
+		name  string
+		close func(hh sszutils.HashWalker, idx int)
+	}{
+		{"plain", func(hh sszutils.HashWalker, idx int) { hh.MerkleizeProgressive(idx) }},
+		{"mixin", func(hh sszutils.HashWalker, idx int) { hh.MerkleizeProgressiveWithMixin(idx, 3) }},
+		{"active fields", func(hh sszutils.HashWalker, idx int) { hh.MerkleizeProgressiveWithActiveFields(idx, []byte{0x07}) }},
+	}
+
+	for _, tt := range variants {
+		t.Run(tt.name, func(t *testing.T) {
+			stream := func(hh sszutils.HashWalker) {
+				root := hh.StartTree(sszutils.TreeTypeNone)
+				child := hh.StartTree(sszutils.TreeTypeNone)
+				hh.PutUint64(1)
+				hh.PutUint64(2)
+				hh.Merkleize(child)
+				hh.PutUint64(3)
+				hh.PutUint64(4)
+				tt.close(hh, root)
+			}
+
+			ref := NewWrapper()
+			stream(ref)
+			refTree := ref.Node()
+			refRoot := refTree.Hash()
+
+			hh := hasher.FastHasherPool.Get()
+			defer hasher.FastHasherPool.Put(hh)
+			// The root scope is scheduled with a retained child, but the
+			// stream closes it progressively.
+			ph := NewProofHasher(&ProofSchedule{children: map[uint64]*ProofSchedule{0: {children: map[uint64]*ProofSchedule{0: {}}}}}, hh, nil)
+			stream(ph)
+			tree, err := ph.ProofTree()
+			if err != nil {
+				t.Fatalf("ProofTree: %v", err)
+			}
+			if !bytes.Equal(tree.Hash(), refRoot) {
+				t.Fatalf("root = %x, want %x", tree.Hash(), refRoot)
+			}
+			want, refErr := refTree.Prove(2)
+			if refErr != nil {
+				t.Fatalf("reference Prove: %v", refErr)
+			}
+			got, err := tree.Prove(2)
+			if err != nil {
+				t.Fatalf("pruned Prove: %v", err)
+			}
+			assertSameProof(t, 2, want, got)
+		})
+	}
+}
+
+// PutRootVector propagates the hasher's validation error.
+func TestProofHasherPutRootVectorError(t *testing.T) {
+	hh := hasher.FastHasherPool.Get()
+	defer hasher.FastHasherPool.Put(hh)
+	ph := NewProofHasher(&ProofSchedule{}, hh, nil)
+	if err := ph.PutRootVector([][]byte{{1, 2}}); err == nil {
+		t.Fatal("expected error for malformed root")
+	}
+	hh.Reset()
+}
+
+// A stream that bypasses the proof capture entirely still serves its root
+// as a single leaf: the buffer holds the truth.
+func TestProofHasherProofTreeBypassedStream(t *testing.T) {
+	hh := hasher.FastHasherPool.Get()
+	defer hasher.FastHasherPool.Put(hh)
+	ph := NewProofHasher(&ProofSchedule{}, hh, nil)
+	ph.Hasher.PutUint64(7)
+	tree, err := ph.ProofTree()
+	if err != nil {
+		t.Fatalf("ProofTree: %v", err)
+	}
+	if !tree.IsLeaf() {
+		t.Fatal("expected leaf tree for bypassed stream")
+	}
+}
+
+// rangeRoot serves fully padded ranges from the zero-hash table.
+func TestProofHasherRangeRootPadding(t *testing.T) {
+	ph := &ProofHasher{}
+	root := ph.rangeRoot(nil, 4, 2, 2)
+	if !bytes.Equal(root[:], hasher.GetZeroHash(2)) {
+		t.Fatalf("padded rangeRoot = %x, want zero hash", root)
+	}
+}
+
+// alignRegion pads a trailing partial chunk; aligned regions pass through
+// untouched.
+func TestProofHasherAlignRegion(t *testing.T) {
+	ph := &ProofHasher{}
+	aligned := bytes.Repeat([]byte{1}, 64)
+	if got := ph.alignRegion(aligned); &got[0] != &aligned[0] {
+		t.Fatal("aligned region must pass through without copying")
+	}
+	got := ph.alignRegion([]byte{1, 2, 3})
+	if len(got) != 32 || got[0] != 1 || got[3] != 0 || got[31] != 0 {
+		t.Fatalf("misaligned region not zero-padded: %x", got)
+	}
+}
+
+// A Merkleize on the base level without a tracked scope forwards untouched.
+func TestProofHasherBaseMerkleize(t *testing.T) {
+	hh := hasher.FastHasherPool.Get()
+	defer hasher.FastHasherPool.Put(hh)
+	ph := NewProofHasher(&ProofSchedule{}, hh, nil)
+	ph.PutUint64(1)
+	ph.PutUint64(2)
+	ph.Merkleize(0)
+	tree, err := ph.ProofTree()
+	if err != nil {
+		t.Fatalf("ProofTree: %v", err)
+	}
+	if !tree.IsLeaf() {
+		t.Fatal("expected leaf tree")
+	}
+}

--- a/treeproof/proofschedule.go
+++ b/treeproof/proofschedule.go
@@ -1,0 +1,221 @@
+// Copyright (c) 2025 pk910
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the dynamic-ssz library.
+
+package treeproof
+
+import (
+	"math/bits"
+
+	"github.com/pk910/dynamic-ssz/ssztypes"
+	"github.com/pk910/dynamic-ssz/sszutils"
+)
+
+// ProofSchedule describes which subtrees of a value's Merkle tree must keep
+// their structure for a set of proof paths. It is derived from the value's
+// type descriptor and the requested generalized indices: a child appears in
+// the schedule when a proof path descends to or below it, and retainAll
+// marks subtrees whose internal tree shape depends on runtime data
+// (progressive trees, unions, optionals, delegated types), so they are kept
+// whole.
+type ProofSchedule struct {
+	children  map[uint64]*ProofSchedule
+	retainAll bool
+}
+
+var retainAllSchedule = &ProofSchedule{retainAll: true}
+
+// child returns the schedule for the child at the given ordinal, nil when
+// the child's subtree carries no proof path and can collapse to its root.
+// Schedules with retainAll never reach ordinal lookups: their whole subtree
+// is captured through the tree wrapper instead.
+func (s *ProofSchedule) child(ordinal uint64) *ProofSchedule {
+	return s.children[ordinal]
+}
+
+// addChild returns the child schedule at the given ordinal, creating it if
+// needed.
+func (s *ProofSchedule) addChild(ordinal uint64) *ProofSchedule {
+	if s.children == nil {
+		s.children = make(map[uint64]*ProofSchedule, 1)
+	}
+	child := s.children[ordinal]
+	if child == nil {
+		child = &ProofSchedule{}
+		s.children[ordinal] = child
+	}
+	return child
+}
+
+// BuildProofSchedule derives the retention schedule for proving the given
+// generalized indices against a value of the given type. Chunk-level and
+// interior targets are recorded as leaf-slot retentions so the pruned
+// assembly keeps every node on their paths; shapes whose tree layout depends
+// on runtime data are marked to be retained whole.
+func BuildProofSchedule(desc *ssztypes.TypeDescriptor, gindices []int) (*ProofSchedule, error) {
+	root := &ProofSchedule{}
+	for _, gindex := range gindices {
+		if gindex < 1 {
+			return nil, sszutils.NewSszErrorf(sszutils.ErrInvalidValueRange, "invalid generalized index %d (must be >= 1)", gindex)
+		}
+		scheduleTarget(root, desc, uint64(gindex))
+	}
+	return root, nil
+}
+
+// scheduleTarget records the retention a single relative generalized index
+// needs inside the subtree of the given type. A path ending at an interior
+// node retains the leftmost leaf slot below it, which forces the pruned
+// assembly to build every node on the way down.
+func scheduleTarget(sched *ProofSchedule, desc *ssztypes.TypeDescriptor, rel uint64) {
+	for {
+		if rel == 1 || sched.retainAll {
+			return
+		}
+
+		switch desc.SszType {
+		case ssztypes.SszTypeWrapperType:
+			// Wrappers are transparent to the walker's scope stream.
+			desc = desc.ElemDesc
+			continue
+		case ssztypes.SszContainerType:
+			fields := desc.ContainerDesc.Fields
+			slot, ok := consumePath(&rel, chunkDepthSlots(uint64(len(fields))))
+			child := sched.addChild(slot)
+			if !ok || slot >= uint64(len(fields)) {
+				// Interior node or zero padding: the retained slot pins the
+				// path, nothing below it has structure.
+				return
+			}
+			sched = child
+			desc = fields[slot].Type
+			continue
+		case ssztypes.SszVectorType:
+			if chunks, packed := staticChunkCount(desc); packed {
+				slot, _ := consumePath(&rel, chunkDepthSlots(chunks))
+				sched.addChild(slot)
+				return
+			}
+			slot, ok := consumePath(&rel, chunkDepthSlots(uint64(desc.Len)))
+			child := sched.addChild(slot)
+			if !ok {
+				return
+			}
+			sched = child
+			desc = desc.ElemDesc
+			continue
+		case ssztypes.SszListType:
+			if desc.SszTypeFlags&ssztypes.SszTypeFlagHasLimit == 0 {
+				// The tree depth follows the runtime length.
+				sched.retainAll = true
+				return
+			}
+			// Mixin level: left is the chunk tree, right the length chunk.
+			// The mixin structure always exists in the pruned assembly.
+			side, ok := consumePath(&rel, 1)
+			if !ok || side != 0 {
+				return
+			}
+			if limitChunks, packed := listLimitChunks(desc); packed {
+				slot, _ := consumePath(&rel, chunkDepthSlots(limitChunks))
+				sched.addChild(slot)
+				return
+			}
+			slot, ok := consumePath(&rel, chunkDepthSlots(desc.Limit))
+			child := sched.addChild(slot)
+			if !ok {
+				return
+			}
+			sched = child
+			desc = desc.ElemDesc
+			continue
+		case ssztypes.SszBitvectorType:
+			slot, _ := consumePath(&rel, chunkDepthSlots((uint64(desc.Len)+31)/32))
+			sched.addChild(slot)
+			return
+		case ssztypes.SszBoolType, ssztypes.SszUint8Type, ssztypes.SszUint16Type,
+			ssztypes.SszUint32Type, ssztypes.SszUint64Type, ssztypes.SszUint128Type, ssztypes.SszUint256Type,
+			ssztypes.SszInt8Type, ssztypes.SszInt16Type, ssztypes.SszInt32Type, ssztypes.SszInt64Type,
+			ssztypes.SszFloat32Type, ssztypes.SszFloat64Type:
+			// Single-chunk leaves carry no structure below them.
+			return
+		default:
+			// Progressive containers and lists, bitlists, unions, optionals,
+			// custom and delegated types: the tree layout is not derivable
+			// from the descriptor alone, keep the whole subtree.
+			sched.retainAll = true
+			return
+		}
+	}
+}
+
+// consumePath consumes depth bits of the relative generalized index and
+// returns the child slot they select. ok is false when the index ends at an
+// interior node of this range; the returned slot is then the leftmost leaf
+// slot below that node.
+func consumePath(rel *uint64, depth int) (uint64, bool) {
+	length := bits.Len64(*rel) - 1
+	if length < depth {
+		slot := (*rel - 1<<length) << (depth - length)
+		*rel = 1
+		return slot, false
+	}
+	slot := (*rel >> (length - depth)) - 1<<depth
+	*rel = 1<<(length-depth) | *rel&(1<<(length-depth)-1)
+	return slot, true
+}
+
+// chunkDepthSlots returns the depth of a chunk tree padded to the given slot
+// count (the next power of two, as merkleization pads).
+func chunkDepthSlots(count uint64) int {
+	if count <= 1 {
+		return 0
+	}
+	return bits.Len64(count - 1)
+}
+
+// staticChunkCount reports the chunk count of a vector's packed data, with
+// packed false when the elements are composite and merkleize to one chunk
+// slot each. Byte data always reports through its uint8 element type.
+func staticChunkCount(desc *ssztypes.TypeDescriptor) (uint64, bool) {
+	if itemSize := packedElemSize(desc); itemSize > 0 {
+		return (uint64(desc.Len)*itemSize + 31) / 32, true
+	}
+	return 0, false
+}
+
+// listLimitChunks reports the chunk-tree limit of a list's packed data, with
+// packed false when the elements are composite. Byte data always reports
+// through its uint8 element type.
+func listLimitChunks(desc *ssztypes.TypeDescriptor) (uint64, bool) {
+	if itemSize := packedElemSize(desc); itemSize > 0 {
+		return sszutils.CalculateLimit(desc.Limit, 0, itemSize), true
+	}
+	return 0, false
+}
+
+// packedElemSize reports the packed byte size of a list's or vector's
+// element type, unwrapping type wrappers; 0 means the elements are composite
+// and merkleize to one chunk slot each.
+func packedElemSize(desc *ssztypes.TypeDescriptor) uint64 {
+	elemDesc := desc.ElemDesc
+	for elemDesc.SszType == ssztypes.SszTypeWrapperType && elemDesc.ElemDesc != nil {
+		elemDesc = elemDesc.ElemDesc
+	}
+	switch elemDesc.SszType {
+	case ssztypes.SszBoolType, ssztypes.SszUint8Type, ssztypes.SszInt8Type:
+		return 1
+	case ssztypes.SszUint16Type, ssztypes.SszInt16Type:
+		return 2
+	case ssztypes.SszUint32Type, ssztypes.SszInt32Type, ssztypes.SszFloat32Type:
+		return 4
+	case ssztypes.SszUint64Type, ssztypes.SszInt64Type, ssztypes.SszFloat64Type:
+		return 8
+	case ssztypes.SszUint128Type:
+		return 16
+	case ssztypes.SszUint256Type:
+		return 32
+	default:
+		return 0
+	}
+}


### PR DESCRIPTION
## Summary

`DynSsz.GetProofs(source, gindices, opts...)` generates Merkle proofs for a set of generalized indices at close to the cost of a plain `HashTreeRoot` — without materializing the value's proof tree.

## Architecture: proof capture on the optimized hashing path

The value is hashed through `treeproof.ProofHasher`, a HashWalker embedding the optimized `hasher.Hasher`:

- **Off-path subtrees** pass straight through the hasher's flat, batched merkleization — zero nodes, full incremental machinery.
- **Scheduled scopes** (the proof-path spine) run on the hasher's non-incremental path, so their completed children lie as a plain chunk sequence in the hasher's own buffer; at scope close the pruned node tree is assembled directly from that buffer region (new `hasher.BufferSince` accessor — no duplicate shadow buffers), reducing off-path sibling ranges in batched level order.
- **Runtime-shaped subtrees** (progressive containers and lists, bitlists, unions, optionals, unlimited lists, delegated types — `retainAll` in the schedule) are captured whole through the existing tree wrapper, bounded by that subtree. Put-style subtree calls (`PutBitlist` etc., as emitted by generated code) replay through the wrapper when scheduled.

The retention schedule (`treeproof.BuildProofSchedule`) translates generalized indices to child ordinals statically from the type descriptor, including chunk-level and interior targets. The pruned tree carries the value's exact hash tree root — **cross-checked against the hasher's root, so any capture divergence fails loudly instead of producing a wrong proof** — and serves proofs via the existing `Node.Prove`. Since capture happens at the HashWalker level, the walk delegates to generated code exactly like `HashTreeRoot`/`GetTree`; every SSZ shape is supported.

## Benchmarks (mainnet Fulu state, 2.34M validators)

| | time | alloc | retained |
|---|---|---|---|
| HashTreeRoot (sync reflection) | 1.14 s | — | — |
| **GetProofs, 1–1000 pubkey proofs** | **1.4 s** | 0.5 GB cold / 67 MB warm | proof paths only |
| **GetProofs, small-field proof (async16)** | **0.54 s** | — | proof paths only |
| HashTreeRoot (async16) | 0.47 s | — | — |
| GetTree + Prove (with #222) | 2.1 s + 9 µs/proof | 5.3 GB | 5.3 GB tree |

Price of provability: **1.27× a plain sync HashTreeRoot** — and **1.12× the async HashTreeRoot** for proofs whose paths leave the validator registry off-path (it then reduces in the background). Async hashing composes with the capture: scheduled scopes are non-incremental (a completed child never defers, so the tail-chunk capture is exact) and the capture drains any overlapping background reduction.

## Validation

- **Fuzzing campaign**: randomized `reflect.StructOf` types (nested containers, all list/vector/bit shapes, progressive containers and lists, optionals, pointers, packed data), random values with empty/short/limit-edge cases: **1,816,240 types, 45.4M values, 3.03 billion proof comparisons byte-identical to the GetTree+Prove path, zero failures**, including error-parity probes and async-hashing instances in rotation (a further 673M comparisons).
- Stream-level parity suite driving every HashWalker method through all capture states against the full wrapper tree; descriptor-level suites enumerating every generalized index of shape-rich fixtures (progressive, union, optional, wrapper, bitlist included); **100.0% statement coverage for the treeproof package**.
- Mainnet proofs verify against the fastssz-cross-checked root; leaves match the actual validator pubkeys.

## Merge order

#222 should merge first; this branch then rebases onto master, and as part of that rebase the two wrapper-built subtree captures in `ProofHasher` (retainAll close, Put-style replays) switch from `node.Hash()` to `node.Finalize(treeproof.WithHashFn(...))` followed by `Hash()` (#222's final API — `HashWithHashFn` was replaced by `Node.Finalize(...opts)`) so `WithNoFastHash` covers them through #222's batched finalize as well. This backend-selection switch is not observable in root-equivalence tests (both backends produce identical roots by design), so it is tracked here rather than by a test.

Fully independent of #222: merges cleanly in either order (verified by test merges against #222@10b0ecc; merged suite passes with -race). #222 later moved to 7f80960 (streaming/pipelined finalize) — the merge test should be re-run at rebase time.
