### PR TITLE
Add deep-oracle battery to the differential fuzzer (tree/proofs, native HTR, reference oracle)

### DIFF
--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -1,0 +1,88 @@
+# dynamic-ssz differential fuzzer
+
+A generate-then-fuzz harness that invents random SSZ type trees, generates
+matching codegen for them, and then differentially exercises every SSZ code
+path against each other and against independent oracles.
+
+## How it works
+
+1. **Generate** (`cmd/generate`) emits `NumTypes` random Go structs spanning the
+   full breadth of SSZ shapes — primitives, byte/int arrays, vectors and lists,
+   bitvectors and bitlists, progressive lists/bitlists/containers, unions, type
+   wrappers, `uint128`/`uint256`, optionals, multi-dimensional mixed
+   `ssz-size`/`ssz-max` arrays, and nested containers — writes them to
+   `corpus/types_gen.go` + `corpus/registry_gen.go`, and runs `dynssz-gen` to
+   produce `corpus/codegen_gen.go`. The generated `*_gen.go` files are
+   git-ignored and regenerated each run, so every round explores a fresh type
+   universe.
+2. **Fuzz** (`cmd/fuzz`) runs N workers over the generated registry. Each
+   iteration picks one of three input modes — valid fill, mutated-valid, or
+   random bytes — and runs the check battery below.
+
+## Check battery
+
+For every type, per iteration:
+
+### Reflection-vs-codegen differential (the core)
+The reflection engine and the generated code are two independent
+implementations of the same SSZ type. They are cross-checked on:
+
+- **marshal** — reflection bytes == codegen bytes
+- **hash-tree-root** — reflection root == codegen root
+- **streaming** — buffer marshal == stream writer; stream reader (known and
+  unknown/open-region length, with a tiny read buffer forcing genuine open
+  regions) round-trips to the buffer bytes
+- **unmarshal** — reflection and codegen agree on accept/reject; on accept, both
+  re-marshal identically
+- **round-trip** and **decode-into-dirty-target** reuse
+- **mutation** — bit flips, byte edits, insert/delete, targeted 4-byte
+  offset-smashing, and byte swaps, routed through both the buffer and the
+  unknown-length (offsets-at-EOF) verdict paths
+
+### Deep-oracle battery (`-oracles`, default on)
+Layered on top of the differential, for each valid instance:
+
+- **native-hash HTR** — HashTreeRoot on the standard-library sha256 backend must
+  equal the accelerated (hashtree) backend: a third hashing engine
+- **size == len** — `SizeSSZ` must equal `len(MarshalSSZ)`
+- **tree generation + proofs** (`-proofs`, default on) — `GetTree()` on both the
+  reflection and codegen engines must equal `HashTreeRoot` and produce
+  structurally identical trees; sampled leaf `Prove`/`ProveMulti` proofs must
+  verify (completeness) and every tamper — leaf byte, sibling hash, wrong root —
+  must be rejected (soundness)
+- **HashTreeRootWith** — a caller-supplied hasher, fresh and reused-after-`Reset`,
+  must match `HashTreeRoot`
+- **metamorphic HTR** — two distinct serializations of the same type must not
+  share a root
+- **determinism** — `HashTreeRoot` is stable across repeats
+- **independent reference oracle** (`-reference`, default on) — a
+  first-principles reflection SSZ reimplementation (`engine/oracle_ref.go`) that
+  shares no code with dynssz, catching a reflection==codegen-but-both-wrong bug
+  the self-differential checks cannot see. It covers the well-modeled
+  single-dimensional subset (primitives, byte/int vectors and lists, bitvector,
+  nested containers, single-dim collections of containers) and skips constructs
+  whose independent reimplementation is ambiguous (multi-dimensional collections,
+  bitlist delimiter canonicalization, progressive/optional/union/wrapper,
+  uint128/256, spec-driven `dynssz-*`, and extended scalars).
+
+Any divergence is written to `report-dir` as an `issue-*` directory with the
+input bytes and a hex dump; CI fails the round on any issue.
+
+## Usage
+
+```bash
+# one-shot: generate a corpus then fuzz it (see Makefile for parameters)
+make fuzz DURATION=60s NUM_TYPES=100 MAX_DEPTH=4
+
+# or by hand
+go run ./cmd/generate -num-types 100 -max-fields 8 -max-depth 4 -seed 1 -extended=true
+go run ./cmd/fuzz -duration 60s -workers 8 -report-dir fuzz-reports
+
+# toggle sub-batteries
+go run ./cmd/fuzz -oracles=false                 # differential only
+go run ./cmd/fuzz -proofs=false -reference=false  # oracles minus tree/proofs and reference
+```
+
+The stats line reports, per interval: iterations/s, the input-mode split, `ok`
+(valid fills), `oracle` (deep-oracle checks run), and a counter per issue class
+(`panic`, `marshal`, `htr`, `stream`, `unmarshal`).

--- a/tests/fuzz/cmd/fuzz/main.go
+++ b/tests/fuzz/cmd/fuzz/main.go
@@ -30,6 +30,9 @@ func main() {
 		duration   = flag.Duration("duration", 0, "Maximum run duration (0 = infinite)")
 		statsEvery = flag.Duration("stats-every", 5*time.Second, "Stats print interval")
 		workers    = flag.Int("workers", runtime.NumCPU(), "Number of parallel workers")
+		oracles    = flag.Bool("oracles", true, "Run the deep-oracle battery (native HTR, size, reference, tree/proofs, HashTreeRootWith, metamorphic, determinism)")
+		proofs     = flag.Bool("proofs", true, "Run tree generation + Merkle proof checks (part of the oracle battery)")
+		reference  = flag.Bool("reference", true, "Run the independent reference oracle (part of the oracle battery)")
 	)
 	flag.Parse()
 
@@ -75,6 +78,22 @@ func main() {
 	dsUnknown := dynssz.NewDynSsz(nil, dynssz.WithNoFastSsz(), dynssz.WithStreamReaderBufferSize(8))
 	dsUnknownExt := dynssz.NewDynSsz(nil, dynssz.WithNoFastSsz(), dynssz.WithExtendedTypes(), dynssz.WithStreamReaderBufferSize(8))
 
+	// Deep-oracle engines. The codegen (delegating) instances drive the
+	// tree/proof battery through the generated code; the native-hash instances
+	// (WithNoFastHash → standard-library sha256) give a third HashTreeRoot
+	// backend to cross-check against the accelerated one.
+	dsCg := dynssz.NewDynSsz(nil, dynssz.WithNoFastSsz())
+	dsCgExt := dynssz.NewDynSsz(nil, dynssz.WithNoFastSsz(), dynssz.WithExtendedTypes())
+	dsNative := dynssz.NewDynSsz(nil, dynssz.WithNoFastSsz(), dynssz.WithNoDelegation(), dynssz.WithNoFastHash())
+	dsNativeExt := dynssz.NewDynSsz(nil, dynssz.WithNoFastSsz(), dynssz.WithNoDelegation(), dynssz.WithExtendedTypes(), dynssz.WithNoFastHash())
+
+	instances := &engine.Instances{
+		Refl: ds, ReflExt: dsExt,
+		Codegen: dsCg, CodegenExt: dsCgExt,
+		Native: dsNative, NativeExt: dsNativeExt,
+		Unknown: dsUnknown, UnknownExt: dsUnknownExt,
+	}
+
 	// Warm up type caches by doing one marshal per type.
 	// This populates the cache before workers start, avoiding write contention.
 	log.Println("Warming up type caches...")
@@ -113,7 +132,8 @@ func main() {
 		workerSeed := *seed + int64(i)*6364136223846793005
 		go func() {
 			defer wg.Done()
-			eng := engine.NewEngine(reporter, stats, ds, dsExt, workerSeed, *maxData, dsUnknown, dsUnknownExt)
+			eng := engine.NewEngine(reporter, stats, instances, workerSeed, *maxData)
+			eng.SetOracles(*oracles, *proofs, *reference)
 			typeIdx := i // stagger starting positions
 			for {
 				select {

--- a/tests/fuzz/engine/engine.go
+++ b/tests/fuzz/engine/engine.go
@@ -32,6 +32,7 @@ type Stats struct {
 	StreamMismatches  atomic.Uint64
 	UnmarshalDiffs    atomic.Uint64
 	Successes         atomic.Uint64
+	OracleChecks      atomic.Uint64 // deep-oracle checks run (native/size/reference/tree/proofs/...)
 }
 
 // Engine is the core fuzz testing engine.
@@ -45,35 +46,66 @@ type Engine struct {
 	// to a known length during the decoder's initial fill.
 	dsUnknown         *dynssz.DynSsz
 	dsUnknownExtended *dynssz.DynSsz
-	reporter          *Reporter
-	stats             *Stats
-	rng               *rand.Rand
-	filler            *Filler
-	maxDataLen        int
+	// Codegen (delegating) and native-hash instances drive the deep-oracle
+	// checks (tree/proofs on the codegen engine; fast-vs-native HTR).
+	dsCg        *dynssz.DynSsz
+	dsCgExt     *dynssz.DynSsz
+	dsNative    *dynssz.DynSsz
+	dsNativeExt *dynssz.DynSsz
+	reporter    *Reporter
+	stats       *Stats
+	rng         *rand.Rand
+	filler      *Filler
+	maxDataLen  int
+	oracles     bool // run the deep-oracle battery on valid instances
+	proofs      bool // run tree-generation + proof checks (part of the oracle battery)
+	reference   bool // run the independent reference oracle (part of the oracle battery)
+}
+
+// Instances holds the shared DynSsz configurations a fuzz run uses. All are
+// safe to share across workers (the type cache is mutex-guarded).
+type Instances struct {
+	Refl, ReflExt       *dynssz.DynSsz // reflection engine (WithNoFastSsz, WithNoDelegation) [+extended]
+	Codegen, CodegenExt *dynssz.DynSsz // codegen/delegation engine (WithNoFastSsz) [+extended]
+	Native, NativeExt   *dynssz.DynSsz // reflection + WithNoFastHash (native sha256) [+extended]
+	Unknown, UnknownExt *dynssz.DynSsz // codegen + tiny stream buffer for open-region decoding [+extended]
 }
 
 // NewEngine creates a new fuzz engine with its own RNG but shared DynSsz
 // instances. The DynSsz TypeCache is thread-safe (uses sync.RWMutex),
 // so sharing avoids duplicating large type caches across workers.
-func NewEngine(reporter *Reporter, stats *Stats, ds, dsExtended *dynssz.DynSsz, seed int64, maxDataLen int, dsUnknown ...*dynssz.DynSsz) *Engine {
+func NewEngine(reporter *Reporter, stats *Stats, inst *Instances, seed int64, maxDataLen int) *Engine {
 	rng := rand.New(rand.NewSource(seed))
 
-	e := &Engine{
-		ds:         ds,
-		dsExtended: dsExtended,
-		reporter:   reporter,
-		stats:      stats,
-		rng:        rng,
-		filler:     NewFiller(rng),
-		maxDataLen: maxDataLen,
+	return &Engine{
+		ds:                inst.Refl,
+		dsExtended:        inst.ReflExt,
+		dsCg:              inst.Codegen,
+		dsCgExt:           inst.CodegenExt,
+		dsNative:          inst.Native,
+		dsNativeExt:       inst.NativeExt,
+		dsUnknown:         inst.Unknown,
+		dsUnknownExtended: inst.UnknownExt,
+		reporter:          reporter,
+		stats:             stats,
+		rng:               rng,
+		filler:            NewFiller(rng),
+		maxDataLen:        maxDataLen,
+		oracles:           true,
+		proofs:            true,
+		reference:         true,
 	}
-	if len(dsUnknown) > 0 {
-		e.dsUnknown = dsUnknown[0]
-	}
-	if len(dsUnknown) > 1 {
-		e.dsUnknownExtended = dsUnknown[1]
-	}
-	return e
+}
+
+// SetOracles toggles the deep-oracle battery and its sub-batteries. oracles
+// gates the whole battery (native HTR, size, reference, tree/proofs,
+// HashTreeRootWith, metamorphic, determinism); proofs gates tree generation +
+// Merkle proofs; reference gates the independent reference oracle. All default
+// to on.
+func (e *Engine) SetOracles(oracles, proofs, reference bool) {
+	e.oracles = oracles
+	e.proofs = proofs
+	e.reference = reference
 }
 
 // FuzzEntry runs one fuzz iteration on a given type entry.
@@ -146,6 +178,13 @@ func (e *Engine) fuzzValidInstance(entry corpus.TypeEntry, ds *dynssz.DynSsz) {
 
 	// Round-trip: marshal -> unmarshal -> marshal
 	e.testRoundTrip(entry, ds, instance, nil)
+
+	// Deep-oracle battery: native-hash HTR, size==len, independent
+	// reference oracle, tree generation + proofs, HashTreeRootWith reuse,
+	// metamorphic HTR, and determinism.
+	if e.oracles {
+		e.oracleChecks(entry, ds, instance)
+	}
 }
 
 // fuzzMutatedValid creates valid data, then mutates it and tests unmarshal.
@@ -976,7 +1015,7 @@ func PrintStats(stats *Stats, elapsed time.Duration) {
 
 	fmt.Printf(
 		"\r[%s] iters: %d (%.0f/s) | valid: %d mutated: %d random: %d | "+
-			"ok: %d panic: %d marshal: %d htr: %d stream: %d unmarshal: %d | "+
+			"ok: %d oracle: %d panic: %d marshal: %d htr: %d stream: %d unmarshal: %d | "+
 			"mem: %s alloc, %s sys, %d gc",
 		elapsed.Truncate(time.Second),
 		iters, rate,
@@ -984,6 +1023,7 @@ func PrintStats(stats *Stats, elapsed time.Duration) {
 		stats.MutatedFills.Load(),
 		stats.RandomInputs.Load(),
 		stats.Successes.Load(),
+		stats.OracleChecks.Load(),
 		stats.Panics.Load(),
 		stats.MarshalMismatches.Load(),
 		stats.HTRMismatches.Load(),

--- a/tests/fuzz/engine/oracle_ref.go
+++ b/tests/fuzz/engine/oracle_ref.go
@@ -26,6 +26,12 @@ import (
 	"strings"
 )
 
+// SSZ ssz-type tag values used across the reference oracle.
+const (
+	tagBitlist   = "bitlist"
+	tagBitvector = "bitvector"
+)
+
 type refTag struct {
 	size []int // ssz-size dims (-1 for "?")
 	max  []int // ssz-max dims
@@ -94,10 +100,10 @@ func refSupportsType(t reflect.Type, tag reflect.StructTag) bool {
 	case reflect.Array, reflect.Slice:
 		// bitvector is a fixed []byte; supported. bitlist canonicalization
 		// (delimiter placement, trailing-zero trimming) is out of scope.
-		if rt.typ == "bitlist" {
+		if rt.typ == tagBitlist {
 			return false
 		}
-		if rt.typ == "bitvector" {
+		if rt.typ == tagBitvector {
 			return t.Elem().Kind() == reflect.Uint8
 		}
 		// Single-dimensional collections only. Multi-dimensional collections
@@ -116,8 +122,9 @@ func refSupportsType(t reflect.Type, tag reflect.StructTag) bool {
 		return refSupportsType(t.Elem(), consumeDim(tag))
 	case reflect.Struct:
 		return refSupportsStruct(t)
+	default:
+		return false
 	}
-	return false
 }
 
 // consumeDim drops the leading ssz-size / ssz-max dimension from a struct tag,
@@ -183,7 +190,7 @@ func zeroDeref(v reflect.Value) reflect.Value {
 }
 
 func refFixedSize(t reflect.Type, tag refTag) (int, bool) {
-	if tag.typ == "bitlist" {
+	if tag.typ == tagBitlist {
 		return 0, false
 	}
 	switch t.Kind() {
@@ -204,7 +211,7 @@ func refFixedSize(t reflect.Type, tag refTag) (int, bool) {
 		}
 		return es * t.Len(), true
 	case reflect.Slice:
-		if tag.typ == "bitvector" && len(tag.size) > 0 {
+		if tag.typ == tagBitvector && len(tag.size) > 0 {
 			return tag.size[0], true // bitvector: fixed N bytes
 		}
 		// A concrete ssz-size dim makes this a fixed Vector[E, N]; it is fixed
@@ -228,8 +235,9 @@ func refFixedSize(t reflect.Type, tag refTag) (int, bool) {
 			total += fs
 		}
 		return total, true
+	default:
+		return 0, false
 	}
-	return 0, false
 }
 
 func refMarshal(v reflect.Value, tag refTag) []byte {
@@ -267,10 +275,10 @@ func refMarshal(v reflect.Value, tag refTag) []byte {
 		// 4-byte offset per element, no length prefix), then the bodies.
 		return refOffsetEncode(v, tag)
 	case reflect.Slice:
-		if tag.typ == "bitlist" {
+		if tag.typ == tagBitlist {
 			return append([]byte(nil), v.Bytes()...) // raw incl. delimiter
 		}
-		if tag.typ == "bitvector" && len(tag.size) > 0 {
+		if tag.typ == tagBitvector && len(tag.size) > 0 {
 			out := make([]byte, tag.size[0])
 			copy(out, v.Bytes())
 			return out
@@ -292,8 +300,9 @@ func refMarshal(v reflect.Value, tag refTag) []byte {
 		return refOffsetEncode(v, tag)
 	case reflect.Struct:
 		return refMarshalContainer(v)
+	default:
+		return nil
 	}
-	return nil
 }
 
 // refVectorEncode encodes a fixed Vector[E, n]: exactly n elements, drawing
@@ -401,12 +410,12 @@ func refHTR(v reflect.Value, tag refTag) [32]byte {
 		}
 		return refMerkleize(roots, 0)
 	case reflect.Slice:
-		if tag.typ == "bitvector" && len(tag.size) > 0 {
+		if tag.typ == tagBitvector && len(tag.size) > 0 {
 			out := make([]byte, tag.size[0])
 			copy(out, v.Bytes())
 			return refMerkleize(refChunkify(out), 0)
 		}
-		if tag.typ == "bitlist" {
+		if tag.typ == tagBitlist {
 			bl := v.Bytes()
 			nbits := refBitlistLen(bl)
 			limit := (tag.curMax() + 255) / 256
@@ -450,16 +459,18 @@ func refHTR(v reflect.Value, tag refTag) [32]byte {
 			roots[i] = refHTR(v.Field(i), parseRefTag(t.Field(i).Tag))
 		}
 		return refMerkleize(roots, 0)
+	default:
+		return [32]byte{}
 	}
-	return [32]byte{}
 }
 
 func refIsBasicKind(k reflect.Kind) bool {
 	switch k {
 	case reflect.Bool, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		return true
+	default:
+		return false
 	}
-	return false
 }
 
 func refPack(b []byte) [][32]byte { return refChunkify(b) }

--- a/tests/fuzz/engine/oracle_ref.go
+++ b/tests/fuzz/engine/oracle_ref.go
@@ -1,0 +1,591 @@
+package engine
+
+// Independent, spec-first-principles SSZ reference implementation (serialization
+// + hash_tree_root) via reflection over the same struct tags. It shares NO code
+// with the dynssz reflection engine or its generated code, so agreement is
+// genuine third-party corroboration: a reflection==codegen-but-both-wrong bug
+// would be caught here where the self-differential checks cannot see it.
+//
+// It supports the well-modeled single-dimensional subset: primitives, byte/int
+// arrays and vectors, byte/int lists, bitvector, nested containers, pointers to
+// any of these, and single-dimensional collections of containers. Constructs
+// whose independent reimplementation is error-prone or ambiguous are
+// deliberately out of scope (refSupportsType returns false and the caller skips
+// the reference check, leaving it to the self-differential oracles):
+// multi-dimensional collections (mixed ssz-size/ssz-max dimension rules),
+// bitlist (delimiter canonicalization), progressive lists/bitlists/containers,
+// optionals, unions, type wrappers, uint128/256, spec-driven dynssz-size/max,
+// and the extended scalar types int8..64 / float / big.Int / time.Time.
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"math/bits"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+type refTag struct {
+	size []int // ssz-size dims (-1 for "?")
+	max  []int // ssz-max dims
+	typ  string
+}
+
+func parseRefTag(t reflect.StructTag) refTag {
+	var s refTag
+	s.typ = t.Get("ssz-type")
+	if v := t.Get("ssz-size"); v != "" {
+		for _, p := range strings.Split(v, ",") {
+			if p == "?" {
+				s.size = append(s.size, -1)
+			} else {
+				n, _ := strconv.Atoi(p)
+				s.size = append(s.size, n)
+			}
+		}
+	}
+	if v := t.Get("ssz-max"); v != "" {
+		for _, p := range strings.Split(v, ",") {
+			n, _ := strconv.Atoi(p)
+			s.max = append(s.max, n)
+		}
+	}
+	return s
+}
+
+func (s refTag) shift() refTag {
+	n := s
+	if len(n.size) > 0 {
+		n.size = n.size[1:]
+	}
+	if len(n.max) > 0 {
+		n.max = n.max[1:]
+	}
+	return n
+}
+
+func (s refTag) curMax() int {
+	if len(s.max) > 0 {
+		return s.max[0]
+	}
+	return 0
+}
+
+// refSupportsType reports whether the reference oracle can faithfully handle a
+// type. It is deliberately CONSERVATIVE: anything it is not certain about
+// returns false, so the reference check can never produce a false positive on a
+// construct outside its model.
+func refSupportsType(t reflect.Type, tag reflect.StructTag) bool {
+	rt := parseRefTag(tag)
+	switch rt.typ {
+	case "progressive-list", "progressive-bitlist", "optional", "wrapper", "uint128", "uint256", "union":
+		return false
+	}
+	// Spec-driven sizing is out of scope (the oracle has no spec resolver).
+	if tag.Get("dynssz-size") != "" || tag.Get("dynssz-max") != "" {
+		return false
+	}
+	switch t.Kind() {
+	case reflect.Bool, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return true
+	case reflect.Ptr:
+		return refSupportsType(t.Elem(), tag)
+	case reflect.Array, reflect.Slice:
+		// bitvector is a fixed []byte; supported. bitlist canonicalization
+		// (delimiter placement, trailing-zero trimming) is out of scope.
+		if rt.typ == "bitlist" {
+			return false
+		}
+		if rt.typ == "bitvector" {
+			return t.Elem().Kind() == reflect.Uint8
+		}
+		// Single-dimensional collections only. Multi-dimensional collections
+		// (an element that is itself an array/slice, with the mixed ssz-size/
+		// ssz-max dimension rules) are out of scope: an independent
+		// reimplementation of those nested offset/padding rules is exactly
+		// where divergence-from-correct is most likely, so we skip them rather
+		// than risk a false positive. Collections of containers are supported.
+		elem := t.Elem()
+		if elem.Kind() == reflect.Ptr {
+			elem = elem.Elem()
+		}
+		if elem.Kind() == reflect.Array || elem.Kind() == reflect.Slice {
+			return false
+		}
+		return refSupportsType(t.Elem(), consumeDim(tag))
+	case reflect.Struct:
+		return refSupportsStruct(t)
+	}
+	return false
+}
+
+// consumeDim drops the leading ssz-size / ssz-max dimension from a struct tag,
+// so a nested collection is checked against the remaining dimensions.
+func consumeDim(tag reflect.StructTag) reflect.StructTag {
+	rt := parseRefTag(tag).shift()
+	var parts []string
+	if tp := tag.Get("ssz-type"); tp != "" {
+		// The ssz-type applies to the outer dimension; a nested collection has
+		// no residual type qualifier in this generator's output.
+		_ = tp
+	}
+	if len(rt.size) > 0 {
+		ds := make([]string, len(rt.size))
+		for i, d := range rt.size {
+			if d < 0 {
+				ds[i] = "?"
+			} else {
+				ds[i] = strconv.Itoa(d)
+			}
+		}
+		parts = append(parts, `ssz-size:"`+strings.Join(ds, ",")+`"`)
+	}
+	if len(rt.max) > 0 {
+		ms := make([]string, len(rt.max))
+		for i, d := range rt.max {
+			ms[i] = strconv.Itoa(d)
+		}
+		parts = append(parts, `ssz-max:"`+strings.Join(ms, ",")+`"`)
+	}
+	return reflect.StructTag(strings.Join(parts, " "))
+}
+
+func refSupportsStruct(t reflect.Type) bool {
+	// Reject foreign container types (unions, wrappers, time.Time, big.Int, ...).
+	switch t.PkgPath() {
+	case "github.com/pk910/dynamic-ssz", "time", "math/big":
+		return false
+	}
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.Tag.Get("ssz-index") != "" { // progressive container
+			return false
+		}
+		if !refSupportsType(f.Type, f.Tag) {
+			return false
+		}
+	}
+	return true
+}
+
+// zeroDeref returns the concrete value a pointer addresses, or a fresh zero
+// value of the element type when the pointer is nil (SSZ encodes a nil pointer
+// as its zero value, matching dynssz).
+func zeroDeref(v reflect.Value) reflect.Value {
+	if v.Kind() != reflect.Ptr {
+		return v
+	}
+	if v.IsNil() {
+		return reflect.New(v.Type().Elem()).Elem()
+	}
+	return v.Elem()
+}
+
+func refFixedSize(t reflect.Type, tag refTag) (int, bool) {
+	if tag.typ == "bitlist" {
+		return 0, false
+	}
+	switch t.Kind() {
+	case reflect.Bool, reflect.Uint8:
+		return 1, true
+	case reflect.Uint16:
+		return 2, true
+	case reflect.Uint32:
+		return 4, true
+	case reflect.Uint64:
+		return 8, true
+	case reflect.Ptr:
+		return refFixedSize(t.Elem(), tag)
+	case reflect.Array:
+		es, ok := refFixedSize(t.Elem(), tag.shift())
+		if !ok {
+			return 0, false
+		}
+		return es * t.Len(), true
+	case reflect.Slice:
+		if tag.typ == "bitvector" && len(tag.size) > 0 {
+			return tag.size[0], true // bitvector: fixed N bytes
+		}
+		// A concrete ssz-size dim makes this a fixed Vector[E, N]; it is fixed
+		// only when its element type is itself fixed.
+		if len(tag.size) > 0 && tag.size[0] >= 0 {
+			es, ok := refFixedSize(t.Elem(), tag.shift())
+			if !ok {
+				return 0, false
+			}
+			return es * tag.size[0], true
+		}
+		return 0, false // ssz-max lists are variable
+	case reflect.Struct:
+		total := 0
+		for i := 0; i < t.NumField(); i++ {
+			f := t.Field(i)
+			fs, ok := refFixedSize(f.Type, parseRefTag(f.Tag))
+			if !ok {
+				return 0, false
+			}
+			total += fs
+		}
+		return total, true
+	}
+	return 0, false
+}
+
+func refMarshal(v reflect.Value, tag refTag) []byte {
+	v = zeroDeref(v)
+	switch v.Kind() {
+	case reflect.Bool:
+		if v.Bool() {
+			return []byte{1}
+		}
+		return []byte{0}
+	case reflect.Uint8:
+		return []byte{uint8(v.Uint())}
+	case reflect.Uint16:
+		b := make([]byte, 2)
+		binary.LittleEndian.PutUint16(b, uint16(v.Uint()))
+		return b
+	case reflect.Uint32:
+		b := make([]byte, 4)
+		binary.LittleEndian.PutUint32(b, uint32(v.Uint()))
+		return b
+	case reflect.Uint64:
+		b := make([]byte, 8)
+		binary.LittleEndian.PutUint64(b, v.Uint())
+		return b
+	case reflect.Array:
+		et := v.Type().Elem()
+		if _, ok := refFixedSize(et, tag.shift()); ok {
+			var out []byte
+			for i := 0; i < v.Len(); i++ {
+				out = append(out, refMarshal(v.Index(i), tag.shift())...)
+			}
+			return out
+		}
+		// Fixed-length vector of VARIABLE-size elements: an offset table (one
+		// 4-byte offset per element, no length prefix), then the bodies.
+		return refOffsetEncode(v, tag)
+	case reflect.Slice:
+		if tag.typ == "bitlist" {
+			return append([]byte(nil), v.Bytes()...) // raw incl. delimiter
+		}
+		if tag.typ == "bitvector" && len(tag.size) > 0 {
+			out := make([]byte, tag.size[0])
+			copy(out, v.Bytes())
+			return out
+		}
+		et := v.Type().Elem()
+		// A concrete ssz-size dim makes this a fixed Vector[E, N]: exactly N
+		// elements, zero-padded or truncated, regardless of the value's length.
+		if len(tag.size) > 0 && tag.size[0] >= 0 {
+			return refVectorEncode(v, et, tag, tag.size[0])
+		}
+		// ssz-max list: elements as-is (offset table if variable-size).
+		if _, ok := refFixedSize(et, tag.shift()); ok {
+			var out []byte
+			for i := 0; i < v.Len(); i++ {
+				out = append(out, refMarshal(v.Index(i), tag.shift())...)
+			}
+			return out
+		}
+		return refOffsetEncode(v, tag)
+	case reflect.Struct:
+		return refMarshalContainer(v)
+	}
+	return nil
+}
+
+// refVectorEncode encodes a fixed Vector[E, n]: exactly n elements, drawing
+// zero values past the value's length and ignoring any excess, then either
+// concatenated (fixed element) or through an offset table (variable element).
+func refVectorEncode(v reflect.Value, et reflect.Type, tag refTag, n int) []byte {
+	elem := func(i int) reflect.Value {
+		if i < v.Len() {
+			return v.Index(i)
+		}
+		return reflect.Zero(et)
+	}
+	if _, ok := refFixedSize(et, tag.shift()); ok {
+		var out []byte
+		for i := 0; i < n; i++ {
+			out = append(out, refMarshal(elem(i), tag.shift())...)
+		}
+		return out
+	}
+	parts := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		parts[i] = refMarshal(elem(i), tag.shift())
+	}
+	off := 4 * n
+	var head, body []byte
+	for _, p := range parts {
+		ob := make([]byte, 4)
+		binary.LittleEndian.PutUint32(ob, uint32(off))
+		head = append(head, ob...)
+		off += len(p)
+		body = append(body, p...)
+	}
+	return append(head, body...)
+}
+
+// refOffsetEncode encodes an array/slice of variable-size elements as an
+// offset table (one 4-byte offset per element) followed by the element bodies.
+func refOffsetEncode(v reflect.Value, tag refTag) []byte {
+	parts := make([][]byte, v.Len())
+	for i := 0; i < v.Len(); i++ {
+		parts[i] = refMarshal(v.Index(i), tag.shift())
+	}
+	off := 4 * v.Len()
+	var head, body []byte
+	for _, p := range parts {
+		ob := make([]byte, 4)
+		binary.LittleEndian.PutUint32(ob, uint32(off))
+		head = append(head, ob...)
+		off += len(p)
+		body = append(body, p...)
+	}
+	return append(head, body...)
+}
+
+func refMarshalContainer(v reflect.Value) []byte {
+	t := v.Type()
+	n := t.NumField()
+	fixed := make([][]byte, n)
+	variable := make([][]byte, n)
+	isVar := make([]bool, n)
+	fixedLen := 0
+	for i := 0; i < n; i++ {
+		f := t.Field(i)
+		tg := parseRefTag(f.Tag)
+		if _, ok := refFixedSize(f.Type, tg); ok {
+			fixed[i] = refMarshal(v.Field(i), tg)
+			fixedLen += len(fixed[i])
+		} else {
+			isVar[i] = true
+			variable[i] = refMarshal(v.Field(i), tg)
+			fixedLen += 4
+		}
+	}
+	off := fixedLen
+	var head, body []byte
+	for i := 0; i < n; i++ {
+		if isVar[i] {
+			ob := make([]byte, 4)
+			binary.LittleEndian.PutUint32(ob, uint32(off))
+			head = append(head, ob...)
+			off += len(variable[i])
+			body = append(body, variable[i]...)
+		} else {
+			head = append(head, fixed[i]...)
+		}
+	}
+	return append(head, body...)
+}
+
+func refHTR(v reflect.Value, tag refTag) [32]byte {
+	v = zeroDeref(v)
+	switch v.Kind() {
+	case reflect.Bool, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		var c [32]byte
+		copy(c[:], refMarshal(v, tag))
+		return c
+	case reflect.Array:
+		et := v.Type().Elem()
+		if refIsBasicKind(et.Kind()) {
+			return refMerkleize(refPack(refMarshal(v, tag)), 0)
+		}
+		roots := make([][32]byte, v.Len())
+		for i := 0; i < v.Len(); i++ {
+			roots[i] = refHTR(v.Index(i), tag.shift())
+		}
+		return refMerkleize(roots, 0)
+	case reflect.Slice:
+		if tag.typ == "bitvector" && len(tag.size) > 0 {
+			out := make([]byte, tag.size[0])
+			copy(out, v.Bytes())
+			return refMerkleize(refChunkify(out), 0)
+		}
+		if tag.typ == "bitlist" {
+			bl := v.Bytes()
+			nbits := refBitlistLen(bl)
+			limit := (tag.curMax() + 255) / 256
+			return refMixIn(refMerkleize(refChunkify(refTrimDelimiter(bl, nbits)), limit), uint64(nbits))
+		}
+		et := v.Type().Elem()
+		// A concrete ssz-size dim makes this a fixed Vector[E, N]: merkleized to
+		// N (no length mixin), unlike an ssz-max List (mixin over the count).
+		if len(tag.size) > 0 && tag.size[0] >= 0 {
+			n := tag.size[0]
+			if refIsBasicKind(et.Kind()) {
+				es, _ := refFixedSize(et, tag.shift())
+				chunks := (n*es + 31) / 32
+				return refMerkleize(refPack(refMarshal(v, tag)), chunks)
+			}
+			roots := make([][32]byte, n)
+			for i := 0; i < n; i++ {
+				if i < v.Len() {
+					roots[i] = refHTR(v.Index(i), tag.shift())
+				} else {
+					roots[i] = refHTR(reflect.Zero(et), tag.shift())
+				}
+			}
+			return refMerkleize(roots, n)
+		}
+		limit := tag.curMax()
+		if refIsBasicKind(et.Kind()) {
+			es, _ := refFixedSize(et, tag.shift())
+			limitChunks := (limit*es + 31) / 32
+			return refMixIn(refMerkleize(refPack(refMarshal(v, tag)), limitChunks), uint64(v.Len()))
+		}
+		roots := make([][32]byte, v.Len())
+		for i := 0; i < v.Len(); i++ {
+			roots[i] = refHTR(v.Index(i), tag.shift())
+		}
+		return refMixIn(refMerkleize(roots, limit), uint64(v.Len()))
+	case reflect.Struct:
+		t := v.Type()
+		roots := make([][32]byte, t.NumField())
+		for i := 0; i < t.NumField(); i++ {
+			roots[i] = refHTR(v.Field(i), parseRefTag(t.Field(i).Tag))
+		}
+		return refMerkleize(roots, 0)
+	}
+	return [32]byte{}
+}
+
+func refIsBasicKind(k reflect.Kind) bool {
+	switch k {
+	case reflect.Bool, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return true
+	}
+	return false
+}
+
+func refPack(b []byte) [][32]byte { return refChunkify(b) }
+
+func refChunkify(b []byte) [][32]byte {
+	if len(b) == 0 {
+		return [][32]byte{{}}
+	}
+	n := (len(b) + 31) / 32
+	out := make([][32]byte, n)
+	for i := 0; i < n; i++ {
+		copy(out[i][:], b[i*32:min(len(b), i*32+32)])
+	}
+	return out
+}
+
+func refTrimDelimiter(bl []byte, nbits int) []byte {
+	out := make([]byte, (nbits+7)/8)
+	copy(out, bl)
+	if nbits%8 != 0 {
+		out[len(out)-1] &= byte((1 << (uint(nbits) % 8)) - 1)
+	}
+	return out
+}
+
+func refBitlistLen(bl []byte) int {
+	if len(bl) == 0 {
+		return 0
+	}
+	last := bl[len(bl)-1]
+	if last == 0 {
+		return 0
+	}
+	return (len(bl)-1)*8 + bits.Len8(last) - 1
+}
+
+func refMixIn(root [32]byte, length uint64) [32]byte {
+	var lb [32]byte
+	binary.LittleEndian.PutUint64(lb[:8], length)
+	return sha256.Sum256(append(root[:], lb[:]...))
+}
+
+func refMerkleize(chunks [][32]byte, limit int) [32]byte {
+	count := len(chunks)
+	if limit > count {
+		count = limit
+	}
+	if count < 1 {
+		count = 1
+	}
+	width := 1
+	for width < count {
+		width <<= 1
+	}
+	nodes := make([][32]byte, width)
+	copy(nodes, chunks)
+	for width > 1 {
+		for i := 0; i < width/2; i++ {
+			nodes[i] = sha256.Sum256(append(nodes[2*i][:], nodes[2*i+1][:]...))
+		}
+		width /= 2
+	}
+	return nodes[0]
+}
+
+// refCheck compares dynssz reflection bytes/root against the independent
+// reference for a supported type. Returns ("", true) on agreement or an
+// unsupported/undecodable value; a description + false on divergence.
+func refCheck(t reflect.Type, val any, dynBytes []byte, dynRoot [32]byte) (string, bool) {
+	if !refSupportsType(t, "") {
+		return "", true
+	}
+	rv := reflect.ValueOf(val)
+	for rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			return "", true
+		}
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return "", true
+	}
+	var rb []byte
+	var rr [32]byte
+	ok := true
+	if p := capturePanic(func() {
+		rb = refMarshalContainer(rv)
+		rr = refHTR(rv, refTag{})
+	}); p != "" {
+		return "", true // reference could not handle it → skip, never false-positive
+	}
+	if rb == nil {
+		return "", true
+	}
+	if !equalBytes(rb, dynBytes) {
+		return "reference-marshal-divergence: dynssz=" + hexShort(dynBytes) + " ref=" + hexShort(rb), false
+	}
+	if rr != dynRoot {
+		return "reference-HTR-divergence: dynssz=" + hexShort(dynRoot[:]) + " ref=" + hexShort(rr[:]), false
+	}
+	_ = ok
+	return "", true
+}
+
+func equalBytes(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func hexShort(b []byte) string {
+	const h = "0123456789abcdef"
+	n := len(b)
+	if n > 256 {
+		n = 48
+	}
+	sb := make([]byte, n*2)
+	for i := 0; i < n; i++ {
+		sb[i*2] = h[b[i]>>4]
+		sb[i*2+1] = h[b[i]&0xf]
+	}
+	return string(sb)
+}

--- a/tests/fuzz/engine/oracles.go
+++ b/tests/fuzz/engine/oracles.go
@@ -1,0 +1,152 @@
+package engine
+
+// oracleChecks is the deep-oracle battery layered on top of the reflection-vs-
+// codegen differential. For a filled valid instance it runs, in one pass:
+//
+//   - native-hash HTR: the value's HashTreeRoot on the native Go sha256 backend
+//     must equal the accelerated (hashtree) backend — a third hashing engine
+//     beyond reflection-vs-codegen.
+//   - SizeSSZ == len(MarshalSSZ): the size oracle must match the encoded length.
+//   - reference oracle: an independent, first-principles reflection SSZ
+//     implementation (oracle_ref.go) that shares no code with dynssz, for the
+//     classic-SSZ subset it supports — catches reflection==codegen-but-both-wrong.
+//   - tree generation + proofs (proofs.go): GetTree()==HTR on both engines,
+//     structural tree equality, and single/multi proof completeness + soundness.
+//   - HashTreeRootWith on a caller-supplied hasher, fresh and reused-after-Reset.
+//   - metamorphic HTR: two distinct serializations of the same type must not
+//     share a root.
+//   - determinism: HashTreeRoot is stable across repeats.
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+
+	dynssz "github.com/pk910/dynamic-ssz"
+	"github.com/pk910/dynamic-ssz/hasher"
+	"github.com/pk910/dynamic-ssz/tests/fuzz/corpus"
+)
+
+func (e *Engine) oracleChecks(entry corpus.TypeEntry, ds *dynssz.DynSsz, instance any) {
+	report := func(it IssueType, kind, detail string, data []byte) {
+		e.reporter.Report(&Issue{
+			Type:     it,
+			TypeName: fmt.Sprintf("%s [%s]", entry.Name, kind),
+			Data:     data,
+			Details:  detail,
+		})
+	}
+	ck := func() { e.stats.OracleChecks.Add(1) }
+
+	// Primary reflection root + bytes via the public API on the reflection ds.
+	var refRoot [32]byte
+	var rerr error
+	if p := capturePanic(func() { refRoot, rerr = ds.HashTreeRoot(instance) }); p != "" {
+		e.stats.Panics.Add(1)
+		report(IssuePanic, "oracle-htr", p, nil)
+		return
+	}
+	if rerr != nil {
+		return
+	}
+	var encoded []byte
+	var merr error
+	if p := capturePanic(func() { encoded, merr = ds.MarshalSSZ(instance) }); p != "" {
+		e.stats.Panics.Add(1)
+		report(IssuePanic, "oracle-marshal", p, nil)
+		return
+	}
+
+	// --- native-hash HTR cross-check ---
+	nds := e.dsNative
+	if entry.Extended {
+		nds = e.dsNativeExt
+	}
+	if nds != nil {
+		var nRoot [32]byte
+		var nerr error
+		if p := capturePanic(func() { nRoot, nerr = nds.HashTreeRoot(instance) }); p == "" && nerr == nil && nRoot != refRoot {
+			e.stats.HTRMismatches.Add(1)
+			report(IssueHTRMismatch, "htr-fast-vs-native", fmt.Sprintf("fast=%x native=%x", refRoot, nRoot), encoded)
+		}
+		ck()
+	}
+
+	// --- SizeSSZ == len(MarshalSSZ) ---
+	if merr == nil {
+		var sz int
+		var serr error
+		if p := capturePanic(func() { sz, serr = ds.SizeSSZ(instance) }); p == "" && serr == nil && sz != len(encoded) {
+			report(IssueSizeMismatch, "size", fmt.Sprintf("SizeSSZ=%d len(marshal)=%d", sz, len(encoded)), encoded)
+		}
+		ck()
+	}
+
+	// --- independent reference oracle (supported classic-SSZ subset) ---
+	if merr == nil && e.reference {
+		if detail, ok := refCheck(reflect.TypeOf(instance), instance, encoded, refRoot); !ok {
+			report(IssueReferenceMismatch, "reference-oracle", detail, encoded)
+		}
+		ck()
+	}
+
+	// --- tree generation + proof battery ---
+	if e.proofs {
+		cgds := e.dsCg
+		if entry.Extended {
+			cgds = e.dsCgExt
+		}
+		proofCheck(ds, cgds, instance, refRoot, e.rng,
+			func(kind, detail string) { report(IssueProofFail, kind, detail, encoded) }, ck)
+	}
+
+	// --- G5: HashTreeRootWith on a caller-supplied hasher (fresh + reuse) ---
+	hh := hasher.NewHasher()
+	if p := capturePanic(func() {
+		if err := ds.HashTreeRootWith(instance, hh); err == nil {
+			if r, e2 := hh.HashRoot(); e2 == nil && r != refRoot {
+				e.stats.HTRMismatches.Add(1)
+				report(IssueHTRMismatch, "hashtreerootwith", fmt.Sprintf("with=%x htr=%x", r, refRoot), encoded)
+			}
+		}
+	}); p != "" {
+		e.stats.Panics.Add(1)
+		report(IssuePanic, "hashtreerootwith", p, encoded)
+	}
+	ck()
+
+	// second value for hasher reuse + metamorphic HTR
+	val2 := entry.New()
+	if capturePanic(func() { e.filler.FillStruct(val2) }) == "" {
+		r2, e2 := ds.HashTreeRoot(val2)
+		if e2 == nil {
+			hh.Reset()
+			if p := capturePanic(func() {
+				if err := ds.HashTreeRootWith(val2, hh); err == nil {
+					if r, e3 := hh.HashRoot(); e3 == nil && r != r2 {
+						e.stats.HTRMismatches.Add(1)
+						report(IssueHTRMismatch, "hashtreerootwith-reuse", fmt.Sprintf("reuse=%x fresh=%x", r, r2), encoded)
+					}
+				}
+			}); p != "" {
+				e.stats.Panics.Add(1)
+				report(IssuePanic, "hashtreerootwith-reuse", p, encoded)
+			}
+			ck()
+			// G10 metamorphic: distinct serialization ⇒ distinct root
+			if b2, err := ds.MarshalSSZ(val2); err == nil && !bytes.Equal(encoded, b2) && refRoot == r2 {
+				report(IssueMetamorphic, "metamorphic", fmt.Sprintf("distinct serializations share root %x", refRoot), encoded)
+			}
+			ck()
+		}
+	}
+
+	// --- determinism: HTR stable across repeats ---
+	for i := 0; i < 3; i++ {
+		if r, e2 := ds.HashTreeRoot(instance); e2 == nil && r != refRoot {
+			report(IssueNonDeterministic, "determinism", fmt.Sprintf("iter%d %x != %x", i, r, refRoot), encoded)
+			break
+		}
+	}
+	ck()
+}

--- a/tests/fuzz/engine/proofs.go
+++ b/tests/fuzz/engine/proofs.go
@@ -1,0 +1,229 @@
+package engine
+
+// Merkle tree-generation and proof fuzzing. The built-in differential engine
+// never exercised GetTree / Prove / ProveMulti; this battery does, for every
+// randomly generated type that produces a valid value:
+//
+//   - GetTree() on the reflection AND codegen engines; asserts both tree roots
+//     equal HashTreeRoot and the two engines' trees are structurally identical
+//     (node-by-node hashes)
+//   - enumerates leaf generalized indices and, for each: Get(gi) leaf ==
+//     Prove(gi).Leaf, VerifyProof(root, proof) == true (completeness), and every
+//     tamper (leaf byte, a sibling hash, the wrong root) is rejected (soundness)
+//   - ProveMulti over random index subsets: VerifyMultiproof true; each tamper
+//     rejected
+//   - proofs built on the reflection tree also verify against the codegen tree's
+//     root
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+
+	dynssz "github.com/pk910/dynamic-ssz"
+	"github.com/pk910/dynamic-ssz/treeproof"
+)
+
+// capturePanic runs fn and returns a non-empty string (the recovered value) if
+// it panicked, or "" otherwise. Used by the oracle checks to convert a panic into
+// a reported issue instead of taking down the worker.
+func capturePanic(fn func()) (p string) {
+	defer func() {
+		if r := recover(); r != nil {
+			p = fmt.Sprintf("panic: %v", r)
+		}
+	}()
+	fn()
+	return ""
+}
+
+// collectLeaves walks the tree collecting up to `limit` leaf generalized indices.
+func collectLeaves(n *treeproof.Node, gi, depth, maxDepth, limit int, out *[]int) {
+	if n == nil || len(*out) >= limit || depth > maxDepth {
+		return
+	}
+	if n.IsLeaf() {
+		*out = append(*out, gi)
+		return
+	}
+	collectLeaves(n.Left(), gi*2, depth+1, maxDepth, limit, out)
+	collectLeaves(n.Right(), gi*2+1, depth+1, maxDepth, limit, out)
+}
+
+// treeEqual compares two trees structurally (shape + node hashes) up to maxDepth.
+func treeEqual(a, b *treeproof.Node, depth, maxDepth int) bool {
+	if depth > maxDepth {
+		return true
+	}
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	if a.IsLeaf() != b.IsLeaf() || !bytes.Equal(a.Hash(), b.Hash()) {
+		return false
+	}
+	if a.IsLeaf() {
+		return true
+	}
+	return treeEqual(a.Left(), b.Left(), depth+1, maxDepth) && treeEqual(a.Right(), b.Right(), depth+1, maxDepth)
+}
+
+func flipByte(b []byte, i int) []byte {
+	c := append([]byte(nil), b...)
+	if len(c) > 0 {
+		c[i%len(c)] ^= 0x80
+	}
+	return c
+}
+
+// proofCheck runs the full tree/proof battery for one valid value. reflDs is the
+// reflection engine, cgDs the codegen (delegating) engine; htr is the value's
+// HashTreeRoot. Issues are reported through fail; ck counts a completed check.
+func proofCheck(reflDs, cgDs *dynssz.DynSsz, val any, htr [32]byte, rng *rand.Rand,
+	fail func(kind, detail string), ck func()) {
+
+	const maxDepth = 22 // bound traversal for very large / deep trees
+
+	var reflTree, cgTree *treeproof.Node
+	if p := capturePanic(func() { reflTree, _ = reflDs.GetTree(val) }); p != "" {
+		fail("tree-gettree-refl-panic", p)
+		return
+	}
+	if cgDs != nil {
+		if p := capturePanic(func() { cgTree, _ = cgDs.GetTree(val) }); p != "" {
+			fail("tree-gettree-cg-panic", p)
+			return
+		}
+	}
+	if reflTree == nil {
+		return
+	}
+	ck()
+
+	root := reflTree.Hash()
+	if !bytes.Equal(root, htr[:]) {
+		fail("tree-root-neq-htr", fmt.Sprintf("tree=%x htr=%x", root, htr))
+	}
+	if cgTree != nil {
+		if !bytes.Equal(cgTree.Hash(), root) {
+			fail("tree-refl-cg-root-divergence", fmt.Sprintf("refl=%x cg=%x", root, cgTree.Hash()))
+		}
+		if !treeEqual(reflTree, cgTree, 0, maxDepth) {
+			fail("tree-refl-cg-structure-divergence", "trees differ in shape/node-hash")
+		}
+	}
+	ck()
+
+	var leaves []int
+	collectLeaves(reflTree, 1, 0, maxDepth, 96, &leaves)
+	if len(leaves) == 0 {
+		return
+	}
+
+	// --- single proofs: completeness + soundness at each sampled leaf ---
+	for _, gi := range leaves {
+		var node *treeproof.Node
+		var gerr error
+		if p := capturePanic(func() { node, gerr = reflTree.Get(gi) }); p != "" {
+			fail("proof-get-panic", fmt.Sprintf("gi=%d %s", gi, p))
+			continue
+		}
+		var pr *treeproof.Proof
+		var perr error
+		if p := capturePanic(func() { pr, perr = reflTree.Prove(gi) }); p != "" {
+			fail("proof-prove-panic", fmt.Sprintf("gi=%d %s", gi, p))
+			continue
+		}
+		if perr != nil || pr == nil {
+			continue
+		}
+		if gerr == nil && node != nil && !bytes.Equal(node.Hash(), pr.Leaf) {
+			fail("proof-leaf-neq-get", fmt.Sprintf("gi=%d get=%x prove=%x", gi, node.Hash(), pr.Leaf))
+		}
+		// COMPLETENESS
+		if ok, verr := treeproof.VerifyProof(root, pr); verr == nil && !ok {
+			fail("proof-completeness-fail", fmt.Sprintf("gi=%d valid proof did not verify", gi))
+		}
+		ck()
+		if cgTree != nil {
+			if ok2, verr2 := treeproof.VerifyProof(cgTree.Hash(), pr); verr2 == nil && !ok2 {
+				fail("proof-cross-engine-verify-fail", fmt.Sprintf("gi=%d refl proof fails vs cg root", gi))
+			}
+		}
+		// SOUNDNESS: tampered leaf
+		bad := &treeproof.Proof{Index: pr.Index, Leaf: flipByte(pr.Leaf, rng.Intn(32)), Hashes: pr.Hashes}
+		if ok, _ := treeproof.VerifyProof(root, bad); ok && !bytes.Equal(bad.Leaf, pr.Leaf) {
+			fail("proof-soundness-tampered-leaf-accepted", fmt.Sprintf("gi=%d", gi))
+		}
+		ck()
+		// SOUNDNESS: tampered sibling hash
+		if len(pr.Hashes) > 0 {
+			hi := rng.Intn(len(pr.Hashes))
+			th := make([][]byte, len(pr.Hashes))
+			copy(th, pr.Hashes)
+			th[hi] = flipByte(th[hi], 0)
+			if ok, _ := treeproof.VerifyProof(root, &treeproof.Proof{Index: pr.Index, Leaf: pr.Leaf, Hashes: th}); ok {
+				fail("proof-soundness-tampered-hash-accepted", fmt.Sprintf("gi=%d hi=%d", gi, hi))
+			}
+			ck()
+		}
+		// SOUNDNESS: wrong root
+		if ok, _ := treeproof.VerifyProof(flipByte(root, 0), pr); ok {
+			fail("proof-soundness-wrong-root-accepted", fmt.Sprintf("gi=%d", gi))
+		}
+		ck()
+	}
+
+	// --- multiproofs: completeness + soundness over random subsets ---
+	for s := 0; s < 3 && len(leaves) >= 2; s++ {
+		k := 1 + rng.Intn(min(len(leaves), 8))
+		idxset := map[int]bool{}
+		var indices []int
+		for len(indices) < k {
+			g := leaves[rng.Intn(len(leaves))]
+			if !idxset[g] {
+				idxset[g] = true
+				indices = append(indices, g)
+			}
+		}
+		var mp *treeproof.Multiproof
+		var merr error
+		if p := capturePanic(func() { mp, merr = reflTree.ProveMulti(indices) }); p != "" {
+			fail("multiproof-provemulti-panic", p)
+			continue
+		}
+		if merr != nil || mp == nil {
+			continue
+		}
+		if ok, verr := treeproof.VerifyMultiproof(root, mp.Hashes, mp.Leaves, mp.Indices); verr == nil && !ok {
+			fail("multiproof-completeness-fail", fmt.Sprintf("indices=%v did not verify", indices))
+		}
+		ck()
+		if len(mp.Leaves) > 0 {
+			tl := make([][]byte, len(mp.Leaves))
+			copy(tl, mp.Leaves)
+			li := rng.Intn(len(tl))
+			tl[li] = flipByte(tl[li], rng.Intn(32))
+			if ok, _ := treeproof.VerifyMultiproof(root, mp.Hashes, tl, mp.Indices); ok && !bytes.Equal(tl[li], mp.Leaves[li]) {
+				fail("multiproof-soundness-tampered-leaf-accepted", fmt.Sprintf("indices=%v", indices))
+			}
+			ck()
+		}
+		if len(mp.Hashes) > 0 {
+			th := make([][]byte, len(mp.Hashes))
+			copy(th, mp.Hashes)
+			hi := rng.Intn(len(th))
+			th[hi] = flipByte(th[hi], 0)
+			if ok, _ := treeproof.VerifyMultiproof(root, th, mp.Leaves, mp.Indices); ok {
+				fail("multiproof-soundness-tampered-hash-accepted", fmt.Sprintf("indices=%v", indices))
+			}
+			ck()
+		}
+		if ok, _ := treeproof.VerifyMultiproof(flipByte(root, 0), mp.Hashes, mp.Leaves, mp.Indices); ok {
+			fail("multiproof-soundness-wrong-root-accepted", fmt.Sprintf("indices=%v", indices))
+		}
+		ck()
+	}
+}

--- a/tests/fuzz/engine/proofs.go
+++ b/tests/fuzz/engine/proofs.go
@@ -83,7 +83,6 @@ func flipByte(b []byte, i int) []byte {
 // HashTreeRoot. Issues are reported through fail; ck counts a completed check.
 func proofCheck(reflDs, cgDs *dynssz.DynSsz, val any, htr [32]byte, rng *rand.Rand,
 	fail func(kind, detail string), ck func()) {
-
 	const maxDepth = 22 // bound traversal for very large / deep trees
 
 	var reflTree, cgTree *treeproof.Node

--- a/tests/fuzz/engine/reporter.go
+++ b/tests/fuzz/engine/reporter.go
@@ -18,6 +18,12 @@ const (
 	IssueHTRMismatch     IssueType = "htr-mismatch"
 	IssueStreamMismatch  IssueType = "stream-mismatch"
 	IssueUnmarshalDiff   IssueType = "unmarshal-diff"
+	// Deep-oracle issue types.
+	IssueSizeMismatch      IssueType = "size-mismatch"      // SizeSSZ != len(MarshalSSZ)
+	IssueReferenceMismatch IssueType = "reference-mismatch" // independent reference oracle divergence
+	IssueProofFail         IssueType = "proof-fail"         // tree/GetTree or Merkle proof failure
+	IssueMetamorphic       IssueType = "metamorphic"        // distinct serializations share an HTR
+	IssueNonDeterministic  IssueType = "nondeterministic"   // HashTreeRoot not stable across repeats
 )
 
 // Issue represents a single fuzzing issue found.


### PR DESCRIPTION
## Summary

The `tests/fuzz` harness already invents random SSZ type trees, generates matching codegen, and differentially cross-checks the **reflection engine vs the generated code** (marshal, HTR, streaming, round-trip, dirty-target reuse, unknown-length/open-region decoding, and offset-smashing mutation). This PR keeps all of that and **layers additional oracles on top**, run per valid instance, so the same random type universe now also exercises hashing backends, the size oracle, tree generation, Merkle proofs, and an independent reference implementation.

No change to the generator or the existing differential — this is purely additive coverage.

## New checks (per valid instance)

- **native-hash HTR** — `HashTreeRoot` on the standard-library sha256 backend must equal the accelerated hashtree backend (a third, independent hashing engine).
- **`SizeSSZ` == `len(MarshalSSZ)`** — the size oracle must match the encoded length.
- **tree generation + Merkle proofs** — `GetTree()` on **both** the reflection and codegen engines must equal `HashTreeRoot` and produce structurally identical trees; sampled `Prove`/`ProveMulti` proofs must verify (**completeness**), and every tamper — leaf byte, sibling hash, wrong root — must be rejected (**soundness**). *The fuzzer previously never exercised `GetTree`/`Prove`/`ProveMulti` at all.*
- **`HashTreeRootWith`** on a caller-supplied hasher, fresh and reused-after-`Reset`, must match `HashTreeRoot`.
- **metamorphic HTR** — two distinct serializations of the same type must not share a root.
- **determinism** — `HashTreeRoot` is stable across repeats.
- **independent reference oracle** (`engine/oracle_ref.go`) — a first-principles reflection SSZ reimplementation sharing no code with dynssz, to catch a `reflection==codegen`-but-both-wrong bug the self-differential checks cannot see. Scoped to the single-dimensional subset it models exactly (primitives, byte/int vectors and lists, bitvector, nested containers, single-dim collections of containers); constructs whose independent reimplementation is ambiguous are skipped (multi-dimensional mixed `ssz-size`/`ssz-max`, bitlist delimiter canonicalization, progressive/optional/union/wrapper, uint128/256, spec-driven `dynssz-*`, extended scalars).

## Controls

New `cmd/fuzz` flags, all **default on**, so CI picks the checks up automatically:

- `-oracles` — the whole deep-oracle battery
- `-proofs` — tree generation + Merkle proofs (subset of `-oracles`)
- `-reference` — the independent reference oracle (subset of `-oracles`)

Issues are reported through the existing reporter (new types: `size-mismatch`, `reference-mismatch`, `proof-fail`, `metamorphic`, `nondeterministic`; tree/HTR-reuse reuse the existing classes). The stats line gains an `oracle:` counter.

## Validation

Run clean across many random corpora (varied seeds, depths, and extended types) for millions of iterations — **zero issues**. During development the reference oracle surfaced divergences that were **all bugs in the reference oracle itself** (missing offset table for fixed-length arrays of variable-size elements; missing pad/truncate for `ssz-size` vectors; multi-dim and bitlist canonicalization), each verified against the SSZ spec by hand — **dynssz was correct in every case**. Those were fixed or scoped out so the shipped oracle never false-positives.

Existing `engine` tests and `go vet` pass; generated corpus files remain git-ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)